### PR TITLE
feat: add trending API and fix NODE_PATH resolution (#271, #272)

### DIFF
--- a/browsing-bluesky/CHANGELOG.md
+++ b/browsing-bluesky/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `browsing-bluesky` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0] - 2026-02-08
+
+### Added
+
+- Add `get_trending()` for rich trend data with post counts, status, category, and actors (#272)
+- Add `get_trending_topics()` for lightweight trending topic scan (#272)
+- Restructure zeitgeist workflow: trending API first, firehose as deep-dive tool (#272)
+
+### Fixed
+
+- Fix NODE_PATH resolution in zeitgeist-sample.js so modules resolve regardless of working directory (#271)
+
 ## [0.4.1] - 2026-02-06
 
 ### Added

--- a/browsing-bluesky/README.md
+++ b/browsing-bluesky/README.md
@@ -163,4 +163,4 @@ This skill consolidates and replaces:
 
 ## Version
 
-0.1.0
+0.5.0

--- a/browsing-bluesky/_MAP.md
+++ b/browsing-bluesky/_MAP.md
@@ -9,11 +9,13 @@
 
 ### CHANGELOG.md
 - browsing-bluesky - Changelog `h1` :1
-- [0.4.0] - 2026-01-25 `h2` :5
-- [0.4.0] - 2026-01-25 `h2` :15
-- [0.3.0] - 2026-01-25 `h2` :28
-- [0.2.0] - 2026-01-01 `h2` :41
-- [0.1.0] - 2026-01-01 `h2` :51
+- [0.5.0] - 2026-02-08 `h2` :5
+- [0.4.1] - 2026-02-06 `h2` :17
+- [0.4.0] - 2026-01-25 `h2` :27
+- [0.4.0] - 2026-01-25 `h2` :37
+- [0.3.0] - 2026-01-25 `h2` :50
+- [0.2.0] - 2026-01-01 `h2` :63
+- [0.1.0] - 2026-01-01 `h2` :73
 
 ### README.md
 - browsing-bluesky `h1` :1
@@ -30,11 +32,11 @@
 ### SKILL.md
 - Browsing Bluesky `h1` :8
 - Implementation `h2` :12
-- Authentication (Optional) `h2` :32
-- Research Workflows `h2` :64
-- API Endpoint Notes `h2` :161
-- Return Format `h2` :169
-- Account Analysis `h2` :184
+- Authentication (Optional) `h2` :34
+- Research Workflows `h2` :66
+- API Endpoint Notes `h2` :188
+- Return Format `h2` :197
+- Account Analysis `h2` :212
 
 ### __init__.py
 > Imports: `.scripts.bsky`

--- a/browsing-bluesky/__init__.py
+++ b/browsing-bluesky/__init__.py
@@ -14,6 +14,9 @@ from .scripts.bsky import (
     get_followers,
     get_following,
     search_users,
+    # Trending
+    get_trending,
+    get_trending_topics,
     # Account analysis (from categorizing-bsky-accounts)
     get_all_following,
     get_all_followers,
@@ -41,6 +44,9 @@ __all__ = [
     "get_followers",
     "get_following",
     "search_users",
+    # Trending
+    "get_trending",
+    "get_trending_topics",
     # Account analysis
     "get_all_following",
     "get_all_followers",

--- a/browsing-bluesky/scripts/_MAP.md
+++ b/browsing-bluesky/scripts/_MAP.md
@@ -23,27 +23,29 @@
     limit: int = 25
 )` :216
 - **get_feed_posts** (f) `(feed_uri: str, limit: int = 20)` :259
-- **sample_firehose** (f) `(duration: int = 10, filter: Optional[str] = None)` :301
-- **get_thread** (f) `(post_uri_or_url: str, depth: int = 6, parent_height: int = 80)` :333
-- **get_quotes** (f) `(post_uri_or_url: str, limit: int = 25)` :354
-- **get_likes** (f) `(post_uri_or_url: str, limit: int = 50)` :373
-- **get_reposts** (f) `(post_uri_or_url: str, limit: int = 50)` :392
-- **get_followers** (f) `(handle: str, limit: int = 50)` :411
-- **get_following** (f) `(handle: str, limit: int = 50)` :430
-- **search_users** (f) `(query: str, limit: int = 25)` :449
-- **get_all_following** (f) `(handle: str, limit: int = 100)` :516
-- **get_all_followers** (f) `(handle: str, limit: int = 100)` :537
-- **extract_post_text** (f) `(posts: List[Dict[str, Any]])` :558
+- **get_trending** (f) `(limit: int = 10)` :301
+- **get_trending_topics** (f) `(limit: int = 10)` :337
+- **sample_firehose** (f) `(duration: int = 10, filter: Optional[str] = None)` :374
+- **get_thread** (f) `(post_uri_or_url: str, depth: int = 6, parent_height: int = 80)` :406
+- **get_quotes** (f) `(post_uri_or_url: str, limit: int = 25)` :427
+- **get_likes** (f) `(post_uri_or_url: str, limit: int = 50)` :446
+- **get_reposts** (f) `(post_uri_or_url: str, limit: int = 50)` :465
+- **get_followers** (f) `(handle: str, limit: int = 50)` :484
+- **get_following** (f) `(handle: str, limit: int = 50)` :503
+- **search_users** (f) `(query: str, limit: int = 25)` :522
+- **get_all_following** (f) `(handle: str, limit: int = 100)` :589
+- **get_all_followers** (f) `(handle: str, limit: int = 100)` :610
+- **extract_post_text** (f) `(posts: List[Dict[str, Any]])` :631
 - **extract_keywords** (f) `(
     text: str,
     top_n: int = 10,
     stopwords: str = "en"
-)` :570
+)` :643
 - **analyze_account** (f) `(
     handle: str,
     posts_limit: int = 20,
     stopwords: str = "en"
-)` :662
+)` :735
 - **analyze_accounts** (f) `(
     handles: Optional[List[str]] = None,
     following: Optional[str] = None,
@@ -52,7 +54,7 @@
     posts_per_account: int = 20,
     stopwords: str = "en",
     exclude_patterns: Optional[List[str]] = None
-)` :700
+)` :773
 
 ### zeitgeist-sample.js
 - *No top-level symbols*

--- a/browsing-bluesky/scripts/__init__.py
+++ b/browsing-bluesky/scripts/__init__.py
@@ -1,11 +1,29 @@
-"""Bluesky browsing module - API and firehose access."""
+"""Bluesky browsing module - API, trending, and firehose access."""
 
 from .bsky import (
     search_posts,
     get_user_posts,
     get_profile,
     get_feed_posts,
-    sample_firehose
+    sample_firehose,
+    get_thread,
+    get_quotes,
+    get_likes,
+    get_reposts,
+    get_followers,
+    get_following,
+    search_users,
+    get_trending,
+    get_trending_topics,
+    get_all_following,
+    get_all_followers,
+    extract_post_text,
+    extract_keywords,
+    analyze_account,
+    analyze_accounts,
+    is_authenticated,
+    get_authenticated_user,
+    clear_session
 )
 
 __all__ = [
@@ -13,5 +31,23 @@ __all__ = [
     "get_user_posts",
     "get_profile",
     "get_feed_posts",
-    "sample_firehose"
+    "sample_firehose",
+    "get_thread",
+    "get_quotes",
+    "get_likes",
+    "get_reposts",
+    "get_followers",
+    "get_following",
+    "search_users",
+    "get_trending",
+    "get_trending_topics",
+    "get_all_following",
+    "get_all_followers",
+    "extract_post_text",
+    "extract_keywords",
+    "analyze_account",
+    "analyze_accounts",
+    "is_authenticated",
+    "get_authenticated_user",
+    "clear_session"
 ]

--- a/browsing-bluesky/scripts/zeitgeist-sample.js
+++ b/browsing-bluesky/scripts/zeitgeist-sample.js
@@ -4,6 +4,12 @@
  * Samples firehose for N seconds, outputs structured JSON for analysis
  */
 
+// Ensure node_modules installed in home directory are resolvable regardless
+// of the working directory this script is invoked from (fixes #271)
+const path = require('path');
+const homeDir = process.env.HOME || '/home/claude';
+module.paths.unshift(path.join(homeDir, 'node_modules'));
+
 const WebSocket = require('ws');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 

--- a/sampling-bluesky-zeitgeist/scripts/zeitgeist-sample.js
+++ b/sampling-bluesky-zeitgeist/scripts/zeitgeist-sample.js
@@ -4,6 +4,12 @@
  * Samples firehose for N seconds, outputs structured JSON for analysis
  */
 
+// Ensure node_modules installed in home directory are resolvable regardless
+// of the working directory this script is invoked from (fixes #271)
+const path = require('path');
+const homeDir = process.env.HOME || '/home/claude';
+module.paths.unshift(path.join(homeDir, 'node_modules'));
+
 const WebSocket = require('ws');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 


### PR DESCRIPTION
## Summary

- **Fix #271**: `zeitgeist-sample.js` now prepends `$HOME/node_modules` to `module.paths` before `require()` calls, making the script self-contained regardless of invocation directory. Applied to both `browsing-bluesky` and deprecated `sampling-bluesky-zeitgeist` copies.
- **Fix #272**: Add `get_trending()` and `get_trending_topics()` functions that use Bluesky's native trending endpoints (`app.bsky.unspecced.getTrends` and `app.bsky.unspecced.getTrendingTopics`). Restructure SKILL.md to recommend trending API first (~500 tokens) with firehose sampling as an optional deep-dive tool.

## Changes

| File | Change |
|------|--------|
| `browsing-bluesky/scripts/bsky.py` | Add `get_trending()` and `get_trending_topics()` functions |
| `browsing-bluesky/scripts/zeitgeist-sample.js` | Prepend home dir `node_modules` to `module.paths` |
| `sampling-bluesky-zeitgeist/scripts/zeitgeist-sample.js` | Same NODE_PATH fix |
| `browsing-bluesky/SKILL.md` | Restructure trending workflow, bump to 0.5.0 |
| `browsing-bluesky/__init__.py` | Export new trending functions |
| `browsing-bluesky/scripts/__init__.py` | Sync exports with parent `__init__.py` |
| `browsing-bluesky/CHANGELOG.md` | Add 0.5.0 entry |
| `browsing-bluesky/README.md` | Update version from 0.1.0 to 0.5.0 |

## Test plan

- [ ] Verify `node browsing-bluesky/scripts/zeitgeist-sample.js --help` works from any directory (not just where `node_modules` lives)
- [ ] Verify `get_trending_topics()` returns topic list from public API
- [ ] Verify `get_trending()` returns trend data with post counts
- [ ] Verify existing `sample_firehose()` still works unchanged

Closes #271
Closes #272

https://claude.ai/code/session_017MLVGuD1xQCERJv4eab95u