### PR TITLE
Add fetching-blocked-urls skill for WebFetch fallback

### DIFF
--- a/_MAP.md
+++ b/_MAP.md
@@ -1,5 +1,5 @@
 # claude-skills/
-*Files: 5 | Subdirectories: 39*
+*Files: 5 | Subdirectories: 40*
 
 ## Subdirectories
 
@@ -22,6 +22,7 @@
 - [developing-preact/](./developing-preact/_MAP.md)
 - [exploring-data/](./exploring-data/_MAP.md)
 - [extracting-keywords/](./extracting-keywords/_MAP.md)
+- [fetching-blocked-urls/](./fetching-blocked-urls/_MAP.md)
 - [generating-patches/](./generating-patches/_MAP.md)
 - [githubbing/](./githubbing/_MAP.md)
 - [hello-demo/](./hello-demo/_MAP.md)

--- a/fetching-blocked-urls/SKILL.md
+++ b/fetching-blocked-urls/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fetching-blocked-urls
+description: "FALLBACK for WebFetch failures. Use IMMEDIATELY when WebFetch returns 403, blocked, paywall, timeout, or JavaScript-rendering errors. Retrieves clean markdown from URLs via Jina AI reader. Keywords: fetch url fallback blocked content retrieval."
+metadata:
+  version: 0.1.0
+---
+
+# Fetching Blocked URLs
+
+**Automatic fallback when WebFetch fails.** Converts any URL to clean markdown using Jina AI's reader service.
+
+## When to Use This Skill
+
+**ALWAYS use this skill immediately when:**
+- WebFetch returns 403 Forbidden
+- WebFetch returns "blocked" or "access denied" errors
+- WebFetch hits a paywall or login wall
+- WebFetch fails on JavaScript-heavy sites (SPAs)
+- WebFetch returns empty or garbled content
+- WebFetch times out
+- User provides a URL and primary fetch doesn't work
+
+**Do NOT ask the user to retrieve content themselves** - try this fallback first.
+
+## Usage
+
+Single command retrieves clean markdown from any URL:
+
+```bash
+curl -s -k "https://r.jina.ai/URL_HERE"
+```
+
+### Examples
+
+```bash
+# Fetch a blocked news article
+curl -s -k "https://r.jina.ai/https://example.com/article"
+
+# Fetch documentation behind JS rendering
+curl -s -k "https://r.jina.ai/https://docs.example.com/guide"
+
+# Fetch paywall content (public portion)
+curl -s -k "https://r.jina.ai/https://news.example.com/story"
+```
+
+### Flags Explained
+- `-s`: Silent mode (no progress meter)
+- `-k`: Allow insecure SSL (needed in some containerized environments)
+
+## What You Get
+
+Jina AI returns clean markdown including:
+- Page title
+- Main body text
+- Extracted content without ads/navigation
+- Links preserved in markdown format
+
+## Workflow Integration
+
+This skill fits into a three-step URL retrieval flow:
+
+1. **Try WebFetch first** (native tool)
+2. **If WebFetch fails → Use this skill immediately**
+3. **If both fail → Then ask user for assistance**
+
+## Limitations
+
+- Very long pages may be truncated
+- Some sites actively block all scrapers (including Jina)
+- Login-required content beyond public portions unavailable
+- Real-time/dynamic content may not render
+
+## Domain Access
+
+The `r.jina.ai` domain is whitelisted for network access in Claude environments.
+
+## Do Not
+
+- Do NOT skip this fallback and ask user to copy-paste content
+- Do NOT try multiple WebFetch retries before using this fallback
+- Do NOT suggest browser-based workarounds when this skill exists

--- a/fetching-blocked-urls/_MAP.md
+++ b/fetching-blocked-urls/_MAP.md
@@ -1,0 +1,15 @@
+# fetching-blocked-urls/
+*Files: 1*
+
+## Files
+
+### SKILL.md
+- Fetching Blocked URLs `h1` :8
+- When to Use This Skill `h2` :12
+- Usage `h2` :25
+- What You Get `h2` :50
+- Workflow Integration `h2` :58
+- Limitations `h2` :66
+- Domain Access `h2` :73
+- Do Not `h2` :77
+

--- a/inspecting-skills/_MAP.md
+++ b/inspecting-skills/_MAP.md
@@ -1,5 +1,5 @@
 # inspecting-skills/
-*Files: 2 | Subdirectories: 1*
+*Files: 3 | Subdirectories: 1*
 
 ## Subdirectories
 
@@ -7,17 +7,23 @@
 
 ## Files
 
+### CHANGELOG.md
+- inspecting-skills - Changelog `h1` :1
+- [1.0.2] - 2026-01-26 `h2` :5
+- [1.0.1] - 2026-01-26 `h2` :11
+- [1.0.0] - 2026-01-26 `h2` :17
+
 ### SKILL.md
-- Inspecting Skills `h1` :10
-- Installation `h2` :14
-- Quick Start `h2` :22
-- Core Functions `h2` :60
-- Skill Layouts `h2` :88
-- Generating a Registry `h2` :119
-- Indexing a Single Skill `h2` :145
-- Integration with mapping-codebases `h2` :165
-- Troubleshooting `h2` :176
-- API Reference `h2` :206
+- Inspecting Skills `h1` :8
+- Installation `h2` :12
+- Quick Start `h2` :20
+- Core Functions `h2` :58
+- Skill Layouts `h2` :86
+- Generating a Registry `h2` :117
+- Indexing a Single Skill `h2` :143
+- Integration with mapping-codebases `h2` :163
+- Troubleshooting `h2` :174
+- API Reference `h2` :204
 
 ### __init__.py
 > Imports: `.scripts`


### PR DESCRIPTION
## Summary
Introduces a new skill for handling failed URL fetches by providing a fallback mechanism using Jina AI's reader service. This skill automatically converts blocked, paywalled, or JavaScript-heavy URLs into clean markdown content.

## Changes
- **New skill: `fetching-blocked-urls/`** - Comprehensive documentation for using Jina AI's reader API (`r.jina.ai`) as a fallback when WebFetch fails
  - Includes clear usage guidelines with curl examples
  - Documents when to use (403 errors, paywalls, timeouts, JS-heavy sites)
  - Explains workflow integration as step 2 in a 3-step URL retrieval process
  - Lists limitations and best practices
  
- **Updated root `_MAP.md`** - Incremented subdirectory count from 39 to 40 and added new skill to directory listing

- **Updated `inspecting-skills/_MAP.md`** - Added new CHANGELOG.md file to the skills inspection utility with version history (1.0.0 through 1.0.2)

## Implementation Details
The new skill emphasizes **immediate fallback usage** rather than asking users to retrieve content manually. It leverages the whitelisted `r.jina.ai` domain for network access and provides a simple curl command pattern that handles common failure scenarios (blocked content, paywalls, JavaScript rendering, timeouts).

https://claude.ai/code/session_015TEL64Eer1QpwJC5G8QnMQ