### PR TITLE
feat(remembering): Bump to v3.0.0 for utility auto-installation

### DIFF
--- a/remembering/CHANGELOG.md
+++ b/remembering/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `remembering` skill (Muninn) are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.0.0] - 2026-01-16
+
+### Added
+
+- **BREAKING**: Integrated utility code installation into `boot()` - utilities now auto-install during boot sequence
+- Created `remembering/utilities.py` module with `install_utilities()` function
+- Added UTILITIES section to boot output showing installed utility count and names
+- Exported `install_utilities` and `UTIL_DIR` in `__init__.py`
+
+### Changed
+
+- **BREAKING**: `boot()` now automatically materializes utility-code memories to disk at `/home/claude/muninn_utils/`
+- Updated `utility-code-storage` ops entry to reflect automatic installation (removed manual bootstrap instructions)
+
+### Removed
+
+- Manual utility bootstrap code no longer needed in project instructions (now handled by skill)
+
+### Significance
+
+This is a major version bump because the skill can now manage its own utility code - a significant architectural capability. The skill is no longer just about memory storage; it can self-update operational code through the utility system.
+
 ## [2.2.1] - 2026-01-09
 
 ### Added

--- a/remembering/SKILL.md
+++ b/remembering/SKILL.md
@@ -2,7 +2,7 @@
 name: remembering
 description: Advanced memory operations reference. Basic patterns (profile loading, simple recall/remember) are in project instructions. Consult this skill for background writes, memory versioning, complex queries, and edge cases.
 metadata:
-  version: 2.2.1
+  version: 3.0.0
 ---
 
 > **⚠️ IMPORTANT FOR CLAUDE CODE AGENTS**


### PR DESCRIPTION
BREAKING CHANGE: Utilities now auto-install during boot()

This is a major version bump because the skill can now manage its own utility code - a significant architectural capability. The skill is no longer just about memory storage; it can self-update operational code through the utility system.

Changes:
- Updated SKILL.md metadata.version to 3.0.0
- Added CHANGELOG entry documenting the breaking changes
- Marked as breaking because boot() behavior has changed

Follows PR #195 which integrated the utility installation feature.