### PR TITLE
fix(remembering): boot reliability fixes for v2.0.1

### DIFF
--- a/remembering/CLAUDE.md
+++ b/remembering/CLAUDE.md
@@ -1,6 +1,6 @@
 # Muninn Memory System - Claude Code Context
 
-**VERSION:** 2.0.0 (schema rebuild with priority system)
+**VERSION:** 2.0.1 (boot reliability fixes)
 
 **BOOT ON LAUNCH:** Run `boot()` at the start of every session:
 ```python
@@ -67,11 +67,26 @@ This creates a **feedback loop**: improve the skill while using it to track impr
 
 ## Environment Variables
 
-Set these in Claude Code's environment settings:
+**Option 1: Using muninn.env file (recommended for Claude Code)**
 
-| Variable | Purpose |
-|----------|---------|
-| `TURSO_TOKEN` | JWT auth token for Turso HTTP API (required) |
+Create `/mnt/project/muninn.env` with your credentials:
+```bash
+TURSO_TOKEN=your_token_here
+TURSO_URL=https://assistant-memory-oaustegard.aws-us-east-1.turso.io
+```
+
+The skill will automatically load this file on first use.
+
+**Option 2: Environment variables**
+
+Set these in your environment or Claude Code settings:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `TURSO_TOKEN` | JWT auth token for Turso HTTP API | (required) |
+| `TURSO_URL` | Turso database URL | `https://assistant-memory-oaustegard.aws-us-east-1.turso.io` |
+
+**Priority**: Environment variables → muninn.env → defaults
 
 ## Architecture
 

--- a/remembering/SKILL.md
+++ b/remembering/SKILL.md
@@ -2,7 +2,7 @@
 name: remembering
 description: Advanced memory operations reference. Basic patterns (profile loading, simple recall/remember) are in project instructions. Consult this skill for background writes, memory versioning, complex queries, and edge cases.
 metadata:
-  version: 1.0.1
+  version: 2.0.1
 ---
 
 > **⚠️ IMPORTANT FOR CLAUDE CODE AGENTS**


### PR DESCRIPTION
Fixes three critical boot issues:

1. Cache warming race condition
   - Added _cache_warmed flag to track completion
   - recall() now falls back to Turso if cache empty and not warmed
   - Prevents 0 results when recall() called immediately after boot()

2. Credential loading documentation
   - Documented muninn.env file option in CLAUDE.md
   - Clarified priority: env vars → muninn.env → defaults
   - Code already supported this, documentation was missing

3. Clean boot output
   - Silenced all cache-related warning messages
   - FTS5 migration now runs silently
   - Cache errors don't pollute boot() output

All changes maintain backward compatibility. Boot stays async for
performance, recall() handles timing gracefully.

Version: 2.0.0 → 2.0.1