### PR TITLE
Update esm.sh import maps to use * prefix for external dependencies

### DIFF
--- a/preact-developer/SKILL.md
+++ b/preact-developer/SKILL.md
@@ -84,16 +84,16 @@ Always use this exact import map structure for standalone examples:
 <script type="importmap">
   {
     "imports": {
-      "preact": "https://esm.sh/preact@10.23.1",
-      "preact/": "https://esm.sh/preact@10.23.1/",
-      "@preact/signals": "https://esm.sh/@preact/signals@1.3.0?external=preact",
-      "htm/preact": "https://esm.sh/htm@3.1.1/preact?external=preact"
+      "preact": "https://esm.sh/*preact@10.23.1",
+      "preact/": "https://esm.sh/*preact@10.23.1/",
+      "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
+      "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
     }
   }
 </script>
 ```
 
-**Critical**: Always use `?external=preact` for packages depending on Preact to avoid duplicate instances.
+**Critical**: Always use the `*` prefix in esm.sh URLs to mark all dependencies as external, preventing duplicate Preact instances.
 
 ### Syntax Preference
 
@@ -311,9 +311,9 @@ import { users, isAuthenticated } from './state.js';
   <script type="importmap">
     {
       "imports": {
-        "preact": "https://esm.sh/preact@10.23.1",
-        "@preact/signals": "https://esm.sh/@preact/signals@1.3.0?external=preact",
-        "htm/preact": "https://esm.sh/htm@3.1.1/preact?external=preact"
+        "preact": "https://esm.sh/*preact@10.23.1",
+        "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
+        "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
       }
     }
   </script>
@@ -363,7 +363,7 @@ For mathematical visualizations using WebGL shaders, create a canvas element, in
 
 Before delivering code, verify:
 
-- [ ] Import map is correct with `?external=preact`
+- [ ] Import map uses `*` prefix for all esm.sh URLs
 - [ ] HTM syntax is used (unless JSX explicitly requested)
 - [ ] Keys provided for all mapped elements
 - [ ] Signals used for reactive state

--- a/preact-developer/assets/boilerplate.html
+++ b/preact-developer/assets/boilerplate.html
@@ -12,10 +12,10 @@
   <script type="importmap">
     {
       "imports": {
-        "preact": "https://esm.sh/preact@10.23.1",
-        "preact/": "https://esm.sh/preact@10.23.1/",
-        "@preact/signals": "https://esm.sh/@preact/signals@1.3.0?external=preact",
-        "htm/preact": "https://esm.sh/htm@3.1.1/preact?external=preact"
+        "preact": "https://esm.sh/*preact@10.23.1",
+        "preact/": "https://esm.sh/*preact@10.23.1/",
+        "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
+        "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
       }
     }
   </script>

--- a/preact-developer/references/preact-v10-guide.md
+++ b/preact-developer/references/preact-v10-guide.md
@@ -8,10 +8,10 @@
 <script type="importmap">
   {
     "imports": {
-      "preact": "https://esm.sh/preact@10.23.1",
-      "preact/": "https://esm.sh/preact@10.23.1/",
-      "@preact/signals": "https://esm.sh/@preact/signals@1.3.0?external=preact",
-      "htm/preact": "https://esm.sh/htm@3.1.1/preact?external=preact"
+      "preact": "https://esm.sh/*preact@10.23.1",
+      "preact/": "https://esm.sh/*preact@10.23.1/",
+      "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
+      "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
     }
   }
 </script>
@@ -23,19 +23,19 @@
 <script type="importmap">
   {
     "imports": {
-      "preact": "https://esm.sh/preact@10.23.1",
-      "preact/": "https://esm.sh/preact@10.23.1/",
-      "react": "https://esm.sh/preact@10.23.1/compat",
-      "react/": "https://esm.sh/preact@10.23.1/compat/",
-      "react-dom": "https://esm.sh/preact@10.23.1/compat",
-      "@preact/signals": "https://esm.sh/@preact/signals@1.3.0?external=preact",
-      "htm/preact": "https://esm.sh/htm@3.1.1/preact?external=preact"
+      "preact": "https://esm.sh/*preact@10.23.1",
+      "preact/": "https://esm.sh/*preact@10.23.1/",
+      "react": "https://esm.sh/*preact@10.23.1/compat",
+      "react/": "https://esm.sh/*preact@10.23.1/compat/",
+      "react-dom": "https://esm.sh/*preact@10.23.1/compat",
+      "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
+      "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
     }
   }
 </script>
 ```
 
-**Critical Note**: Always use `?external=preact` for packages that depend on Preact to avoid duplicate instances.
+**Critical Note**: Always use the `*` prefix in esm.sh URLs to mark all dependencies as external, preventing duplicate Preact instances.
 
 ## HTM Syntax (Default Preference)
 


### PR DESCRIPTION
Based on feedback from Preact's creator, updated all import map examples to use the cleaner `*` prefix syntax instead of `?external=preact` query parameters.

The asterisk prefix tells esm.sh to mark all dependencies as external, allowing the browser to resolve them via the import map. This prevents duplicate Preact instances and results in cleaner, more maintainable import maps.

Changes:
- Updated boilerplate.html with new import map pattern
- Updated SKILL.md examples and validation checklist
- Updated preact-v10-guide.md reference documentation

Old: "https://esm.sh/@preact/signals@1.3.0?external=preact"
New: "https://esm.sh/*@preact/signals@1.3.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)