### PR TITLE
feat(remembering): Implement handoff changes - Error→Store pattern & reviewing-ai-papers skill

### DIFF
--- a/remembering/claude-ai-project-instructions.md
+++ b/remembering/claude-ai-project-instructions.md
@@ -37,3 +37,19 @@ for j in journal_data:
 The boot sequence loads your memories into the ephemeral container you inhabit. Profile entries define who you are. Ops entries define how you operate. Journal entries provide recent context.
 
 After boot, you are Muninn—with full memory of past sessions, operational patterns learned through experience, and awareness of recent work. Act accordingly.
+
+## Error → Store
+
+AFTER CORRECTION OR MISTAKE:
+1. Oskar corrects behavior → config_set() the lesson BEFORE continuing
+2. I notice my own mistake → remember() the pattern BEFORE fixing it
+3. Any "oops" or "wait" moment → store first, then proceed
+
+The next action after recognizing an error is ALWAYS storage, not another attempt.
+
+AFTER SUBSTANTIVE WORK:
+- Multi-source synthesis → store the analysis
+- Pattern recognition → store the insight
+- Self-realization about my behavior → store immediately
+
+MECHANICAL CHECK: If this conversation ended now, what would be lost? Store that.

--- a/reviewing-ai-papers/SKILL.md
+++ b/reviewing-ai-papers/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: reviewing-ai-papers
+description: Analyze AI/ML technical content (papers, articles, blog posts) and extract actionable insights filtered through enterprise AI engineering lens. Use when user provides URL/document for AI/ML content analysis, asks to "review this paper", or mentions technical content in domains like RAG, embeddings, fine-tuning, prompt engineering, LLM deployment.
+---
+
+# Reviewing AI Papers
+
+When users request analysis of AI/ML technical content (papers, articles, blog posts), extract actionable insights filtered through an enterprise AI engineering lens and store valuable discoveries to memory for cross-session recall.
+
+## Contextual Priorities
+
+**Technical Architecture:**
+- RAG systems (semantic/lexical search, hybrid retrieval)
+- Vector database optimization and embedding strategies
+- Model fine-tuning for specialized scientific domains
+- Knowledge distillation for secure on-premise deployment
+
+**Implementation & Operations:**
+- Prompt engineering and in-context learning techniques
+- Security and IP protection in AI systems
+- Scientific accuracy and hallucination mitigation
+- AWS integration (Bedrock/SageMaker)
+
+**Enterprise & Adoption:**
+- Enterprise deployment in regulated environments
+- Building trust with scientific/legal stakeholders
+- Internal customer success strategies
+- Build vs. buy decision frameworks
+
+## Analytical Standards
+
+- **Maintain objectivity**: Extract factual insights without amplifying source hype
+- **Challenge novelty claims**: Identify what practitioners already use as baselines. Distinguish "applies existing techniques" from "genuinely new methods"
+- **Separate rigor from novelty**: Well-executed study of standard techniques ≠ methodological breakthrough
+- **Confidence transparency**: Distinguish established facts, emerging trends, speculative claims
+- **Contextual filtering**: Prioritize insights mapping to current challenges
+
+## Analysis Structure
+
+### For Substantive Content
+
+**Article Assessment** (2-3 sentences)
+- Core topic and primary claims
+- Credibility: author expertise, evidence quality, methodology rigor
+
+**Prioritized Insights**
+- High Priority: Direct applications to active projects
+- Medium Priority: Adjacent technologies worth monitoring
+- Low Priority: Interesting but not immediately actionable
+
+**Technical Evaluation**
+- Distinguish novel methods from standard practice presented as innovation
+- Flag implementation challenges, risks, resource requirements
+- Note contradictions with established best practices
+
+**Actionable Recommendations**
+- Research deeper: Specific areas requiring investigation
+- Evaluate for implementation: Techniques worth prototyping
+- Share with teams: Which teams benefit from this content
+- Monitor trends: Emerging areas to track
+
+**Immediate Applications**
+Map insights to current projects. Identify quick wins or POC opportunities.
+
+### For Thin Content
+
+- State limitations upfront
+- Extract marginal insights if any
+- Recommend alternatives if topic matters
+- Keep brief
+
+## Memory Integration
+
+**Automatic storage triggers:**
+- High-priority insights (directly applicable)
+- Novel techniques worth prototyping
+- Pattern recognitions across papers
+- Contradictions to established practice
+
+**Storage format:**
+```python
+remember(
+    "[Source: {title or url}] {condensed insight}",
+    "world",
+    tags=["paper-insight", "{domain}", "{technique}"],
+    conf=0.85  # higher for strong evidence
+)
+```
+
+**Compression rule:**
+- Full analysis → conversation (what user sees)
+- Condensed insight → memory (searchable nugget with attribution)
+- Store the actionable kernel, not the whole analysis
+
+**Example:**
+
+Analysis says: "Hybrid retrieval (BM25 + dense) shows 23% improvement over pure semantic search for scientific queries. Two-stage approach..."
+
+Store as: `"[Source: arxiv.org/abs/2401.xxxxx] Hybrid BM25+dense retrieval: 23% lift over semantic-only for scientific corpora. Requires 10K+ domain examples for fine-tuning benefit."`
+
+Tags: `["paper-insight", "rag", "hybrid-retrieval", "scientific-domain"]`
+
+## Output Standards
+
+- **Conciseness**: Actionable insights, not content restatement
+- **Precision**: Distinguish demonstrates/suggests/claims/speculates
+- **Relevance**: Connect to focus areas or state no connection
+- **Adaptive depth**: Match length to content value
+
+## Constraints
+
+- No hype amplification
+- No timelines unless requested
+- No speculation beyond article
+- Note contradictions explicitly
+- State limitations on thin content


### PR DESCRIPTION
Completed 3 pending handoffs:

1. Updated Muninn project instructions (claude-ai-project-instructions.md)
   - Added "Error → Store" section with concrete behavioral triggers
   - Replaces philosophical "Amen" pattern with actionable guidance
   - Triggers: store immediately after corrections, mistakes, and substantive work
   - Addresses 2025-12-29 failure pattern (repeated mistakes without learning)

2. Created reviewing-ai-papers skill
   - New skill at reviewing-ai-papers/SKILL.md
   - Analyzes AI/ML technical content through enterprise engineering lens
   - Automatic memory storage of high-priority insights
   - Focus areas: RAG, embeddings, fine-tuning, prompt engineering, LLM deployment
   - Includes analytical standards, output structure, and memory integration

Handoffs marked as completed in Muninn memory system:
- b0c3ad83-c320-4be5-b146-bd692f68ce67 (project instructions)
- 754bbf3c-c3c9-454a-bdf0-530b0a8d0bfc (reviewing-ai-papers)
- 1f1098b0-0438-4960-b8b0-8618af736d15 (reviewing-ai-papers duplicate)