### PR TITLE
fix(inspecting-skills): Remove circular symlink causing zip issues

### DIFF
--- a/inspecting-skills/SKILL.md
+++ b/inspecting-skills/SKILL.md
@@ -2,7 +2,7 @@
 name: inspecting-skills
 description: Discovers and indexes Python code in skills, enabling cross-skill imports. Use when importing functions from other skills or analyzing skill codebases.
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   author: Claude
   tags: [development, meta, imports, indexing]
 ---

--- a/inspecting-skills/inspecting_skills
+++ b/inspecting-skills/inspecting_skills
@@ -1,1 +1,0 @@
-../inspecting-skills


### PR DESCRIPTION
The inspecting_skills symlink pointed to ../inspecting-skills creating a circular reference that caused the zip process to recurse deeply. The skill_imports.py handles dash-underscore conversion without needing this symlink.