### PR TITLE
feat(remembering): fix aliases, expansion threshold, return format (v3.7.0)

### DIFF
--- a/_MAP.md
+++ b/_MAP.md
@@ -1,5 +1,5 @@
 # claude-skills/
-*Files: 5 | Subdirectories: 40*
+*Files: 5 | Subdirectories: 42*
 
 ## Subdirectories
 
@@ -8,6 +8,7 @@
 - [asking-questions/](./asking-questions/_MAP.md)
 - [browsing-bluesky/](./browsing-bluesky/_MAP.md)
 - [building-github-index/](./building-github-index/_MAP.md)
+- [building-github-index-v2/](./building-github-index-v2/_MAP.md)
 - [categorizing-bsky-accounts/](./categorizing-bsky-accounts/_MAP.md)
 - [charting-vega-lite/](./charting-vega-lite/_MAP.md)
 - [check-tools/](./check-tools/_MAP.md)
@@ -20,6 +21,7 @@
 - [creating-mcp-servers/](./creating-mcp-servers/_MAP.md)
 - [creating-skill/](./creating-skill/_MAP.md)
 - [developing-preact/](./developing-preact/_MAP.md)
+- [exploring-codebases/](./exploring-codebases/_MAP.md)
 - [exploring-data/](./exploring-data/_MAP.md)
 - [extracting-keywords/](./extracting-keywords/_MAP.md)
 - [fetching-blocked-urls/](./fetching-blocked-urls/_MAP.md)

--- a/building-github-index-v2/_MAP.md
+++ b/building-github-index-v2/_MAP.md
@@ -1,0 +1,28 @@
+# building-github-index-v2/
+*Files: 3 | Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+
+## Files
+
+### CHANGELOG.md
+- building-github-index - Changelog `h1` :1
+- [2.0.0] - 2026-02-04 `h2` :5
+
+### README.md
+- building-github-index `h1` :1
+
+### SKILL.md
+- Building GitHub Index `h1` :8
+- Quick Start `h2` :12
+- Script Options `h2` :25
+- Description Extraction Priority `h2` :37
+- When Descriptions Fail `h2` :45
+- Output Format `h2` :62
+- API Access `h2` :84
+- Network `h2` :98
+- Related Skills `h2` :102
+- Condensed Format (pk_index.py) `h2` :107
+

--- a/building-github-index-v2/scripts/_MAP.md
+++ b/building-github-index-v2/scripts/_MAP.md
@@ -1,0 +1,35 @@
+# scripts/
+*Files: 2*
+
+## Files
+
+### github_index.py
+> Imports: `argparse, base64, json, os, re`...
+- **api_request** (f) `(url: str, token: Optional[str] = None, timeout: int = 30)` :57
+- **get_repo_info** (f) `(owner: str, repo: str, token: Optional[str] = None)` :72
+- **get_repo_tree** (f) `(owner: str, repo: str, branch: str, token: Optional[str] = None)` :77
+- **should_include** (f) `(path: str, include: list[str], exclude: list[str])` :82
+- **fetch_file** (f) `(owner: str, repo: str, path: str, branch: str, 
+               token: Optional[str] = None)` :95
+- **extract_frontmatter** (f) `(content: str)` :106
+- **extract_headings** (f) `(content: str)` :124
+- **extract_notebook_title** (f) `(content: str)` :143
+- **extract_code_symbols** (f) `(content: str, lang: str)` :156
+- **infer_category** (f) `(path: str)` :194
+- **description_from_path** (f) `(path: str)` :212
+- **process_repo** (f) `(owner: str, repo: str, token: Optional[str] = None,
+                 include: list[str] = None, exclude: list[str] = None,
+                 max_files: int = 200, skip_fetch: bool = False,
+                 code_symbols: bool = False)` :219
+- **generate_index** (f) `(repos: list[RepoInfo])` :295
+- **main** (f) `()` :341
+
+### pk_index.py
+> Imports: `json, os, sys, tarfile, tempfile`...
+- **fetch_tarball** (f) `(owner: str, repo: str, ref: str = 'main')` :31
+- **extract_md_topics** (f) `(content: str)` :37
+- **extract_py_symbols** (f) `(content: bytes, parser)` :50
+- **extract_js_symbols** (f) `(content: bytes, parser)` :67
+- **process_repo** (f) `(owner: str, repo: str, ref: str = 'main', output: str = None)` :100
+- **generate_pk_output** (f) `(owner: str, repo: str, ref: str, entries: list, output_path: str)` :169
+

--- a/exploring-codebases/_MAP.md
+++ b/exploring-codebases/_MAP.md
@@ -1,0 +1,24 @@
+# exploring-codebases/
+*Files: 3 | Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+
+## Files
+
+### CHANGELOG.md
+- exploring-codebases - Changelog `h1` :1
+- [0.2.0] - 2026-02-03 `h2` :5
+
+### README.md
+- exploring-codebases `h1` :1
+
+### SKILL.md
+- Exploring Codebases `h1` :8
+- Progressive Disclosure `h2` :12
+- Installation `h2` :16
+- Usage `h2` :23
+- Options `h2` :33
+- Examples `h2` :39
+

--- a/exploring-codebases/scripts/_MAP.md
+++ b/exploring-codebases/scripts/_MAP.md
@@ -1,0 +1,22 @@
+# scripts/
+*Files: 1*
+
+## Files
+
+### search.py
+> Imports: `subprocess, json, sys, os, dataclasses`...
+- **HybridRetriever** (C) :71
+  - **__init__** (m) `(self)` :72
+  - **_get_language** (m) `(self, file_path: str)` :75
+  - **_get_parser** (m) `(self, language: str)` :79
+  - **_run_ripgrep** (m) `(self, query: str, path: str, glob: Optional[str] = None)` :88
+  - **_get_node_name** (m) `(self, node, source_bytes: bytes)` :132
+  - **_extract_signature** (m) `(self, node, source_bytes: bytes, language: str)` :146
+  - **_extract_python_signature** (m) `(self, node, source_bytes: bytes)` :160
+  - **_extract_js_signature** (m) `(self, node, source_bytes: bytes)` :203
+  - **_extract_go_signature** (m) `(self, node, source_bytes: bytes)` :215
+  - **_get_node_at_line** (m) `(self, root_node, line_number: int, language: str)` :226
+  - **_expand_context** (m) `(self, file_path: str, line_number: int, signatures_only: bool = True)` :263
+  - **search** (m) `(self, query: str, path: str = ".", glob: Optional[str] = None, signatures_only: bool = True)` :314
+- **main** (f) `()` :333
+

--- a/mapping-codebases/_MAP.md
+++ b/mapping-codebases/_MAP.md
@@ -1,0 +1,26 @@
+# mapping-codebases/
+*Files: 3 | Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+
+## Files
+
+### CHANGELOG.md
+- mapping-codebases - Changelog `h1` :1
+- [0.6.0] - 2026-02-03 `h2` :5
+
+### README.md
+- mapping-codebases `h1` :1
+
+### SKILL.md
+- Mapping Codebases `h1` :8
+- Installation `h2` :12
+- Generate Maps `h2` :19
+- Navigate Via Maps `h2` :27
+- Map Contents `h2` :45
+- Commands `h2` :74
+- Supported Languages `h2` :92
+- Limitations `h2` :96
+

--- a/mapping-codebases/scripts/_MAP.md
+++ b/mapping-codebases/scripts/_MAP.md
@@ -1,0 +1,23 @@
+# scripts/
+*Files: 1*
+
+## Files
+
+### codemap.py
+> Imports: `os, sys, pathlib, dataclasses, tree_sitter_language_pack`
+- **get_language** (f) `(filepath: Path)` :58
+- **get_node_text** (f) `(node, source: bytes)` :61
+- **extract_python** (f) `(tree, source: bytes)` :64
+- **extract_typescript** (f) `(tree, source: bytes)` :144
+- **extract_go** (f) `(tree, source: bytes)` :223
+- **extract_rust** (f) `(tree, source: bytes)` :247
+- **extract_ruby** (f) `(tree, source: bytes)` :290
+- **extract_java** (f) `(tree, source: bytes)` :324
+- **extract_html_javascript** (f) `(tree, source: bytes)` :360
+- **extract_markdown** (f) `(tree, source: bytes)` :454
+- **analyze_file** (f) `(filepath: Path)` :512
+- **format_symbol** (f) `(symbol: Symbol, indent: int = 0)` :535
+- **generate_map_for_directory** (f) `(dirpath: Path, skip_dirs: set[str])` :560
+- **generate_maps** (f) `(root: Path, skip_dirs: set[str], dry_run: bool = False)` :639
+- **main** (f) `()` :664
+

--- a/remembering/CLAUDE.md
+++ b/remembering/CLAUDE.md
@@ -422,7 +422,23 @@ if github['available']:
 - `prune_by_age()` - delete old memories with priority filters
 - `prune_by_priority()` - delete low-priority memories
 
+## What's New in v3.7.0
+
+**Parameter & Field Aliases** (#262): Common field name mistakes are now transparently resolved instead of raising errors:
+- `m.content` / `m['content']` resolves to `m.summary`
+- `m.conf` resolves to `m.confidence`
+- `recall(limit=20)` works as alias for `recall(n=20)`
+
+**Configurable Query Expansion** (#238): The query expansion threshold is now configurable:
+- `recall("term", expansion_threshold=5)` - expand if fewer than 5 results
+- `recall("term", expansion_threshold=0)` - disable expansion entirely
+- Default remains 3 for backward compatibility
+
+**Standardized Return Format** (#264): All results now include computed fields regardless of source:
+- `summary_preview` (first 100 chars) always present
+- `bm25_score`, `composite_rank`, `composite_score` added to VALID_FIELDS
+- Results from Turso and cache are normalized to the same field set
+
 ## Known Limitations
 
 - Session filtering bypasses cache (queries Turso directly) - cache support planned for future release
-- Query expansion fallback threshold is fixed at 3 results (not configurable)

--- a/remembering/_MAP.md
+++ b/remembering/_MAP.md
@@ -10,50 +10,51 @@
 ### CHANGELOG.md
 - Muninn Memory System - Changelog `h1` :1
 - [3.6.0] - 2026-01-31 `h2` :5
-- [3.5.0] - 2026-01-27 `h2` :20
-- [3.4.0] - 2026-01-25 `h2` :27
-- [3.4.0] - 2026-01-25 `h2` :38
-- [3.3.3] - 2026-01-22 `h2` :52
-- [3.3.2] - 2026-01-22 `h2` :58
-- [3.3.2] - 2026-01-22 `h2` :69
-- [3.3.1] - 2026-01-22 `h2` :83
-- [3.3.0] - 2026-01-21 `h2` :89
-- [3.2.1] - 2026-01-21 `h2` :99
-- [3.2.0] - 2026-01-16 `h2` :103
+- [3.6.0] - 2026-01-31 `h2` :11
+- [3.5.0] - 2026-01-27 `h2` :26
+- [3.4.0] - 2026-01-25 `h2` :33
+- [3.4.0] - 2026-01-25 `h2` :44
+- [3.3.3] - 2026-01-22 `h2` :58
+- [3.3.2] - 2026-01-22 `h2` :64
+- [3.3.2] - 2026-01-22 `h2` :75
+- [3.3.1] - 2026-01-22 `h2` :89
+- [3.3.0] - 2026-01-21 `h2` :95
+- [3.2.1] - 2026-01-21 `h2` :105
 - [3.2.0] - 2026-01-16 `h2` :109
-- [3.1.0] - 2026-01-16 `h2` :138
-- [3.0.0] - 2026-01-16 `h2` :144
-- [3.0.0] - 2026-01-16 `h2` :162
-- [2.2.1] - 2026-01-09 `h2` :184
-- [2.1.1] - 2026-01-09 `h2` :204
-- [2.1.0] - 2026-01-09 `h2` :214
-- [2.0.2] - 2026-01-09 `h2` :220
-- [2.0.1] - 2026-01-09 `h2` :226
-- [1.0.1] - 2026-01-09 `h2` :237
-- [2.0.0] - 2026-01-09 `h2` :247
-- [0.14.1] - 2026-01-06 `h2` :253
+- [3.2.0] - 2026-01-16 `h2` :115
+- [3.1.0] - 2026-01-16 `h2` :144
+- [3.0.0] - 2026-01-16 `h2` :150
+- [3.0.0] - 2026-01-16 `h2` :168
+- [2.2.1] - 2026-01-09 `h2` :190
+- [2.1.1] - 2026-01-09 `h2` :210
+- [2.1.0] - 2026-01-09 `h2` :220
+- [2.0.2] - 2026-01-09 `h2` :226
+- [2.0.1] - 2026-01-09 `h2` :232
+- [1.0.1] - 2026-01-09 `h2` :243
+- [2.0.0] - 2026-01-09 `h2` :253
 - [0.14.1] - 2026-01-06 `h2` :259
-- [0.14.0] - 2026-01-04 `h2` :266
-- [0.13.1] - 2026-01-02 `h2` :272
-- [0.13.0] - 2025-12-30 `h2` :289
-- [0.12.2] - 2025-12-30 `h2` :301
-- [0.12.1] - 2025-12-30 `h2` :305
-- [0.12.0] - 2025-12-30 `h2` :338
-- [0.11.0] - 2025-12-30 `h2` :377
-- [0.10.1] - 2025-12-29 `h2` :409
-- [0.10.0] - 2025-12-28 `h2` :448
-- [0.9.1] - 2025-12-28 `h2` :501
-- [0.9.0] - 2025-12-28 `h2` :520
-- [0.8.0] - 2025-12-27 `h2` :569
-- [0.7.1] - 2025-12-27 `h2` :603
-- [0.7.0] - 2025-12-27 `h2` :630
-- [0.6.1] - 2025-12-27 `h2` :675
-- [0.6.0] - 2025-12-27 `h2` :699
-- [0.4.0] - 2025-12-27 `h2` :735
-- [0.3.1] - 2025-12-26 `h2` :754
-- [0.3.0] - 2025-12-26 `h2` :761
-- [0.1.0] - 2025-12-26 `h2` :770
-- Summary `h2` :781
+- [0.14.1] - 2026-01-06 `h2` :265
+- [0.14.0] - 2026-01-04 `h2` :272
+- [0.13.1] - 2026-01-02 `h2` :278
+- [0.13.0] - 2025-12-30 `h2` :295
+- [0.12.2] - 2025-12-30 `h2` :307
+- [0.12.1] - 2025-12-30 `h2` :311
+- [0.12.0] - 2025-12-30 `h2` :344
+- [0.11.0] - 2025-12-30 `h2` :383
+- [0.10.1] - 2025-12-29 `h2` :415
+- [0.10.0] - 2025-12-28 `h2` :454
+- [0.9.1] - 2025-12-28 `h2` :507
+- [0.9.0] - 2025-12-28 `h2` :526
+- [0.8.0] - 2025-12-27 `h2` :575
+- [0.7.1] - 2025-12-27 `h2` :609
+- [0.7.0] - 2025-12-27 `h2` :636
+- [0.6.1] - 2025-12-27 `h2` :681
+- [0.6.0] - 2025-12-27 `h2` :705
+- [0.4.0] - 2025-12-27 `h2` :741
+- [0.3.1] - 2025-12-26 `h2` :760
+- [0.3.0] - 2025-12-26 `h2` :767
+- [0.1.0] - 2025-12-26 `h2` :776
+- Summary `h2` :787
 
 ### CLAUDE.md
 - Muninn Memory System - Claude Code Context `h1` :1
@@ -73,7 +74,8 @@
 - What's New in v3.6.0 `h2` :360
 - What's New in v3.5.0 `h2` :381
 - What's New in v3.2.0 `h2` :408
-- Known Limitations `h2` :425
+- What's New in v3.7.0 `h2` :425
+- Known Limitations `h2` :442
 
 ### README.md
 - remembering `h1` :1
@@ -93,17 +95,17 @@
 - Therapy Helpers `h2` :429
 - Analysis Helpers `h2` :464
 - FTS5 Search with Porter Stemmer (v0.13.0) `h2` :498
-- Soft Delete `h2` :522
-- Memory Quality Guidelines `h2` :534
-- Handoff Convention `h2` :544
-- Session Scoping (v3.2.0) `h2` :629
-- Retrieval Observability (v3.2.0) `h2` :650
-- Retention Management (v3.2.0) `h2` :667
-- Export/Import for Portability `h2` :692
-- Type-Safe Results (v3.4.0) `h2` :723
-- Proactive Memory Hints (v3.4.0) `h2` :765
-- Edge Cases `h2` :820
-- Implementation Notes `h2` :840
+- Soft Delete `h2` :527
+- Memory Quality Guidelines `h2` :539
+- Handoff Convention `h2` :549
+- Session Scoping (v3.2.0) `h2` :634
+- Retrieval Observability (v3.2.0) `h2` :655
+- Retention Management (v3.2.0) `h2` :672
+- Export/Import for Portability `h2` :697
+- Type-Safe Results (v3.4.0) `h2` :728
+- Proactive Memory Hints (v3.4.0) `h2` :786
+- Edge Cases `h2` :841
+- Implementation Notes `h2` :861
 
 ### __init__.py
 > Imports: `requests, json, uuid, threading, os`...
@@ -177,46 +179,48 @@
 - **recall** (f) `(search: str = None, *, n: int = 10, tags: list = None,
            type: str = None, conf: float = None, tag_mode: str = "any",
            use_cache: bool = True, strict: bool = False, session_id: str = None,
-           auto_strengthen: bool = False, raw: bool = False)` :219
+           auto_strengthen: bool = False, raw: bool = False,
+           expansion_threshold: int = 3,
+           limit: int = None)` :219
 - **recall_since** (f) `(after: str, *, search: str = None, n: int = 50,
                  type: str = None, tags: list = None, tag_mode: str = "any",
-                 session_id: str = None, raw: bool = False)` :489
+                 session_id: str = None, raw: bool = False)` :498
 - **recall_between** (f) `(after: str, before: str, *, search: str = None,
                    n: int = 100, type: str = None, tags: list = None,
-                   tag_mode: str = "any", session_id: str = None, raw: bool = False)` :556
-- **forget** (f) `(memory_id: str)` :625
+                   tag_mode: str = "any", session_id: str = None, raw: bool = False)` :565
+- **forget** (f) `(memory_id: str)` :634
 - **supersede** (f) `(original_id: str, summary: str, type: str, *,
-              tags: list = None, conf: float = None)` :643
-- **reprioritize** (f) `(memory_id: str, priority: int)` :711
-- **memory_histogram** (f) `()` :752
-- **prune_by_age** (f) `(older_than_days: int, priority_floor: int = 0, dry_run: bool = True)` :808
-- **prune_by_priority** (f) `(max_priority: int = -1, dry_run: bool = True)` :854
-- **strengthen** (f) `(memory_id: str, boost: int = 1)` :893
-- **weaken** (f) `(memory_id: str, drop: int = 1)` :933
+              tags: list = None, conf: float = None)` :652
+- **reprioritize** (f) `(memory_id: str, priority: int)` :720
+- **memory_histogram** (f) `()` :761
+- **prune_by_age** (f) `(older_than_days: int, priority_floor: int = 0, dry_run: bool = True)` :817
+- **prune_by_priority** (f) `(max_priority: int = -1, dry_run: bool = True)` :863
+- **strengthen** (f) `(memory_id: str, boost: int = 1)` :902
+- **weaken** (f) `(memory_id: str, drop: int = 1)` :942
 
 ### result.py
 > Imports: `typing`
-- **MemoryResult** (C) :71
-  - **__init__** (m) `(self, data: dict)` :90
-  - **__getattr__** (m) `(self, name: str)` :94
-  - **__setattr__** (m) `(self, name: str, value: Any)` :104
-  - **__getitem__** (m) `(self, key: str)` :111
-  - **__contains__** (m) `(self, key: str)` :118
-  - **__iter__** (m) `(self)` :122
-  - **__len__** (m) `(self)` :126
-  - **__repr__** (m) `(self)` :130
-  - **__str__** (m) `(self)` :137
-  - **_error_message** (m) `(self, field: str, error_type: str)` :141
-  - **get** (m) `(self, key: str, default: Any = None)` :155
-  - **keys** (m) `(self)` :169
-  - **values** (m) `(self)` :173
-  - **items** (m) `(self)` :177
-  - **to_dict** (m) `(self)` :181
-  - **copy** (m) `(self)` :190
-- **MemoryResultList** (C) :195
-  - **__repr__** (m) `(self)` :202
-  - **to_dicts** (m) `(self)` :207
-- **wrap_results** (f) `(results: List[dict])` :212
+- **MemoryResult** (C) :77
+  - **__init__** (m) `(self, data: dict)` :96
+  - **__getattr__** (m) `(self, name: str)` :100
+  - **__setattr__** (m) `(self, name: str, value: Any)` :118
+  - **__getitem__** (m) `(self, key: str)` :125
+  - **__contains__** (m) `(self, key: str)` :140
+  - **__iter__** (m) `(self)` :144
+  - **__len__** (m) `(self)` :148
+  - **__repr__** (m) `(self)` :152
+  - **__str__** (m) `(self)` :159
+  - **_error_message** (m) `(self, field: str, error_type: str)` :163
+  - **get** (m) `(self, key: str, default: Any = None)` :177
+  - **keys** (m) `(self)` :196
+  - **values** (m) `(self)` :200
+  - **items** (m) `(self)` :204
+  - **to_dict** (m) `(self)` :208
+  - **copy** (m) `(self)` :217
+- **MemoryResultList** (C) :222
+  - **__repr__** (m) `(self)` :229
+  - **to_dicts** (m) `(self)` :234
+- **wrap_results** (f) `(results: List[dict])` :255
 
 ### state.py
 > Imports: `threading, os, pathlib`

--- a/remembering/__init__.py
+++ b/remembering/__init__.py
@@ -40,11 +40,11 @@ from .memory import (
     memory_histogram, prune_by_age, prune_by_priority  # v3.2.0: retention helpers
 )
 
-# Import result types (v3.4.0: type-safe memory results)
+# Import result types (v3.4.0: type-safe memory results, v3.7.0: normalization)
 from .result import (
     MemoryResult, MemoryResultList,
     VALID_FIELDS, COMMON_MISTAKES,
-    wrap_results
+    wrap_results, _normalize_memory
 )
 
 # Import hints layer (v3.4.0: proactive memory surfacing)


### PR DESCRIPTION
## Summary

Fixes the three most impactful open issues for the remembering skill, bumping to v3.7.0:

- **#262 - Parameter & field name aliases**: `MemoryResult` now transparently resolves common field aliases (`content` → `summary`, `conf` → `confidence`, etc.) instead of raising errors. Also accepts `limit=` as a deprecated alias for `n=` in `recall()`. This eliminates ~30% of correction memories caused by standard API naming conventions conflicting with Muninn field names.
- **#238 - Configurable query expansion threshold**: Added `expansion_threshold` parameter to `recall()` (default 3). Set to `0` to disable expansion entirely. Removes a documented known limitation.
- **#264 - Standardized return dict format**: Added `_normalize_memory()` function applied in `wrap_results()` so `summary_preview` is always present regardless of whether results came from cache or Turso. Added `bm25_score`, `composite_rank`, `composite_score` to `VALID_FIELDS`.

Closes #262, closes #238, closes #264

## Test plan

- [x] Verified `MemoryResult` transparent alias resolution (`m.content` → `m.summary`) works for `__getattr__`, `__getitem__`, and `get()`
- [x] Verified truly invalid fields still raise `AttributeError`/`KeyError` with valid field list
- [x] Verified `recall()` signature includes `expansion_threshold` (default 3) and `limit` (default None)
- [x] Verified `wrap_results()` normalizes dicts to include `summary_preview`
- [x] Verified code maps regenerated

https://claude.ai/code/session_01LeBHDyhAkRXtqSKHDGiS8F