### PR TITLE
Extend getting-env to parse shell exports and use it for Turso creds in remembering

### DIFF
--- a/getting-env/SKILL.md
+++ b/getting-env/SKILL.md
@@ -2,7 +2,7 @@
 name: getting-env
 description: Universal environment variable loader for AI agent environments. Loads secrets and config from Claude.ai, Claude Code, OpenAI Codex, Jules, and standard .env files.
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   replaces: api-credentials
 ---
 
@@ -31,7 +31,7 @@ env = detect_environment()  # "claude.ai", "claude-code-desktop", "codex", "jule
 |-------------|----------------|
 | **Claude.ai Projects** | `/mnt/project/*.env`, `/mnt/project/*-token.txt` |
 | **Claude Code** | `~/.claude/settings.json` (`env` block), `.claude/settings.json` |
-| **OpenAI Codex** | `~/.codex/config.toml`, setup script → `~/.bashrc` |
+| **OpenAI Codex** | `~/.codex/config.toml`, setup script → `~/.bashrc`, `shell_snapshots/*.sh` |
 | **Jules** | Environment settings UI, `.env` in repo |
 | **Universal** | `os.environ`, `.env`, `.env.local` |
 

--- a/remembering/SKILL.md
+++ b/remembering/SKILL.md
@@ -2,7 +2,7 @@
 name: remembering
 description: Advanced memory operations reference. Basic patterns (profile loading, simple recall/remember) are in project instructions. Consult this skill for background writes, memory versioning, complex queries, edge cases, session scoping, and retention management.
 metadata:
-  version: 3.3.0
+  version: 3.3.1
 ---
 
 > **⚠️ IMPORTANT FOR CLAUDE CODE AGENTS**


### PR DESCRIPTION
### Motivation
- Improve detection of TURSO credentials in environments where tokens are exported from shell snapshots or profile files (not just .env/config files), particularly for OpenAI Codex snapshots. 
- Allow the `remembering` Turso initializer to use the unified loader so credentials can be discovered from richer sources when available.

### Description
- Added `_parse_shell_exports(path: Path)` to `getting-env/scripts/getting_env.py` to parse `export KEY=value` and `declare -x KEY=value` lines from shell files and snapshots. 
- Extended `_load_codex()` in `getting-env/scripts/getting_env.py` to read `~/.bashrc`, `~/.profile` and the newest `shell_snapshots/*.sh` under `CODEX_HOME` and merge parsed exports into the environment map, and updated the reported loaded source string. 
- Bumped `getting-env` metadata version to `1.0.1` and documented `shell_snapshots/*.sh` in `getting-env/SKILL.md`. 
- Updated `remembering/turso.py` initialization to optionally import and call `getting_env.get_env()` (via `importlib`) to obtain `TURSO_URL` and `TURSO_TOKEN` if they were not found via existing fallbacks. 
- Bumped `remembering` skill metadata version to `3.3.1`.

### Testing
- Ran `python3 getting-env/scripts/getting_env.py` and observed `Environment: codex` with `Sources: os.environ, codex:config.toml + shell exports + shell_snapshots` (succeeded). 
- Ran a quick integration attempt with `TURSO_TOKEN=dummy TURSO_URL=... python3 - <<'PY' ... from remembering.turso import _init; _init()` which failed during import with `ModuleNotFoundError: No module named 'requests'`, indicating the runtime lacks `requests` and preventing full Turso init verification (failed). 
- Notes: the changes are limited to env-loading and optional use of `getting_env` when present; full Turso connectivity requires `requests` available and valid TURSO credentials.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e619206c832483614fbac267df30)