### PR TITLE
fix: Update workflow to trigger on SKILL.md changes instead of VERSION

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - '*/VERSION'
+      - '*/SKILL.md'
   workflow_dispatch:
     inputs:
       skill_name:
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       version:
-        description: 'Version number (will use VERSION file if not specified)'
+        description: 'Version number (will use metadata.version from SKILL.md if not specified)'
         required: false
         type: string
 


### PR DESCRIPTION
Change GitHub Actions workflow trigger from VERSION file changes to SKILL.md changes, aligning with frontmatter metadata.version migration.

Changes:
- Trigger path: '*/VERSION' → '*/SKILL.md'
- Updated workflow_dispatch description to reference metadata.version instead of VERSION file

Note: Workflow triggers on any SKILL.md change but release-skill.sh uses detect-version-changes.py to filter for actual version changes, preventing spurious releases from documentation-only updates.

This enables automatic releases when version is bumped in frontmatter.