### PR TITLE
feat(remembering): fix top 5 open issues (v3.8.0)

### DIFF
--- a/remembering/CLAUDE.md
+++ b/remembering/CLAUDE.md
@@ -439,6 +439,31 @@ if github['available']:
 - `bm25_score`, `composite_rank`, `composite_score` added to VALID_FIELDS
 - Results from Turso and cache are normalized to the same field set
 
+## What's New in v3.8.0
+
+**Auto-Credential Detection** (#263): Turso credentials are now auto-detected from well-known env file paths:
+- Scans `/mnt/project/turso.env`, `/mnt/project/muninn.env`, `~/.muninn/.env`
+- No manual `set -a; . turso.env; set +a` needed
+- Built-in env file parser eliminates dependency on `configuring` skill
+
+**Session Cache Support** (#237): Session-filtered queries now use the local cache:
+- `recall(session_id="my-session")` uses cache (~5ms) instead of Turso (~200ms)
+- `session_id` stored in `memory_index` cache table
+- Automatic migration adds column on first boot
+
+**Ops Entry Hygiene** (#265): Default ops topic mapping updated:
+- Removed stale `muninn-env-loading` (superseded by #263 auto-detection)
+- Consolidated `recall-fields` and `recall-discipline` into Memory Operations topic
+
+**Unified GitHub API** (#240): New `github_api()` function:
+- `from remembering import github_api`
+- Automatically selects gh CLI or GITHUB_TOKEN/GH_TOKEN
+- Supports GET, POST, PUT, PATCH, DELETE methods
+
+**Repo Defaults Fallback** (#239): Boot now falls back to version-controlled defaults:
+- `defaults/profile.json` and `defaults/ops.json` provide minimal config
+- Used when both Turso and local cache are unavailable (fresh install + network outage)
+
 ## Known Limitations
 
-- Session filtering bypasses cache (queries Turso directly) - cache support planned for future release
+- None currently tracked

--- a/remembering/_MAP.md
+++ b/remembering/_MAP.md
@@ -1,60 +1,62 @@
 # remembering/
-*Files: 16 | Subdirectories: 1*
+*Files: 16 | Subdirectories: 2*
 
 ## Subdirectories
 
+- [defaults/](./defaults/_MAP.md)
 - [tests/](./tests/_MAP.md)
 
 ## Files
 
 ### CHANGELOG.md
 - Muninn Memory System - Changelog `h1` :1
-- [3.6.0] - 2026-01-31 `h2` :5
+- [3.7.0] - 2026-02-05 `h2` :5
 - [3.6.0] - 2026-01-31 `h2` :11
-- [3.5.0] - 2026-01-27 `h2` :26
-- [3.4.0] - 2026-01-25 `h2` :33
-- [3.4.0] - 2026-01-25 `h2` :44
-- [3.3.3] - 2026-01-22 `h2` :58
-- [3.3.2] - 2026-01-22 `h2` :64
-- [3.3.2] - 2026-01-22 `h2` :75
-- [3.3.1] - 2026-01-22 `h2` :89
-- [3.3.0] - 2026-01-21 `h2` :95
-- [3.2.1] - 2026-01-21 `h2` :105
-- [3.2.0] - 2026-01-16 `h2` :109
+- [3.6.0] - 2026-01-31 `h2` :17
+- [3.5.0] - 2026-01-27 `h2` :32
+- [3.4.0] - 2026-01-25 `h2` :39
+- [3.4.0] - 2026-01-25 `h2` :50
+- [3.3.3] - 2026-01-22 `h2` :64
+- [3.3.2] - 2026-01-22 `h2` :70
+- [3.3.2] - 2026-01-22 `h2` :81
+- [3.3.1] - 2026-01-22 `h2` :95
+- [3.3.0] - 2026-01-21 `h2` :101
+- [3.2.1] - 2026-01-21 `h2` :111
 - [3.2.0] - 2026-01-16 `h2` :115
-- [3.1.0] - 2026-01-16 `h2` :144
-- [3.0.0] - 2026-01-16 `h2` :150
-- [3.0.0] - 2026-01-16 `h2` :168
-- [2.2.1] - 2026-01-09 `h2` :190
-- [2.1.1] - 2026-01-09 `h2` :210
-- [2.1.0] - 2026-01-09 `h2` :220
-- [2.0.2] - 2026-01-09 `h2` :226
-- [2.0.1] - 2026-01-09 `h2` :232
-- [1.0.1] - 2026-01-09 `h2` :243
-- [2.0.0] - 2026-01-09 `h2` :253
-- [0.14.1] - 2026-01-06 `h2` :259
+- [3.2.0] - 2026-01-16 `h2` :121
+- [3.1.0] - 2026-01-16 `h2` :150
+- [3.0.0] - 2026-01-16 `h2` :156
+- [3.0.0] - 2026-01-16 `h2` :174
+- [2.2.1] - 2026-01-09 `h2` :196
+- [2.1.1] - 2026-01-09 `h2` :216
+- [2.1.0] - 2026-01-09 `h2` :226
+- [2.0.2] - 2026-01-09 `h2` :232
+- [2.0.1] - 2026-01-09 `h2` :238
+- [1.0.1] - 2026-01-09 `h2` :249
+- [2.0.0] - 2026-01-09 `h2` :259
 - [0.14.1] - 2026-01-06 `h2` :265
-- [0.14.0] - 2026-01-04 `h2` :272
-- [0.13.1] - 2026-01-02 `h2` :278
-- [0.13.0] - 2025-12-30 `h2` :295
-- [0.12.2] - 2025-12-30 `h2` :307
-- [0.12.1] - 2025-12-30 `h2` :311
-- [0.12.0] - 2025-12-30 `h2` :344
-- [0.11.0] - 2025-12-30 `h2` :383
-- [0.10.1] - 2025-12-29 `h2` :415
-- [0.10.0] - 2025-12-28 `h2` :454
-- [0.9.1] - 2025-12-28 `h2` :507
-- [0.9.0] - 2025-12-28 `h2` :526
-- [0.8.0] - 2025-12-27 `h2` :575
-- [0.7.1] - 2025-12-27 `h2` :609
-- [0.7.0] - 2025-12-27 `h2` :636
-- [0.6.1] - 2025-12-27 `h2` :681
-- [0.6.0] - 2025-12-27 `h2` :705
-- [0.4.0] - 2025-12-27 `h2` :741
-- [0.3.1] - 2025-12-26 `h2` :760
-- [0.3.0] - 2025-12-26 `h2` :767
-- [0.1.0] - 2025-12-26 `h2` :776
-- Summary `h2` :787
+- [0.14.1] - 2026-01-06 `h2` :271
+- [0.14.0] - 2026-01-04 `h2` :278
+- [0.13.1] - 2026-01-02 `h2` :284
+- [0.13.0] - 2025-12-30 `h2` :301
+- [0.12.2] - 2025-12-30 `h2` :313
+- [0.12.1] - 2025-12-30 `h2` :317
+- [0.12.0] - 2025-12-30 `h2` :350
+- [0.11.0] - 2025-12-30 `h2` :389
+- [0.10.1] - 2025-12-29 `h2` :421
+- [0.10.0] - 2025-12-28 `h2` :460
+- [0.9.1] - 2025-12-28 `h2` :513
+- [0.9.0] - 2025-12-28 `h2` :532
+- [0.8.0] - 2025-12-27 `h2` :581
+- [0.7.1] - 2025-12-27 `h2` :615
+- [0.7.0] - 2025-12-27 `h2` :642
+- [0.6.1] - 2025-12-27 `h2` :687
+- [0.6.0] - 2025-12-27 `h2` :711
+- [0.4.0] - 2025-12-27 `h2` :747
+- [0.3.1] - 2025-12-26 `h2` :766
+- [0.3.0] - 2025-12-26 `h2` :773
+- [0.1.0] - 2025-12-26 `h2` :782
+- Summary `h2` :793
 
 ### CLAUDE.md
 - Muninn Memory System - Claude Code Context `h1` :1
@@ -75,7 +77,8 @@
 - What's New in v3.5.0 `h2` :381
 - What's New in v3.2.0 `h2` :408
 - What's New in v3.7.0 `h2` :425
-- Known Limitations `h2` :442
+- What's New in v3.8.0 `h2` :442
+- Known Limitations `h2` :467
 
 ### README.md
 - remembering `h1` :1
@@ -105,7 +108,8 @@
 - Type-Safe Results (v3.4.0) `h2` :728
 - Proactive Memory Hints (v3.4.0) `h2` :786
 - Edge Cases `h2` :841
-- Implementation Notes `h2` :861
+- Unified GitHub API (v3.8.0) `h2` :861
+- Implementation Notes `h2` :876
 
 ### __init__.py
 > Imports: `requests, json, uuid, threading, os`...
@@ -113,24 +117,26 @@
 
 ### boot.py
 > Imports: `json, os, shutil, subprocess, threading`...
-- **classify_ops_key** (f) `(key: str)` :128
-- **detect_github_access** (f) `()` :148
-- **group_ops_by_topic** (f) `(ops_entries: list)` :225
-- **profile** (f) `()` :276
-- **ops** (f) `(include_reference: bool = False)` :281
-- **boot** (f) `()` :334
-- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :520
-- **journal_recent** (f) `(n: int = 10)` :537
-- **journal_prune** (f) `(keep: int = 40)` :553
-- **therapy_scope** (f) `()` :567
-- **therapy_session_count** (f) `()` :582
-- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :591
-- **group_by_type** (f) `(memories: list)` :606
-- **group_by_tag** (f) `(memories: list)` :622
-- **muninn_export** (f) `()` :642
-- **handoff_pending** (f) `()` :656
-- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :671
-- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :703
+- **classify_ops_key** (f) `(key: str)` :132
+- **detect_github_access** (f) `()` :152
+- **github_api** (f) `(endpoint: str, *, method: str = "GET", body: dict = None,
+               accept: str = "application/vnd.github+json")` :229
+- **group_ops_by_topic** (f) `(ops_entries: list)` :312
+- **profile** (f) `()` :363
+- **ops** (f) `(include_reference: bool = False)` :368
+- **boot** (f) `()` :468
+- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :662
+- **journal_recent** (f) `(n: int = 10)` :679
+- **journal_prune** (f) `(keep: int = 40)` :695
+- **therapy_scope** (f) `()` :709
+- **therapy_session_count** (f) `()` :724
+- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :733
+- **group_by_type** (f) `(memories: list)` :748
+- **group_by_tag** (f) `(memories: list)` :764
+- **muninn_export** (f) `()` :784
+- **handoff_pending** (f) `()` :798
+- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :813
+- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :845
 
 ### bootstrap.py
 > Imports: `sys, os`
@@ -141,9 +147,9 @@
 
 ### cache.py
 > Imports: `sqlite3, json, uuid, datetime, .`...
-- **cache_stats** (f) `()` :566
-- **recall_stats** (f) `(limit: int = 100)` :599
-- **top_queries** (f) `(n: int = 10)` :654
+- **cache_stats** (f) `()` :591
+- **recall_stats** (f) `(limit: int = 100)` :624
+- **top_queries** (f) `(n: int = 10)` :679
 
 ### claude-ai-project-instructions.md
 - Muninn `h1` :1
@@ -184,19 +190,19 @@
            limit: int = None)` :219
 - **recall_since** (f) `(after: str, *, search: str = None, n: int = 50,
                  type: str = None, tags: list = None, tag_mode: str = "any",
-                 session_id: str = None, raw: bool = False)` :498
+                 session_id: str = None, raw: bool = False)` :499
 - **recall_between** (f) `(after: str, before: str, *, search: str = None,
                    n: int = 100, type: str = None, tags: list = None,
-                   tag_mode: str = "any", session_id: str = None, raw: bool = False)` :565
-- **forget** (f) `(memory_id: str)` :634
+                   tag_mode: str = "any", session_id: str = None, raw: bool = False)` :566
+- **forget** (f) `(memory_id: str)` :635
 - **supersede** (f) `(original_id: str, summary: str, type: str, *,
-              tags: list = None, conf: float = None)` :652
-- **reprioritize** (f) `(memory_id: str, priority: int)` :720
-- **memory_histogram** (f) `()` :761
-- **prune_by_age** (f) `(older_than_days: int, priority_floor: int = 0, dry_run: bool = True)` :817
-- **prune_by_priority** (f) `(max_priority: int = -1, dry_run: bool = True)` :863
-- **strengthen** (f) `(memory_id: str, boost: int = 1)` :902
-- **weaken** (f) `(memory_id: str, drop: int = 1)` :942
+              tags: list = None, conf: float = None)` :653
+- **reprioritize** (f) `(memory_id: str, priority: int)` :721
+- **memory_histogram** (f) `()` :762
+- **prune_by_age** (f) `(older_than_days: int, priority_floor: int = 0, dry_run: bool = True)` :818
+- **prune_by_priority** (f) `(max_priority: int = -1, dry_run: bool = True)` :864
+- **strengthen** (f) `(memory_id: str, boost: int = 1)` :903
+- **weaken** (f) `(memory_id: str, drop: int = 1)` :943
 
 ### result.py
 > Imports: `typing`

--- a/remembering/__init__.py
+++ b/remembering/__init__.py
@@ -61,6 +61,7 @@ from .config import (
 from .boot import (
     profile, ops, _warm_cache, boot,
     detect_github_access,  # v3.5.0: GitHub access detection
+    github_api,  # v3.8.0: Unified GitHub API interface (#240)
     journal, journal_recent, journal_prune,
     therapy_scope, therapy_session_count, decisions_recent,
     group_by_type, group_by_tag,
@@ -82,6 +83,7 @@ __all__ = [
     "config_get", "config_set", "config_delete", "config_list", "config_set_boot_load", "config_set_priority",  # config
     "profile", "ops", "boot", "journal", "journal_recent", "journal_prune",  # boot & journal
     "detect_github_access",  # v3.5.0: GitHub access detection
+    "github_api",  # v3.8.0: Unified GitHub API interface (#240)
     "therapy_scope", "therapy_session_count", "decisions_recent",  # therapy helpers
     "group_by_type", "group_by_tag",  # analysis helpers
     "handoff_pending", "handoff_complete",  # handoff workflow

--- a/remembering/defaults/_MAP.md
+++ b/remembering/defaults/_MAP.md
@@ -1,0 +1,8 @@
+# defaults/
+*Files: 2*
+
+## Other Files
+
+- ops.json
+- profile.json
+

--- a/remembering/defaults/ops.json
+++ b/remembering/defaults/ops.json
@@ -1,0 +1,12 @@
+{
+  "remembering-api": {
+    "value": "Memory operations: remember(what, type, tags=[], conf=None) -> id; recall(search, n=10, tags=[], type=None) -> list; forget(id); supersede(old_id, summary, type) -> new_id. Types: decision, world, anomaly, experience. Config: config_get(key), config_set(key, value, category).",
+    "category": "ops",
+    "boot_load": 1
+  },
+  "storage-rules": {
+    "value": "Write complete, searchable summaries that standalone without conversation context. Bad: 'User wants code'. Good: 'User prefers direct answers with code examples over lengthy explanations'. Always include type parameter.",
+    "category": "ops",
+    "boot_load": 1
+  }
+}

--- a/remembering/defaults/profile.json
+++ b/remembering/defaults/profile.json
@@ -1,0 +1,6 @@
+{
+  "identity": {
+    "value": "I am Muninn, a persistent memory system for Claude. I store decisions, observations, anomalies, and experiences across conversations.",
+    "category": "profile"
+  }
+}

--- a/remembering/memory.py
+++ b/remembering/memory.py
@@ -119,7 +119,7 @@ def remember(what: str, type: str, *, tags: list = None, conf: float = None,
     # Write to local cache immediately (if available) - v0.7.0
     if _cache_available():
         _cache_memory(mem_id, what, type, now, conf, tags, priority,
-                     refs=refs, valid_from=valid_from)
+                     refs=refs, valid_from=valid_from, session_id=session_id)
 
     if sync:
         # Blocking write to Turso
@@ -266,8 +266,9 @@ def recall(search: str = None, *, n: int = 10, tags: list = None,
 
     # Try cache first (progressive disclosure)
     # v2.0.1: Only trust empty cache results if warming completed, otherwise fall back to Turso
+    # v3.8.0: Session-filtered queries now use cache (#237) instead of bypassing it
     if use_cache and _cache_available():
-        results = _cache_query_index(search=search, type=type, tags=tags, n=n, conf=conf, tag_mode=tag_mode, strict=strict)
+        results = _cache_query_index(search=search, type=type, tags=tags, n=n, conf=conf, tag_mode=tag_mode, strict=strict, session_id=session_id)
 
         # v2.0.1: If cache returns no results and warming isn't complete, fall back to Turso
         # This fixes race condition where recall() called immediately after boot() returns 0 results


### PR DESCRIPTION
## Summary

Addresses the top 5 open issues for the remembering skill, bumping version to 3.8.0:

- **#263 Auto-detect credentials**: Built-in env file parser scans `/mnt/project/turso.env`, `/mnt/project/muninn.env`, `~/.muninn/.env` for `TURSO_TOKEN`/`TURSO_URL`. Eliminates need for manual `set -a; . turso.env; set +a` or dependency on `configuring` skill.

- **#237 Session cache support**: Session-filtered `recall()` queries now use the local SQLite cache (~5ms) instead of bypassing to Turso (~200ms). `session_id` column added to `memory_index` with automatic migration on first boot.

- **#265 Ops entry hygiene**: Removed stale `muninn-env-loading` from default topic mapping (superseded by #263). Consolidated `recall-fields` and `recall-discipline` into Memory Operations topic.

- **#240 Unified GitHub API**: New `github_api()` function auto-selects gh CLI (when authenticated) or `GITHUB_TOKEN`/`GH_TOKEN` for GitHub REST API calls.

- **#239 Repo defaults fallback**: New `defaults/profile.json` and `defaults/ops.json` provide minimal boot context when both Turso and local cache are unavailable.

## Test plan

- [x] All modules import successfully
- [x] Env file parser handles comments, quoted values, blank lines, missing files
- [x] `_load_repo_defaults()` returns correct profile/ops entries from JSON files
- [ ] Session-filtered recall uses cache after boot warming completes
- [ ] Auto-credential loading works in Claude.ai with turso.env present
- [ ] github_api falls back from gh CLI to HTTP when CLI unavailable

https://claude.ai/code/session_01VCAiFLY7dwNAsm7JdA6Vmb