### PR TITLE
fix: Move version to metadata wrapper in browsing-bluesky

### DIFF
--- a/browsing-bluesky/SKILL.md
+++ b/browsing-bluesky/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: browsing-bluesky
 description: Browse Bluesky content via API and firehose - search posts, fetch user activity, sample trending topics, read feeds and lists. Use for Bluesky research, user monitoring, trend analysis, feed reading, firehose sampling.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # Browsing Bluesky


### PR DESCRIPTION
The version field was at the top level of frontmatter instead of nested under metadata. This prevented the release workflow from detecting and extracting the version correctly.

Before:
  version: 0.1.0

After:
  metadata:
    version: 0.1.0

This aligns with the frontmatter schema used by all other skills.