### PR TITLE
feat(remembering): Integrate utility installation into boot.py

### DIFF
--- a/_MAP.md
+++ b/_MAP.md
@@ -1,5 +1,5 @@
 # claude-skills/
-*Files: 5 | Subdirectories: 33*
+*Files: 5 | Subdirectories: 35*
 
 ## Subdirectories
 
@@ -7,6 +7,7 @@
 - [api-credentials/](./api-credentials/_MAP.md)
 - [asking-questions/](./asking-questions/_MAP.md)
 - [browsing-bluesky/](./browsing-bluesky/_MAP.md)
+- [building-github-index/](./building-github-index/_MAP.md)
 - [categorizing-bsky-accounts/](./categorizing-bsky-accounts/_MAP.md)
 - [charting-vega-lite/](./charting-vega-lite/_MAP.md)
 - [check-tools/](./check-tools/_MAP.md)
@@ -35,6 +36,7 @@
 - [scripts/](./scripts/_MAP.md)
 - [templates/](./templates/_MAP.md)
 - [updating-knowledge/](./updating-knowledge/_MAP.md)
+- [using-webctl/](./using-webctl/_MAP.md)
 - [versioning-skills/](./versioning-skills/_MAP.md)
 
 ## Files

--- a/building-github-index/_MAP.md
+++ b/building-github-index/_MAP.md
@@ -1,0 +1,27 @@
+# building-github-index/
+*Files: 3 | Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+
+## Files
+
+### CHANGELOG.md
+- building-github-index - Changelog `h1` :1
+- [0.0.1] - 2026-01-15 `h2` :5
+
+### README.md
+- building-github-index `h1` :1
+
+### SKILL.md
+- Building GitHub Index `h1` :8
+- Quick Start `h2` :12
+- Script Options `h2` :20
+- Output Structure `h2` :35
+- API Access `h2` :60
+- Manual Index Creation `h2` :76
+- Quality Standards `h2` :86
+- Network Requirements `h2` :94
+- Related Skills `h2` :98
+

--- a/building-github-index/scripts/_MAP.md
+++ b/building-github-index/scripts/_MAP.md
@@ -1,0 +1,24 @@
+# scripts/
+*Files: 1*
+
+## Files
+
+### github_index.py
+> Imports: `argparse, base64, json, os, re`...
+- **api_request** (f) `(url: str, token: Optional[str] = None, timeout: int = 30)` :52
+- **get_repo_info** (f) `(owner: str, repo: str, token: Optional[str] = None)` :72
+- **get_repo_tree** (f) `(owner: str, repo: str, branch: str, token: Optional[str] = None)` :79
+- **should_include** (f) `(path: str, include: list[str], exclude: list[str])` :86
+- **is_content_file** (f) `(path: str)` :103
+- **fetch_file** (f) `(owner: str, repo: str, path: str, branch: str, 
+               token: Optional[str] = None)` :108
+- **extract_frontmatter** (f) `(content: str)` :122
+- **extract_notebook_title** (f) `(content: str)` :147
+- **infer_category** (f) `(path: str)` :162
+- **description_from_path** (f) `(path: str)` :194
+- **process_repo** (f) `(owner: str, repo: str, token: Optional[str] = None,
+                 include: list[str] = None, exclude: list[str] = None,
+                 max_files: int = 200, skip_fetch: bool = False)` :203
+- **generate_index** (f) `(repos: list[RepoInfo])` :272
+- **main** (f) `()` :329
+

--- a/remembering/_MAP.md
+++ b/remembering/_MAP.md
@@ -1,5 +1,5 @@
 # remembering/
-*Files: 14 | Subdirectories: 1*
+*Files: 15 | Subdirectories: 1*
 
 ## Subdirectories
 
@@ -92,21 +92,23 @@
 
 ### boot.py
 > Imports: `json, threading, datetime, ., .turso`...
-- **profile** (f) `()` :26
-- **ops** (f) `(include_reference: bool = False)` :31
-- **boot** (f) `()` :84
-- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :231
-- **journal_recent** (f) `(n: int = 10)` :248
-- **journal_prune** (f) `(keep: int = 40)` :264
-- **therapy_scope** (f) `()` :278
-- **therapy_session_count** (f) `()` :293
-- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :302
-- **group_by_type** (f) `(memories: list)` :317
-- **group_by_tag** (f) `(memories: list)` :333
-- **muninn_export** (f) `()` :353
-- **handoff_pending** (f) `()` :367
-- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :379
-- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :411
+- **classify_ops_key** (f) `(key: str)` :71
+- **group_ops_by_topic** (f) `(ops_entries: list)` :90
+- **profile** (f) `()` :117
+- **ops** (f) `(include_reference: bool = False)` :122
+- **boot** (f) `()` :175
+- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :323
+- **journal_recent** (f) `(n: int = 10)` :340
+- **journal_prune** (f) `(keep: int = 40)` :356
+- **therapy_scope** (f) `()` :370
+- **therapy_session_count** (f) `()` :385
+- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :394
+- **group_by_type** (f) `(memories: list)` :409
+- **group_by_tag** (f) `(memories: list)` :425
+- **muninn_export** (f) `()` :445
+- **handoff_pending** (f) `()` :459
+- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :471
+- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :503
 
 ### bootstrap.py
 > Imports: `sys, os`
@@ -167,4 +169,8 @@
 ### turso.py
 > Imports: `requests, json, os, time, pathlib`...
 - *No top-level symbols*
+
+### utilities.py
+> Imports: `os, sys`
+- **install_utilities** (f) `()` :8
 

--- a/remembering/__init__.py
+++ b/remembering/__init__.py
@@ -54,6 +54,9 @@ from .boot import (
     muninn_export, muninn_import
 )
 
+# Import utilities layer
+from .utilities import install_utilities, UTIL_DIR
+
 # Short aliases
 r = remember
 q = recall
@@ -71,5 +74,6 @@ __all__ = [
     "cache_stats",  # cache diagnostics
     "reprioritize",  # priority adjustment
     "strengthen", "weaken",  # deprecated (v2.0.0) - no-op, kept for compat
+    "install_utilities", "UTIL_DIR",  # utilities
     "r", "q", "j", "TYPES"  # aliases & constants
 ]

--- a/remembering/utilities.py
+++ b/remembering/utilities.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+UTIL_DIR = "/home/claude/muninn_utils"
+CODE_START = "<" + "<" + "<PYTHON>" + ">" + ">"
+CODE_END = "<" + "<" + "<END>" + ">" + ">"
+
+def install_utilities() -> dict:
+    """
+    Materialize all utility-code memories to disk.
+    Called by boot() after cache refresh.
+
+    Returns:
+        Dict mapping utility names to file paths
+    """
+    from .memory import recall
+
+    os.makedirs(UTIL_DIR, exist_ok=True)
+    init_path = os.path.join(UTIL_DIR, "__init__.py")
+    if not os.path.exists(init_path):
+        open(init_path, 'w').close()
+
+    parent = os.path.dirname(UTIL_DIR)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+
+    results = recall(tags=["utility-code"], n=50)
+    installed = {}
+
+    for mem in results:
+        content = mem.get("summary", "")
+        if not content.startswith("NAME:"):
+            continue
+        name = content.split("\n")[0].replace("NAME:", "").strip()
+        if CODE_START not in content:
+            continue
+        code = content.split(CODE_START, 1)[1].split(CODE_END, 1)[0].strip()
+
+        file_path = os.path.join(UTIL_DIR, f"{name}.py")
+        with open(file_path, 'w') as f:
+            f.write(code + "\n")
+        installed[name] = file_path
+
+    return installed

--- a/using-webctl/_MAP.md
+++ b/using-webctl/_MAP.md
@@ -1,0 +1,28 @@
+# using-webctl/
+*Files: 3 | Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+
+## Files
+
+### CHANGELOG.md
+- using-webctl - Changelog `h1` :1
+- [0.0.1] - 2026-01-15 `h2` :5
+
+### README.md
+- using-webctl `h1` :1
+
+### SKILL.md
+- Using webctl in Claude.ai Containers `h1` :8
+- When This Skill Applies `h2` :12
+- Core Problem `h2` :18
+- Solution `h2` :22
+- Setup Procedure `h2` :26
+- Quick Reference `h2` :79
+- Troubleshooting `h2` :123
+- Limitations `h2` :142
+- Domain Restrictions `h2` :148
+- Output Filtering `h2` :152
+

--- a/using-webctl/scripts/_MAP.md
+++ b/using-webctl/scripts/_MAP.md
@@ -1,0 +1,16 @@
+# scripts/
+*Files: 2*
+
+## Files
+
+### auth_proxy.py
+> Imports: `asyncio, base64, os, socket, threading`...
+- **get_local_proxy_url** (f) `()` :22
+- **start_auth_proxy** (f) `()` :44
+- **stop_auth_proxy** (f) `()` :149
+
+### setup_webctl.py
+> Imports: `subprocess, sys, pathlib`
+- **run** (f) `(cmd, check=True)` :13
+- **main** (f) `()` :23
+


### PR DESCRIPTION
Implements handoff 97fc220b to move utility code bootstrap logic from
project instructions into the remembering skill itself.

Changes:
- Created remembering/utilities.py with install_utilities() function
- Modified boot.py to call install_utilities() after cache warming
- Updated boot() output to display UTILITIES section with count and names
- Exported install_utilities and UTIL_DIR in __init__.py
- Updated code maps (_MAP.md) across repository

Testing:
- boot() now shows "# UTILITIES (4)" section
- Successfully imports from muninn_utils after boot
- All utility-code memories materialized to disk

Handoff 97fc220b marked as completed in Muninn.