### PR TITLE
feat(remembering): implement progressive disclosure for ops entries (v2.1.0)

### DIFF
--- a/remembering/bootstrap.py
+++ b/remembering/bootstrap.py
@@ -55,7 +55,8 @@ def create_tables():
             category TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             char_limit INTEGER,
-            read_only BOOLEAN DEFAULT FALSE
+            read_only BOOLEAN DEFAULT FALSE,
+            boot_load INTEGER DEFAULT 1
         )
     """)
 
@@ -82,6 +83,13 @@ def migrate_schema():
     try:
         _exec("ALTER TABLE config ADD COLUMN read_only BOOLEAN DEFAULT FALSE")
         print("Added read_only column to config table")
+    except:
+        pass  # Column already exists
+
+    # v2.1.0: Add boot_load column for progressive disclosure
+    try:
+        _exec("ALTER TABLE config ADD COLUMN boot_load INTEGER DEFAULT 1")
+        print("Added boot_load column to config table")
     except:
         pass  # Column already exists
 


### PR DESCRIPTION
Reduces boot() output size by allowing ops entries to be marked as
boot-loaded (default) or reference-only.

Changes:
- Added boot_load column to config table (both remote and local cache)
- Created config_set_boot_load() function to manage boot_load flags
- Modified ops() function to filter by boot_load with include_reference param
- Updated boot() to show reference index of available reference-only entries
- Classified 15/36 ops as reference-only to reduce token usage

Implementation details:
- Handles Turso's string return type ('0'/'1') for boot_load values
- Reference entries remain accessible via config_get()
- Progressive disclosure pattern reduces boot output while maintaining discoverability

Results:
- Boot-loaded ops: 21 (core behavioral and workflow)
- Reference-only ops: 15 (API docs, container specs, rarely-triggered)
- Boot output includes reference index for progressive access

Completes handoff d243fe53-7455-48d1-a988-f90137a2f951