### PR TITLE
Fix keyword extraction in account categorization

### DIFF
--- a/categorizing-bsky-accounts/SKILL.md
+++ b/categorizing-bsky-accounts/SKILL.md
@@ -20,14 +20,16 @@ The analyzer delegates keyword extraction to the extracting-keywords skill, whic
 
 When users request Bluesky account analysis:
 
-1. **Determine input mode** based on user's request:
+1. **Ensure keyword extraction is set up** - Invoke the extracting-keywords skill using the Skill tool to ensure YAKE venv exists (skip if already invoked in this session)
+
+2. **Determine input mode** based on user's request:
    - Following list → use `--following handle`
    - Followers → use `--followers handle`
    - List of handles → use `--handles "h1,h2,h3"`
    - File provided → use `--file accounts.txt`
 
-2. **Configure parameters:**
-   - `--accounts N` - Number to analyze (default: 10, max: 100)
+3. **Configure parameters:**
+   - `--accounts N` - Number to analyze (default: 100, max: 100)
    - `--posts N` - Posts per account (default: 20, max: 100)
    - `--stopwords [en|ai|ls]` - Choose domain-specific stopwords:
      - `en`: English (general purpose)
@@ -35,7 +37,7 @@ When users request Bluesky account analysis:
      - `ls`: Life Sciences (for biomedical/research accounts)
    - `--exclude "pattern1,pattern2"` - Skip spam/bot accounts
 
-3. **Run script** - Outputs simple text format to stdout:
+4. **Run script** - Outputs simple text format to stdout:
    ```
    @handle1.bsky.social (Display Name)
    Bio text here
@@ -46,18 +48,18 @@ When users request Bluesky account analysis:
    Keywords: keyword4, keyword5, keyword6
    ```
 
-4. **Categorize accounts** - Claude analyzes bio + keywords to categorize by topic
+5. **Categorize accounts** - Claude analyzes bio + keywords to categorize by topic
 
 ## Quick Start
 
 **Analyze following list with AI/ML stopwords:**
 ```bash
-python scripts/bluesky_analyzer.py --following austegard.com --accounts 20 --stopwords ai
+python scripts/bluesky_analyzer.py --following austegard.com --stopwords ai
 ```
 
 **Analyze followers:**
 ```bash
-python scripts/bluesky_analyzer.py --followers austegard.com --accounts 20
+python scripts/bluesky_analyzer.py --followers austegard.com
 ```
 
 **Analyze specific handles:**
@@ -94,7 +96,7 @@ Read handles from file (one per line)
 ### Analysis Options
 
 **--accounts N**
-Number of accounts to analyze (1-100, default: 10)
+Number of accounts to analyze (1-100, default: 100)
 
 **--posts N**
 Posts to fetch per account (1-100, default: 20)
@@ -133,7 +135,7 @@ Claude then categorizes accounts based on bio + keywords without hardcoded rules
 ### Audit Your Following List
 
 ```bash
-python scripts/bluesky_analyzer.py --following your-handle.bsky.social --accounts 50 --stopwords ai
+python scripts/bluesky_analyzer.py --following your-handle.bsky.social --stopwords ai
 ```
 
 Claude will categorize accounts by topic and identify patterns in who you follow.
@@ -141,7 +143,7 @@ Claude will categorize accounts by topic and identify patterns in who you follow
 ### Find Experts in a Topic
 
 ```bash
-python scripts/bluesky_analyzer.py --following alice.bsky.social --accounts 100 --stopwords ai
+python scripts/bluesky_analyzer.py --following alice.bsky.social --stopwords ai
 ```
 
 Ask Claude: "Which of these accounts are ML researchers?" or "Who focuses on climate tech?"
@@ -232,7 +234,7 @@ This agentic pattern is more flexible than hardcoded keyword matching.
 
 **Claude:**
 ```bash
-python scripts/bluesky_analyzer.py --following user-handle.bsky.social --accounts 50 --stopwords ai
+python scripts/bluesky_analyzer.py --following user-handle.bsky.social --stopwords ai
 ```
 
 Based on the output, I can see you follow:
@@ -245,7 +247,7 @@ Based on the output, I can see you follow:
 
 **Claude:**
 ```bash
-python scripts/bluesky_analyzer.py --following alice.bsky.social --accounts 100 --stopwords ai
+python scripts/bluesky_analyzer.py --following alice.bsky.social --stopwords ai
 ```
 
 I found 23 ML researchers in Alice's network:

--- a/categorizing-bsky-accounts/scripts/bluesky_analyzer.py
+++ b/categorizing-bsky-accounts/scripts/bluesky_analyzer.py
@@ -4,8 +4,8 @@ BlueSky Account Analyzer
 Fetches Bluesky account data and extracts keywords for Claude to categorize.
 
 Usage:
-  python scripts/bluesky_analyzer.py --following austegard.com --accounts 20 --stopwords ai
-  python scripts/bluesky_analyzer.py --followers handle.bsky.social --accounts 10
+  python scripts/bluesky_analyzer.py --following austegard.com --stopwords ai
+  python scripts/bluesky_analyzer.py --followers handle.bsky.social
   python scripts/bluesky_analyzer.py --handles "h1.bsky.social,h2.bsky.social"
 """
 
@@ -291,8 +291,8 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python %(prog)s --following austegard.com --accounts 20 --stopwords ai
-  python %(prog)s --followers handle.bsky.social --accounts 10
+  python %(prog)s --following austegard.com --stopwords ai
+  python %(prog)s --followers handle.bsky.social
   python %(prog)s --handles "user1.bsky.social,user2.bsky.social"
         """
     )
@@ -305,8 +305,8 @@ Examples:
     input_group.add_argument('--file', help='Read handles from file (one per line)')
 
     # Analysis options
-    parser.add_argument('--accounts', type=int, default=10,
-                       help='Number of accounts to analyze (default: 10, max: 100)')
+    parser.add_argument('--accounts', type=int, default=100,
+                       help='Number of accounts to analyze (default: 100, max: 100)')
     parser.add_argument('--posts', type=int, default=20,
                        help='Number of posts per account (default: 20)')
     parser.add_argument('--exclude', help='Skip accounts with these keywords (comma-separated)')


### PR DESCRIPTION
…and increase default accounts

## Changes

1. **Add proactive skill invocation step**: Updated Core Workflow to instruct Claude to invoke the extracting-keywords skill using the Skill tool before running the analyzer. This prevents runtime failures when YAKE venv doesn't exist.

2. **Increase default account limit**: Changed default from 10 to 100 accounts:
   - Updated SKILL.md documentation (workflow, parameters, examples)
   - Updated bluesky_analyzer.py script default
   - Removed explicit --accounts parameters from examples to use the new default

## Fixes

This addresses the issue where the skill would fail on first use because the extracting-keywords skill wasn't invoked to set up the YAKE venv. The workflow now explicitly instructs Claude to invoke the prerequisite skill before running the analyzer script.

The higher default (100 accounts) provides more comprehensive analysis without requiring users to specify the parameter manually.