### PR TITLE
fix: Process all unprocessed zips on manual trigger, not just recentl…

### DIFF
--- a/.github/workflows/skill-upload.yml
+++ b/.github/workflows/skill-upload.yml
@@ -27,4 +27,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_BEFORE_COMMIT: ${{ github.event.before }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: .github/scripts/process-skill-upload.sh


### PR DESCRIPTION
…y modified ones

## Summary
- Add `workflow_dispatch` trigger to enable manual workflow execution
- Fix processing logic to handle all unprocessed zip files when manually triggered

## Problem
The skill-upload workflow only processes zip files that were added/modified in the most recent push. When the automatic trigger doesn't fire (GitHub Actions hiccups), previously uploaded zip files remain unprocessed even when manually triggering the workflow.

## Solution
1. Added `workflow_dispatch` trigger for manual execution via GitHub Actions UI
2. Updated processing logic to differentiate between trigger types:
   - **Push events**: Only process newly added/modified zips (existing behavior)
   - **Manual triggers**: Process ALL zip files in `uploads/` directory

## Changes
- `.github/workflows/skill-upload.yml`: Added `workflow_dispatch` trigger and `GITHUB_EVENT_NAME` env var
- `.github/scripts/process-skill-upload.sh`: Added conditional logic based on event type

## Usage
To manually process uploads:
1. Go to Actions → Upload Skill
2. Click "Run workflow"
3. Select branch (usually `main`) and click "Run workflow"

All zip files in `uploads/` will be processed and PRs created.