### PR TITLE
feat: Treat VERSION files as workflow metadata

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -129,9 +129,9 @@ jobs:
             # Copy skill folder to temp directory
             cp -r "$SKILL_DIR" "$TEMP_DIR/"
 
-            # Create ZIP from temp directory
+            # Create ZIP from temp directory (exclude VERSION - it's workflow metadata)
             cd "$TEMP_DIR"
-            zip -r "$SKILL_DIR.zip" "$SKILL_DIR/"
+            zip -r "$SKILL_DIR.zip" "$SKILL_DIR/" -x "$SKILL_DIR/VERSION"
 
             echo "✓ Created $SKILL_DIR.zip"
             echo "ZIP contents:"

--- a/.github/workflows/skill-upload.yml
+++ b/.github/workflows/skill-upload.yml
@@ -159,8 +159,9 @@ jobs:
 
             git checkout -b "$BRANCH_NAME"
 
-            # Copy skill files (exclude VCS directories)
-            rsync -av --delete --exclude='.git' --exclude='.svn' --exclude='.hg' "$EXTRACTED_PATH/" "$SKILL_DIR_NAME/"
+            # Copy skill files (exclude VCS directories and VERSION file)
+            # VERSION files are workflow metadata, not part of the skill content
+            rsync -av --delete --exclude='.git' --exclude='.svn' --exclude='.hg' --exclude='VERSION' "$EXTRACTED_PATH/" "$SKILL_DIR_NAME/"
 
             # Add the new skill files and remove the original zip file
             git add "$SKILL_DIR_NAME"

--- a/README.md
+++ b/README.md
@@ -23,20 +23,33 @@ My collection of Claude skills -- primarily used for the CLaude.ai PaaS skill co
      └── your-skill/
          ├── SKILL.md
          └── resources/  (optional)
+
+   # NOTE: Do NOT include a VERSION file in your ZIP
+   # VERSION files are workflow metadata and will be ignored
    ```
 3. Upload the ZIP to the `uploads/` directory
-4. The workflow will automatically create a PR with your skill
+4. The workflow will automatically create a PR with your skill content
+5. When ready to release, update the VERSION file separately (see "Releasing Skills" below)
 
 ### Via Direct Development
 
 1. Create a new branch
-2. Add your skill folder at the repository root
-3. Include a `VERSION` file (e.g., `1.0.0`)
-4. Submit a PR
+2. Add your skill folder at the repository root (SKILL.md and resources)
+3. Submit a PR with your skill content
+4. When ready to release, update the VERSION file separately (see "Releasing Skills" below)
 
 ## Releasing Skills
 
-Skills are automatically released when VERSION files are updated on the main branch.
+**Important:** VERSION files are workflow metadata, separate from skill content.
+
+- Releases are triggered **explicitly** by updating VERSION files on main branch
+- Simply changing skill content does NOT trigger a release
+- This separation allows you to iterate on skills without creating releases for every change
+
+### How It Works
+
+1. **Develop & Update:** Upload ZIPs or edit skill files directly → PRs update skill content in repo
+2. **Release When Ready:** Update VERSION file → Automatic release created with downloadable ZIP
 
 ### Creating a New Release
 
@@ -53,10 +66,11 @@ Skills are automatically released when VERSION files are updated on the main bra
    ```
 
 3. The workflow will automatically:
-   - Create a properly structured ZIP file
+   - Create a properly structured ZIP file (VERSION excluded - it's not part of the skill)
    - Generate a GitHub release with tag `your-skill-v1.1.0`
    - Attach the ZIP as a release asset
    - Generate release notes from recent commits
+   - Users download this ZIP to install the skill
 
 ### Manual Release
 


### PR DESCRIPTION
Changes the workflow to treat VERSION files as workflow metadata separate from skill content, simplifying the development workflow.

Changes to skill-upload.yml:
- Exclude VERSION files when copying from uploaded ZIPs
- Preserves existing VERSION files in repo
- Uploaded ZIPs should NOT contain VERSION files

Changes to skill-release.yml:
- Exclude VERSION files from generated release ZIPs
- VERSION remains in repo but not in user-facing downloads
- Users install skills without VERSION metadata

Changes to README.md:
- Clarify VERSION files are workflow metadata
- Document that uploaded ZIPs should not include VERSION
- Explain separation: content updates vs releases
- Add note that released ZIPs exclude VERSION

Workflow benefits:
- Upload skill content multiple times without triggering releases
- Releases only created when explicitly bumping VERSION
- Clean separation of concerns: content vs versioning
- Round-trip compatible: download release ZIP, modify, re-upload