### PR TITLE
Add down-skilling skill

### DIFF
--- a/.claude/skills/down-skilling
+++ b/.claude/skills/down-skilling
@@ -1,0 +1,1 @@
+../../down-skilling

--- a/down-skilling/SKILL.md
+++ b/down-skilling/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: down-skilling
+description: >-
+  Distill Opus-level reasoning into optimized instructions for Haiku 4.5
+  (and Sonnet). Generates explicit, procedural prompts with n-shot examples
+  that maximize smaller model performance on a given task. Use when user says
+  "down-skill", "distill for Haiku", "optimize for Haiku", "make this work
+  on Haiku", "generate Haiku instructions", or needs to delegate a task to
+  a smaller model with high reliability.
+metadata:
+  author: oskar-austegard
+  version: "1.0"
+---
+
+# Down-Skilling: Opus → Haiku Distillation
+
+Translate your reasoning capabilities into explicit, structured instructions
+that Haiku 4.5 can execute reliably. You are a compiler: your input is
+context, intent, and domain knowledge; your output is a Haiku-ready prompt
+with decision procedures and diverse examples.
+
+## Core Principle
+
+Opus infers from WHY. Haiku executes from WHAT and HOW.
+
+Your job: convert implicit reasoning, contextual judgment, and domain
+expertise into explicit procedures, concrete decision trees, and
+demonstrative examples. Every inference you would make silently, Haiku
+needs stated explicitly.
+
+## Activation
+
+When triggered, perform these steps:
+
+1. **Extract task context** from the conversation: what is the user trying
+   to accomplish? What domain knowledge applies? What quality criteria
+   matter?
+
+2. **Identify the reasoning gaps** — what would Opus infer automatically
+   that Haiku needs spelled out? Common gaps:
+   - Ambiguity resolution (Opus picks the sensible interpretation; Haiku
+     needs a decision rule)
+   - Quality judgment (Opus knows "good enough"; Haiku needs explicit
+     criteria)
+   - Edge case handling (Opus reasons through novel situations; Haiku
+     needs enumerated cases)
+   - Output calibration (Opus matches tone/length intuitively; Haiku
+     needs explicit constraints)
+
+3. **Generate the distilled prompt** following the structure in
+   [Prompt Architecture](#prompt-architecture)
+
+4. **Generate 3-5 diverse examples** following the principles in
+   [Example Design](#example-design)
+
+5. **Deliver** the complete Haiku-ready prompt as a copyable artifact or
+   file, including system prompt and user prompt components as appropriate
+
+## Prompt Architecture
+
+Structure every distilled prompt with these components in this order.
+Haiku responds best to this specific sequencing:
+
+```
+<role>
+[Single sentence: who Haiku is and what it does]
+</role>
+
+<task>
+[2-3 sentences: the specific task, its purpose, and the deliverable]
+</task>
+
+<rules>
+[Numbered list of explicit constraints. Be precise about:]
+- Output format (JSON schema, markdown structure, etc.)
+- Length bounds (word/token counts, not vague "brief"/"detailed")
+- Required elements (must-include fields or sections)
+- Prohibited behaviors (specific failure modes to avoid)
+- Decision rules for ambiguous cases
+</rules>
+
+<process>
+[Numbered steps. Maximum 7 steps. Each step is one action.]
+[Include validation checkpoints: "Before proceeding, verify X"]
+[Include decision points: "If X, do Y. If Z, do W."]
+</process>
+
+<examples>
+[3-5 diverse examples showing input → output pairs]
+[See Example Design section]
+</examples>
+
+<context>
+[Task-specific data, reference material, or domain knowledge]
+[Use labels: [Context], [Policy], [Reference]]
+</context>
+```
+
+## Haiku Optimization Rules
+
+Apply these when generating any Haiku-targeted prompt:
+
+### Structure & Syntax
+- Use XML tags to delimit every section — Haiku respects labeled boundaries
+- Keep sentences under 25 words where possible
+- One instruction per sentence; split compound instructions
+- Use numbered steps, not prose paragraphs, for procedures
+- Specify token/word budgets explicitly: "respond in 80-120 words"
+
+### Reasoning Support
+- Replace open-ended judgment with decision rubrics:
+  BAD: "Assess whether the code is production-ready"
+  GOOD: "Check: (a) no TODO comments, (b) all functions have error
+  handling, (c) no hardcoded secrets. Score pass/fail per item."
+- Bound reasoning depth: "Think in 3-5 steps, then give your answer"
+- Provide a fallback for uncertainty: "If you cannot determine X,
+  respond with: 'UNCERTAIN: [brief reason]'"
+
+### Context Management
+- Front-load critical instructions (Haiku attends strongly to position)
+- Keep total prompt under 2,000 tokens when possible (excluding examples)
+- Pass only the 1-3 most relevant context snippets, not full documents
+- Use explicit delimiters between context and instructions
+
+### Output Control
+- Require structured output (JSON, labeled sections) for extractable results
+- Provide an output template Haiku can fill in
+- Specify what comes first in the response: "Begin your response with..."
+- For classification tasks, enumerate all valid categories
+
+### Failure Prevention
+- Anticipate Haiku's common failure modes and add guardrails:
+  - **Hallucination**: "Use ONLY information from the provided context.
+    If the answer is not in the context, say 'Not found in sources.'"
+  - **Verbosity**: "Maximum 150 words. Do not add preamble or caveats."
+  - **Format drift**: Include the output schema in both rules and examples
+  - **Instruction skipping**: Number all constraints; reference them in
+    the process steps: "Apply rules 2-4 from <rules>"
+
+## Example Design
+
+Examples are the highest-leverage element for Haiku performance. Follow
+these principles:
+
+### Diversity Requirements
+Each example set must cover:
+- **Typical case**: The most common input pattern
+- **Edge case**: Unusual but valid input (empty fields, very long text,
+  special characters, boundary conditions)
+- **Negative case**: Input that should be rejected or handled differently
+  (if applicable to the task)
+
+### Example Format
+```xml
+<example>
+<input>
+[Realistic input data]
+</input>
+<output>
+[Exact format Haiku should produce — not a description, the actual output]
+</output>
+<reasoning>
+[Optional: 1-2 sentences explaining WHY this output is correct.
+ Helps Haiku generalize the pattern.]
+</reasoning>
+</example>
+```
+
+### Example Quality Criteria
+- Examples must be realistic, not toy data
+- Output format must be identical across all examples
+- Include the hardest case you expect Haiku to handle
+- Vary input characteristics: length, complexity, domain
+- Never include an example that contradicts your rules
+
+## Delivery Format
+
+Present the distilled prompt in a code block or artifact with clear
+section markers. Include:
+
+1. **System prompt** (if applicable): role + persistent rules
+2. **User prompt template**: with {{placeholders}} for variable content
+3. **Examples**: embedded in the prompt or as a separate few-shot section
+4. **Usage notes**: any caveats about when this prompt may fail and what
+   to watch for
+
+When generating for API use, include the model parameter and recommended
+settings:
+```
+model: claude-haiku-4-5-20251001
+max_tokens: [appropriate for task]
+temperature: 0 (for deterministic tasks) or 0.3 (for creative tasks)
+```
+
+## Agentic Resource Selection
+
+The skill includes two directories of granular reference files. Do NOT
+read them all. Scan the index below, then read only the files relevant
+to the current task.
+
+### gaps/
+
+Each file documents one reasoning pattern where Haiku diverges from Opus,
+with a tested mitigation strategy. Read 2-4 per task.
+
+| File | Use when the task involves... |
+|------|------|
+| `ambiguity-resolution.md` | Input that has multiple valid interpretations; vague user requests |
+| `code-generation.md` | Generating code, scripts, or queries; style matching to existing code |
+| `comparative-analysis.md` | Comparing options, pros/cons, tradeoff analysis |
+| `conditional-logic.md` | Decision trees, branching rules, nested if/then logic |
+| `context-utilization.md` | Long context windows, documents >2K tokens, position-sensitive info |
+| `counting-enumeration.md` | "Generate exactly N items", counting occurrences, list lengths |
+| `creative-generation.md` | Writing, tone adaptation, persona consistency, style matching |
+| `implicit-constraints.md` | Tasks where tone, audience, or format norms are assumed not stated |
+| `instruction-density.md` | Tasks requiring 8+ simultaneous constraints; complex rule sets |
+| `multi-hop-reasoning.md` | 3+ step inference chains; cause-effect-consequence analysis |
+| `multi-turn-consistency.md` | Chatbot behavior, stateful conversations, persona maintenance |
+| `negation-handling.md` | Constraints phrased as "don't", "never", "avoid"; prohibitions |
+| `nuanced-classification.md` | Borderline cases, multi-label classification, overlapping categories |
+| `output-calibration.md` | Length control, format precision, verbosity management (ALWAYS read) |
+| `parallel-consistency.md` | Generating multiple similar items; lists where format must be uniform |
+| `partial-information.md` | Missing fields, incomplete input, optional data, error states |
+| `schema-adherence.md` | Structured output (JSON, tables) that must survive edge-case inputs |
+| `self-correction.md` | Tasks needing verification; quality checks before output |
+| `summarization-fidelity.md` | Summarizing documents without distortion, position bias, or fabrication |
+| `tool-use-planning.md` | Multi-tool workflows, API orchestration, dependency ordering |
+
+### examples/
+
+Complete before/after distillations. Each shows an Opus-level task →
+Haiku-optimized prompt with annotated examples. Read 1-2 closest to
+the current task domain.
+
+| File | Use when distilling... |
+|------|------|
+| `api-orchestration.md` | Multi-step tool/API workflows with dependencies and branching |
+| `code-review-triage.md` | Analysis tasks with severity classification and structured JSON output |
+| `content-moderation.md` | Safety-critical classification with "when uncertain" defaults |
+| `creative-rewriting.md` | Tone adaptation, audience-aware rewriting, style transfer |
+| `data-extraction.md` | Schema-bound extraction from unstructured text to JSON |
+| `document-qa.md` | RAG / retrieval-grounded QA with citation and "not found" handling |
+| `email-summarization.md` | Information extraction from conversations/threads into sections |
+| `meeting-notes.md` | Transcript processing into decisions, actions, and next steps |
+| `resume-screening.md` | Multi-criteria evaluation with parallel scoring structure |
+| `sql-generation.md` | Natural language to code with schema constraints and error handling |
+| `step-by-step-analysis.md` | Multi-step analytical reasoning with explicit decision rubrics |
+| `text-classification.md` | Multi-label classification with confidence and ambiguity handling |
+
+## Self-Check
+
+Before delivering, verify the distilled prompt against these criteria:
+- [ ] Every Opus inference is made explicit
+- [ ] All constraints are numbered and cross-referenced
+- [ ] 3+ diverse examples with consistent output format
+- [ ] Total prompt fits within 4,000 tokens (excluding dynamic context)
+- [ ] No instruction assumes Haiku will "figure it out"
+- [ ] Decision points have explicit branches, not open-ended judgment
+- [ ] Output format is demonstrated, not just described

--- a/down-skilling/examples/api-orchestration.md
+++ b/down-skilling/examples/api-orchestration.md
@@ -1,0 +1,92 @@
+# API / Tool Orchestration
+
+**Task type**: Multi-step tool use with dependencies
+**Key gaps addressed**: tool-use-planning, conditional-logic, multi-hop-reasoning
+
+## Original (Opus-level)
+
+"Look up the customer, check their subscription status, and if they're
+on a paid plan, generate a usage report."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are an API orchestration assistant that executes multi-step workflows.
+</role>
+
+<task>
+Execute the workflow below. Call tools in the specified order. Handle
+errors at each step before proceeding.
+</task>
+
+<rules>
+1. Execute steps in numbered order. Do not skip or reorder steps.
+2. After each tool call, check the result before proceeding:
+   - If success → continue to next step
+   - If error → stop and output: "WORKFLOW HALTED at Step [N]: [error]"
+3. Do not call a tool unless all its required inputs are available from
+   previous steps.
+4. Store each result with a label for use in later steps.
+</rules>
+
+<workflow>
+Step 1: LOOKUP CUSTOMER
+  Tool: get_customer
+  Input: {"email": "{{customer_email}}"}
+  Store result as: CUSTOMER
+  If not found → output: "Customer not found for {{customer_email}}"
+
+Step 2: CHECK SUBSCRIPTION
+  Tool: get_subscription
+  Input: {"customer_id": CUSTOMER.id}
+  Store result as: SUBSCRIPTION
+  Check: SUBSCRIPTION.plan_type
+    If "free" → output: "Customer is on free plan. No usage report available."
+    If "paid" or "enterprise" → continue to Step 3
+
+Step 3: GENERATE REPORT
+  Tool: generate_usage_report
+  Input: {"customer_id": CUSTOMER.id, "plan": SUBSCRIPTION.plan_type, "period": "last_30_days"}
+  Store result as: REPORT
+  Output: REPORT.download_url
+</workflow>
+
+<examples>
+<example>
+<input>customer_email: alice@example.com</input>
+<sequence>
+1. get_customer({"email": "alice@example.com"}) → {"id": 42, "name": "Alice"}
+   CUSTOMER = {"id": 42, "name": "Alice"}
+2. get_subscription({"customer_id": 42}) → {"plan_type": "paid", "status": "active"}
+   SUBSCRIPTION = {"plan_type": "paid", "status": "active"}
+   plan_type is "paid" → continue
+3. generate_usage_report({"customer_id": 42, "plan": "paid", "period": "last_30_days"})
+   → {"download_url": "https://reports.example.com/42.pdf"}
+</sequence>
+<o>
+Usage report generated: https://reports.example.com/42.pdf
+</o>
+</example>
+
+<example>
+<input>customer_email: bob@example.com</input>
+<sequence>
+1. get_customer({"email": "bob@example.com"}) → {"id": 99, "name": "Bob"}
+2. get_subscription({"customer_id": 99}) → {"plan_type": "free", "status": "active"}
+   plan_type is "free" → stop
+</sequence>
+<o>
+Customer is on free plan. No usage report available.
+</o>
+</example>
+</examples>
+```
+
+## Why it works for Haiku
+
+- Workflow is fully sequenced (no planning needed)
+- Each step specifies: tool, input (with source), and exit conditions
+- Branching is explicit at each decision point
+- Error handling is per-step, not a general "handle errors" instruction
+- Both success and early-exit paths are demonstrated in examples

--- a/down-skilling/examples/code-review-triage.md
+++ b/down-skilling/examples/code-review-triage.md
@@ -1,0 +1,96 @@
+# Code Review Triage
+
+**Task type**: Structured analysis with classification
+**Key gaps addressed**: nuanced-classification, schema-adherence, implicit-constraints
+
+## Original (Opus-level)
+
+"Review this PR diff and flag anything concerning — security issues,
+performance problems, logic errors. Give me a prioritized summary."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a code review assistant that triages pull request diffs.
+</role>
+
+<task>
+Analyze the provided code diff and produce a structured report of issues
+found. Classify each issue by severity and category. Output valid JSON.
+</task>
+
+<rules>
+1. Examine ONLY the changed lines (prefixed with + or -).
+2. Classify each issue into exactly one category:
+   SECURITY | PERFORMANCE | LOGIC | STYLE
+3. Assign exactly one severity: HIGH | MEDIUM | LOW
+4. Severity criteria:
+   - HIGH: could cause data loss, security breach, or crash in production
+   - MEDIUM: incorrect behavior under some conditions, or notable
+     performance regression
+   - LOW: style issues, minor inefficiencies, non-blocking improvements
+5. If no issues found, output: {"issues": [], "summary": "No issues found."}
+6. Maximum 10 issues. Prioritize higher severity.
+7. Do not suggest improvements that are not problems.
+</rules>
+
+<process>
+1. Read the diff in <context>.
+2. For each changed line, check against categories in rule 2.
+3. For each issue found, assign category and severity per rules 3-4.
+4. Sort issues by severity (HIGH first), then by line number.
+5. Verify: does each issue reference a specific line? If not, remove it.
+6. Output JSON matching the schema in the examples.
+</process>
+
+<examples>
+<example>
+<input>
++ password = request.params["password"]
++ db.execute(f"SELECT * FROM users WHERE pw = '{password}'")
+</input>
+<o>
+{
+  "issues": [
+    {
+      "line": 2,
+      "category": "SECURITY",
+      "severity": "HIGH",
+      "description": "SQL injection via unsanitized string interpolation. Use parameterized queries."
+    },
+    {
+      "line": 1,
+      "category": "SECURITY",
+      "severity": "MEDIUM",
+      "description": "Password compared as plaintext. Should use hashed comparison."
+    }
+  ],
+  "summary": "2 issues: 1 HIGH (SQL injection), 1 MEDIUM (plaintext password)."
+}
+</o>
+</example>
+
+<example>
+<input>
+- color = "blue"
++ color = "red"
+</input>
+<o>
+{"issues": [], "summary": "No issues found."}
+</o>
+<reasoning>Simple constant change — no security, performance, or logic concern.</reasoning>
+</example>
+</examples>
+
+<context>
+{{diff_content}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Enumerates every valid category and severity level (no judgment needed)
+- Explicit severity criteria replace Opus's intuitive "concerning"
+- Negative example (no issues) prevents hallucinated problems
+- Verification step 5 catches untethered claims

--- a/down-skilling/examples/content-moderation.md
+++ b/down-skilling/examples/content-moderation.md
@@ -1,0 +1,80 @@
+# Content Moderation
+
+**Task type**: Classification with safety-critical constraints
+**Key gaps addressed**: nuanced-classification, negation-handling, conditional-logic
+
+## Original (Opus-level)
+
+"Flag user comments that violate our community guidelines. Handle edge
+cases with good judgment."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a content moderation assistant that classifies user comments.
+</role>
+
+<task>
+Classify each comment as APPROVED, FLAGGED, or REMOVED. Provide the
+violated policy (if any) and a confidence score.
+</task>
+
+<rules>
+1. Verdict: exactly one of APPROVED | FLAGGED | REMOVED
+   - APPROVED: no policy violation detected
+   - FLAGGED: possible violation, needs human review
+   - REMOVED: clear, unambiguous violation
+2. Policy categories: HATE_SPEECH | HARASSMENT | SPAM | MISINFORMATION | NONE
+3. Confidence: HIGH | MEDIUM | LOW
+4. When uncertain between APPROVED and FLAGGED, choose FLAGGED.
+5. When uncertain between FLAGGED and REMOVED, choose FLAGGED.
+6. Sarcasm and irony: classify based on surface content. If surface content
+   is hostile, flag it regardless of possible sarcastic intent.
+7. Quoting or discussing harmful content in an educational context is APPROVED.
+8. Output: JSON array of {id, verdict, policy, confidence, reason}
+9. "reason": max 15 words.
+</rules>
+
+<process>
+1. Read each comment.
+2. Check against policy categories in rule 2.
+3. Apply rules 4-5 for uncertain cases.
+4. Apply rule 6 for tone-ambiguous content.
+5. Apply rule 7 for quoted/discussed content.
+6. Assign confidence: HIGH if clear match/non-match, MEDIUM if rule 4-5
+   applied, LOW if edge case.
+7. Output JSON.
+</process>
+
+<examples>
+<example>
+<input>
+Comment 1: "This article is garbage, the author should be fired"
+Comment 2: "I think the data in paragraph 3 is outdated, here's a newer source: [link]"
+Comment 3: "lol imagine being this stupid, kys"
+Comment 4: "The article discusses how hate speech affects communities"
+</input>
+<o>
+[
+  {"id": 1, "verdict": "APPROVED", "policy": "NONE", "confidence": "HIGH", "reason": "Negative opinion about content, not targeted harassment."},
+  {"id": 2, "verdict": "APPROVED", "policy": "NONE", "confidence": "HIGH", "reason": "Constructive criticism with sourced correction."},
+  {"id": 3, "verdict": "REMOVED", "policy": "HARASSMENT", "confidence": "HIGH", "reason": "Direct insult with self-harm encouragement."},
+  {"id": 4, "verdict": "APPROVED", "policy": "NONE", "confidence": "HIGH", "reason": "Educational discussion of hate speech, not hate speech itself."}
+]
+</o>
+</example>
+</examples>
+
+<context>
+{{comments}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Rules 4-5: explicit "when uncertain" defaults (critical for safety tasks)
+- Rule 6: sarcasm handled by surface-content rule, not judgment
+- Rule 7: educational context carved out explicitly
+- Comment 1 vs 3: demonstrates the harassment threshold boundary
+- Comment 4: prevents over-flagging of meta-discussion

--- a/down-skilling/examples/creative-rewriting.md
+++ b/down-skilling/examples/creative-rewriting.md
@@ -1,0 +1,69 @@
+# Creative Rewriting / Tone Adaptation
+
+**Task type**: Generative with style constraints
+**Key gaps addressed**: creative-generation, implicit-constraints, output-calibration
+
+## Original (Opus-level)
+
+"Rewrite this technical paragraph for a general audience blog post.
+Make it engaging but accurate."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a technical writer who adapts complex content for general audiences.
+</role>
+
+<task>
+Rewrite the technical paragraph for a blog post. Maintain factual accuracy
+while making it accessible and engaging to non-experts.
+</task>
+
+<rules>
+1. Reading level: high school graduate (no jargon without explanation)
+2. Length: 80-120 words (original may be shorter or longer)
+3. Begin with a hook — a question, surprising fact, or relatable scenario
+4. Replace technical terms with plain equivalents. If a term must stay,
+   add a brief parenthetical explanation.
+5. Use active voice. Vary sentence length (8-25 words per sentence).
+6. End with a forward-looking statement or implication.
+7. Do not add information not present in the original.
+8. Do not use: "In today's world", "It's important to note", "crucial",
+   "revolutionary", "game-changing".
+</rules>
+
+<examples>
+<example>
+<input>
+The system employs a microservices architecture with event-driven
+communication via Apache Kafka, enabling horizontal scalability and
+fault isolation across service boundaries.
+</input>
+<o>
+What happens when one part of a massive app breaks? In a well-designed
+system, the answer is: almost nothing. Modern apps split into small,
+independent pieces that talk to each other through a message queue (think
+of it like a post office for data). If one piece fails, the others keep
+running. Need to handle more traffic? Just add more copies of the busy
+pieces. The rest of the system doesn't even notice.
+</o>
+<reasoning>
+Replaced "microservices" with "small independent pieces", "event-driven
+via Kafka" with "message queue" + analogy, "horizontal scalability" with
+"add more copies", "fault isolation" with "others keep running".
+</reasoning>
+</example>
+</examples>
+
+<context>
+{{technical_paragraph}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Style exemplar shows the target voice (concrete > descriptive)
+- Banned phrases list prevents generic AI-sounding output
+- Word count range prevents over/under-shooting
+- Rule 7 prevents hallucinated additions

--- a/down-skilling/examples/data-extraction.md
+++ b/down-skilling/examples/data-extraction.md
@@ -1,0 +1,63 @@
+# Structured Data Extraction
+
+**Task type**: Classification + extraction to schema
+**Key gaps addressed**: schema-adherence, nuanced-classification, output-calibration
+
+## Original (Opus-level)
+
+"Parse these customer feedback comments and extract the key themes."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a customer feedback analyst that categorizes comments.
+</role>
+
+<task>
+Read each comment. Extract: sentiment, theme, one-sentence summary.
+Output a JSON array.
+</task>
+
+<rules>
+1. Sentiment: POSITIVE | NEGATIVE | MIXED | NEUTRAL
+   - POSITIVE: satisfaction, praise, or gratitude
+   - NEGATIVE: frustration, complaint, or disappointment
+   - MIXED: both positive and negative elements
+   - NEUTRAL: factual statement, no emotional valence
+2. Theme: PRICING | UX | PERFORMANCE | SUPPORT | FEATURE_REQUEST | OTHER
+3. Summary: one sentence, max 20 words
+4. Output: JSON array of {id, sentiment, theme, summary}
+5. Process in order. Do not skip any comment.
+6. Unintelligible/empty input:
+   {"id": N, "sentiment": "NEUTRAL", "theme": "OTHER", "summary": "Not interpretable."}
+</rules>
+
+<examples>
+<example>
+<input>
+Comment 1: "Love the new dashboard! So much faster."
+Comment 2: "Price up 30% but no new features."
+Comment 3: "asdfghjkl"
+</input>
+<o>
+[
+  {"id": 1, "sentiment": "POSITIVE", "theme": "PERFORMANCE", "summary": "Praises new dashboard speed."},
+  {"id": 2, "sentiment": "NEGATIVE", "theme": "PRICING", "summary": "Frustrated by price increase without new features."},
+  {"id": 3, "sentiment": "NEUTRAL", "theme": "OTHER", "summary": "Not interpretable."}
+]
+</o>
+</example>
+</examples>
+
+<context>
+{{comments}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Every valid value enumerated for every field
+- Unintelligible input handled explicitly (schema-adherence gap)
+- MIXED category prevents forced binary choice (classification gap)
+- Schema demonstrated in examples, not just described

--- a/down-skilling/examples/document-qa.md
+++ b/down-skilling/examples/document-qa.md
@@ -1,0 +1,76 @@
+# Document Question Answering (RAG)
+
+**Task type**: Retrieval-grounded QA with citation
+**Key gaps addressed**: context-utilization, self-correction, ambiguity-resolution
+
+## Original (Opus-level)
+
+"Answer the user's question based on these document chunks. Be accurate
+and cite your sources."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a document-grounded Q&A assistant. You answer ONLY from provided
+context.
+</role>
+
+<task>
+Answer the user's question using the provided document excerpts.
+Cite the source excerpt for each claim. If the answer is not in the
+documents, say so explicitly.
+</task>
+
+<rules>
+1. Use ONLY information from <context>. No external knowledge.
+2. Cite sources as [Source N] after each claim.
+3. If the answer is not in the context: "The provided documents do not
+   contain information to answer this question."
+4. If the answer is partially in the context, answer what you can and
+   state what is missing.
+5. Maximum 150 words.
+6. Begin your response with the direct answer, then supporting detail.
+7. Do not speculate, hedge, or add qualifiers like "it appears that".
+</rules>
+
+<examples>
+<example>
+<input>
+Question: What is the company's return policy?
+
+[Source 1]: Returns accepted within 30 days of purchase with original receipt.
+[Source 2]: Electronics have a 15-day return window. Opened software is non-refundable.
+[Source 3]: Our customer support team is available 24/7 at support@example.com.
+</input>
+<o>
+Returns are accepted within 30 days with original receipt [Source 1].
+Electronics have a shorter 15-day window, and opened software cannot
+be returned [Source 2].
+</o>
+</example>
+
+<example>
+<input>
+Question: What are the shipping costs?
+
+[Source 1]: Returns accepted within 30 days of purchase.
+[Source 2]: Our warehouse is located in Austin, TX.
+</input>
+<o>
+The provided documents do not contain information about shipping costs.
+</o>
+</example>
+</examples>
+
+<context>
+{{retrieved_chunks}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Rule 1 is the anti-hallucination anchor — repeated from role for emphasis
+- "Not in context" response is fully scripted (Haiku won't invent one)
+- Partial-answer case handled explicitly (rule 4)
+- Negative example demonstrates correct refusal behavior

--- a/down-skilling/examples/email-summarization.md
+++ b/down-skilling/examples/email-summarization.md
@@ -1,0 +1,95 @@
+# Email Thread Summarization
+
+**Task type**: Information extraction with structured output
+**Key gaps addressed**: implicit-constraints, output-calibration, self-correction
+
+## Original (Opus-level)
+
+"Summarize this email thread for someone who just joined the project.
+Focus on what matters — decisions made, action items, open questions."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a project communication assistant that summarizes email threads.
+</role>
+
+<task>
+Read the email thread and produce a structured summary. Extract decisions,
+action items, and open questions. Output in the exact markdown format shown.
+</task>
+
+<rules>
+1. Output exactly three sections: ## Decisions, ## Action Items, ## Open Questions
+2. Each section: numbered list. If no items, write "None."
+3. Action items format: "- [Person]: [task] (by [date])" or
+   "- [Person]: [task] (no deadline mentioned)"
+4. Decisions: state WHAT was decided, not the discussion leading to it.
+5. Open questions: phrased as questions ending with "?"
+6. Ignore pleasantries, greetings, signatures, and scheduling logistics.
+7. Maximum 200 words total.
+8. Use ONLY information from the thread. Do not infer unstated decisions.
+</rules>
+
+<examples>
+<example>
+<input>
+From: Alice (Mon 9am)
+After reviewing proposals, let's go with Vendor B. Bob, draft the SOW
+by Friday? Also — keeping the dashboard or migrating everything?
+
+From: Bob (Mon 11am)
+On it — SOW draft Thursday. @Carol, budget approval?
+
+From: Carol (Mon 2pm)
+Budget approved for Q1. PO tomorrow.
+</input>
+<o>
+## Decisions
+1. Vendor B selected for analytics platform.
+2. Q1 budget approved.
+
+## Action Items
+- Bob: Draft SOW for Vendor B (by Thursday)
+- Carol: Send purchase order (by Tuesday)
+
+## Open Questions
+1. Keep existing dashboard or migrate everything?
+</o>
+</example>
+
+<example>
+<input>
+From: Dave (Wed 3pm)
+Hi all, how's everyone? Excited for the offsite!
+
+From: Eve (Wed 4pm)
+Great! Has anyone heard from legal on the data retention policy?
+</input>
+<o>
+## Decisions
+None.
+
+## Action Items
+None.
+
+## Open Questions
+1. Has anyone heard from legal on the data retention policy?
+</o>
+<reasoning>Thread is mostly pleasantries (rule 6). Only Eve's legal
+question is substantive.</reasoning>
+</example>
+</examples>
+
+<context>
+{{email_thread}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Action item format fully specified (person + task + deadline)
+- "None." specified as empty-state output (prevents invention)
+- Pleasantries example shows what to ignore
+- Rule 8 is the critical hallucination guardrail

--- a/down-skilling/examples/meeting-notes.md
+++ b/down-skilling/examples/meeting-notes.md
@@ -1,0 +1,83 @@
+# Meeting Notes Generation
+
+**Task type**: Information extraction with multiple output sections
+**Key gaps addressed**: parallel-consistency, summarization-fidelity, counting-enumeration
+
+## Original (Opus-level)
+
+"Turn this meeting transcript into clean notes with decisions, action
+items, and next steps."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a meeting notes assistant that converts transcripts into
+structured summaries.
+</role>
+
+<task>
+Convert the meeting transcript into structured notes with five sections.
+Follow the output template exactly.
+</task>
+
+<rules>
+1. Output exactly these sections in this order:
+   **Meeting**: [title] | [date] | [attendees]
+   **Summary**: 2-3 sentences, max 50 words
+   **Decisions**: numbered list of decisions made
+   **Action Items**: numbered list, format: "[Person] — [task] — [deadline or 'TBD']"
+   **Next Steps**: numbered list of upcoming milestones or follow-ups
+2. Each section must have at least one item. If none exist, write "None identified."
+3. Attendees: list only names that speak in the transcript.
+4. Decisions: must be something the group agreed to, not proposals or ideas.
+5. Action items: must have an assigned person. If no person named, attribute
+   to "Team" and flag with "(unassigned)".
+6. Do not include side conversations, jokes, or off-topic discussion.
+7. Maximum 250 words total.
+</rules>
+
+<examples>
+<example>
+<input>
+[Transcript excerpt]
+Sarah: OK so we're going with the new vendor for Q2. Mike, can you get
+the contract reviewed by legal by next Friday?
+Mike: Sure. Oh hey did anyone see the game last night?
+Sarah: Ha, no. Anyway, we also need to decide on the launch date.
+Lisa: I think March 15th works. Everyone agree?
+Sarah: Works for me. Mike?
+Mike: Yep, March 15th.
+</input>
+<o>
+**Meeting**: Vendor & Launch Planning | [date not specified] | Sarah, Mike, Lisa
+**Summary**: Team confirmed new vendor for Q2 and set March 15th as launch date. Mike to get contract through legal review.
+**Decisions**:
+1. New vendor selected for Q2.
+2. Launch date set for March 15th.
+**Action Items**:
+1. Mike — Get contract reviewed by legal — by next Friday
+**Next Steps**:
+1. Legal contract review completion (next Friday)
+2. Launch preparation for March 15th
+</o>
+<reasoning>
+"Did anyone see the game" excluded per rule 6. Vendor selection and
+launch date both qualify as decisions (explicit agreement). Only Mike
+has a named action item.
+</reasoning>
+</example>
+</examples>
+
+<context>
+{{transcript}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Five sections with exact formatting prevents structural drift
+- Action item format is fully specified (person — task — deadline)
+- Rule 4 distinguishes decisions from proposals (Haiku would conflate them)
+- Rule 5 handles unassigned actions with explicit default
+- Example excludes off-topic content, demonstrating rule 6 in practice

--- a/down-skilling/examples/resume-screening.md
+++ b/down-skilling/examples/resume-screening.md
@@ -1,0 +1,84 @@
+# Resume Screening
+
+**Task type**: Multi-criteria evaluation with structured scoring
+**Key gaps addressed**: parallel-consistency, instruction-density, partial-information
+
+## Original (Opus-level)
+
+"Screen these resumes against the job requirements and rank the candidates."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a resume screening assistant that evaluates candidates against
+job requirements.
+</role>
+
+<task>
+Evaluate each resume against the job requirements. Score each criterion.
+Produce a ranked candidate list.
+</task>
+
+<rules>
+1. Evaluate each candidate on exactly these criteria:
+   a. Required skills match (0-3): 0=none, 1=some, 2=most, 3=all
+   b. Experience level (0-3): 0=none relevant, 1=junior, 2=mid, 3=senior+
+   c. Education fit (0-2): 0=no match, 1=related field, 2=exact match
+   d. Overall score: sum of a+b+c (max 8)
+2. Output format per candidate:
+   **[Name]** — Score: [N]/8
+   Skills: [score] | Experience: [score] | Education: [score]
+   Key match: [strongest qualification in ≤15 words]
+   Gap: [biggest missing requirement in ≤15 words, or "None identified"]
+3. Rank candidates by overall score (highest first).
+4. Ties: rank by skills score, then experience score.
+5. Score ONLY based on information explicitly stated in the resume.
+   Do not infer skills from job titles.
+6. If a resume is missing information for a criterion, score it 0 for
+   that criterion and note "(not stated)" in the gap field.
+</rules>
+
+<examples>
+<example>
+<input>
+Job: Senior Python Developer. Required: Python, AWS, PostgreSQL, 5+ years.
+Education: CS degree preferred.
+
+Resume A: "10 years Python, AWS certified, MS in Computer Science.
+Previously at Google and Amazon."
+
+Resume B: "3 years JavaScript, 1 year Python. BS Biology. Interested
+in cloud computing."
+</input>
+<o>
+**Resume A** — Score: 7/8
+Skills: 2 | Experience: 3 | Education: 2
+Key match: 10 years Python with AWS certification and MS CS.
+Gap: PostgreSQL not explicitly mentioned.
+
+**Resume B** — Score: 2/8
+Skills: 1 | Experience: 1 | Education: 0
+Key match: Has some Python experience.
+Gap: Missing most required skills; experience level below requirement.
+</o>
+</example>
+</examples>
+
+<job_requirements>
+{{job_description}}
+</job_requirements>
+
+<context>
+{{resumes}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Scoring is mechanical (numbered scale per criterion, not judgment)
+- Rule 5 prevents skill inference (Haiku might assume a "Senior Developer"
+  knows Python without it being stated)
+- Rule 6 handles missing info explicitly (partial-information gap)
+- Tie-breaking is deterministic
+- Per-candidate template enforces parallel structure

--- a/down-skilling/examples/sql-generation.md
+++ b/down-skilling/examples/sql-generation.md
@@ -1,0 +1,86 @@
+# SQL Query Generation
+
+**Task type**: Code generation from natural language
+**Key gaps addressed**: code-generation, ambiguity-resolution, schema-adherence
+
+## Original (Opus-level)
+
+"Write a SQL query for the user's request. Use the provided schema."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a SQL assistant that generates queries from natural language requests.
+</role>
+
+<task>
+Generate a SQL query that answers the user's question using the provided
+database schema. Output the query and a brief explanation.
+</task>
+
+<rules>
+1. Use ONLY tables and columns from <schema>. Never invent columns.
+2. Use standard SQL (PostgreSQL dialect).
+3. Always use explicit JOIN syntax (not comma-separated FROM).
+4. Always qualify column names with table aliases when joining.
+5. Include ORDER BY when the question implies ranking or "top N".
+6. Include LIMIT when the question asks for "top N" or a specific count.
+7. Default to LIMIT 10 if "a few" or "some" is requested.
+8. Use COUNT/SUM/AVG with GROUP BY for aggregate questions.
+9. If the schema cannot answer the question, output:
+   "-- Cannot answer: [reason]. Required column/table not in schema."
+10. Output format:
+    ```sql
+    [query]
+    ```
+    Explanation: [one sentence, max 20 words]
+</rules>
+
+<examples>
+<example>
+<input>
+Schema: users(id, name, email, created_at), orders(id, user_id, total, status, created_at)
+Question: "Who are our top 5 customers by total spending?"
+</input>
+<o>
+```sql
+SELECT u.name, SUM(o.total) AS total_spent
+FROM users u
+JOIN orders o ON o.user_id = u.id
+WHERE o.status = 'completed'
+GROUP BY u.id, u.name
+ORDER BY total_spent DESC
+LIMIT 5;
+```
+Explanation: Sums completed order totals per user, returns top 5 spenders.
+</o>
+</example>
+
+<example>
+<input>
+Schema: users(id, name, email, created_at), orders(id, user_id, total, status, created_at)
+Question: "What's the average customer age?"
+</input>
+<o>
+-- Cannot answer: no age or birthdate column in users table.
+Explanation: Schema lacks age data; cannot compute average age.
+</o>
+</example>
+</examples>
+
+<schema>
+{{database_schema}}
+</schema>
+
+<context>
+{{user_question}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Rule 1 prevents column hallucination (Haiku's most common SQL failure)
+- Rule 9 with example shows correct "can't answer" behavior
+- Explicit JOIN and alias rules prevent common syntax shortcuts
+- Rules 5-7 handle vague quantifiers with concrete defaults

--- a/down-skilling/examples/step-by-step-analysis.md
+++ b/down-skilling/examples/step-by-step-analysis.md
@@ -1,0 +1,59 @@
+# Multi-Step Analytical Task
+
+**Task type**: Decomposed reasoning chain
+**Key gaps addressed**: multi-hop-reasoning, self-correction, output-calibration
+
+## Original (Opus-level)
+
+"Analyze this dataset summary and recommend whether we should expand
+into the European market."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a market analysis assistant that evaluates expansion opportunities.
+</role>
+
+<task>
+Analyze the provided market data and produce a structured recommendation
+on European market expansion. Follow the process steps exactly.
+</task>
+
+<rules>
+1. Output four labeled sections: ## Market Size, ## Risks, ## Recommendation, ## Confidence
+2. Market Size: 2-3 sentences with specific numbers from the data.
+3. Risks: exactly 3 bullet points, each one sentence.
+4. Recommendation: exactly one of EXPAND | DELAY | DO NOT EXPAND
+5. Confidence: LOW | MEDIUM | HIGH with one sentence justification.
+6. Use ONLY data from <context>. If data is insufficient for a section,
+   write: "Insufficient data to assess."
+7. Total response: 150-200 words.
+</rules>
+
+<process>
+1. Read the market data in <context>.
+2. Extract market size figures. Write ## Market Size section.
+3. Identify risk factors. Select the top 3 by potential impact.
+   Write ## Risks section.
+4. Based on sections 1-2, determine recommendation per rule 4.
+   Decision guide:
+   - Market size > $500M AND risks manageable → EXPAND
+   - Market size > $500M BUT significant regulatory risk → DELAY
+   - Market size < $500M → DO NOT EXPAND
+5. Assess data completeness. Write ## Confidence section.
+6. Verify total word count is 150-200.
+</process>
+
+<context>
+{{market_data_summary}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Multi-hop reasoning decomposed into explicit sequential steps
+- Decision guide in step 4 replaces Opus's judgment with a rubric
+- "Insufficient data" fallback prevents fabrication
+- Confidence section forces Haiku to assess its own certainty
+  (with structure, not open-ended reflection)

--- a/down-skilling/examples/text-classification.md
+++ b/down-skilling/examples/text-classification.md
@@ -1,0 +1,62 @@
+# Multi-Label Text Classification
+
+**Task type**: Classification with decision rubric
+**Key gaps addressed**: nuanced-classification, ambiguity-resolution, self-correction
+
+## Original (Opus-level)
+
+"Categorize these support tickets by urgency and topic."
+
+## Distilled Haiku Prompt
+
+```xml
+<role>
+You are a support ticket classifier.
+</role>
+
+<task>
+Classify each ticket by urgency and topic. Output a JSON array.
+</task>
+
+<rules>
+1. Urgency (exactly one):
+   - CRITICAL: system down, data loss, security breach, blocking all users
+   - HIGH: feature broken for some users, significant degradation
+   - MEDIUM: non-blocking issue, workaround exists
+   - LOW: question, feature request, cosmetic issue
+2. Topic (exactly one):
+   - BILLING | AUTHENTICATION | PERFORMANCE | DATA | UI | INTEGRATION | OTHER
+3. If urgency is ambiguous, classify as the HIGHER urgency level.
+4. If topic is ambiguous, classify as OTHER.
+5. Output: JSON array of {id, urgency, topic, reason}
+6. "reason": one sentence explaining the classification. Max 15 words.
+</rules>
+
+<examples>
+<example>
+<input>
+Ticket 1: "Can't log in. Getting 500 error. Need access for client demo in 1 hour."
+Ticket 2: "The font on the settings page looks weird on mobile."
+Ticket 3: "We're being charged for 50 seats but only have 12 users."
+</input>
+<o>
+[
+  {"id": 1, "urgency": "CRITICAL", "topic": "AUTHENTICATION", "reason": "Login failure blocking user with time-sensitive need."},
+  {"id": 2, "urgency": "LOW", "topic": "UI", "reason": "Cosmetic rendering issue on mobile."},
+  {"id": 3, "urgency": "HIGH", "topic": "BILLING", "reason": "Overcharge affecting customer billing."}
+]
+</o>
+</example>
+</examples>
+
+<context>
+{{tickets}}
+</context>
+```
+
+## Why it works for Haiku
+
+- Ambiguity resolution rule (3): "if unclear, go higher" prevents Haiku
+  from inconsistently guessing
+- Default topic (4): "OTHER" prevents forced categorization
+- Reason field constrains Haiku's tendency to over-explain

--- a/down-skilling/gaps/ambiguity-resolution.md
+++ b/down-skilling/gaps/ambiguity-resolution.md
@@ -1,0 +1,17 @@
+# Ambiguity Resolution
+
+**Opus**: Selects the most contextually appropriate interpretation of
+ambiguous input. Weighs multiple factors silently.
+
+**Haiku**: May pick any valid interpretation, often the most literal one.
+Inconsistent across runs.
+
+**Mitigation**: Provide explicit disambiguation rules.
+
+```
+If the input could mean X or Y, default to X unless the input
+explicitly contains [specific signal for Y].
+```
+
+Always enumerate interpretations and assign a default. Haiku will not
+weigh contextual clues to choose — it needs a decision rule.

--- a/down-skilling/gaps/code-generation.md
+++ b/down-skilling/gaps/code-generation.md
@@ -1,0 +1,41 @@
+# Code Generation
+
+**Opus**: Generates well-structured code with appropriate error handling,
+edge cases, naming conventions, and documentation. Infers architectural
+patterns from context.
+
+**Haiku**: Generates functional code for straightforward tasks. Common
+issues:
+- Omits error handling unless explicitly requested
+- May use inconsistent naming conventions
+- Documentation/comments sparse unless requested
+- Edge cases rarely handled proactively
+- May not match the existing codebase style
+
+**Mitigation**: Specify every non-obvious quality requirement.
+
+```
+Write a Python function that [task].
+
+Requirements:
+- Function signature: def process_data(input: list[dict]) -> dict
+- Handle these edge cases: empty list, missing keys, non-string values
+- Include type hints on all parameters and return value
+- Add a docstring with Args, Returns, and Raises sections
+- Use snake_case for variables
+- Raise ValueError (not return None) for invalid input
+- Include inline comments for non-obvious logic only
+```
+
+For code that must match existing style:
+```
+Match the coding style of this example:
+[paste 10-20 lines of existing code]
+
+Specifically match: indentation, naming convention, comment style,
+error handling pattern, import style.
+```
+
+For complex code, decompose into functions:
+"Write function A first. Then write function B that calls A.
+Do not write a single monolithic function."

--- a/down-skilling/gaps/comparative-analysis.md
+++ b/down-skilling/gaps/comparative-analysis.md
@@ -1,0 +1,31 @@
+# Comparative Analysis
+
+**Opus**: Naturally structures comparisons. Weighs trade-offs. Arrives
+at nuanced conclusions that acknowledge context-dependency.
+
+**Haiku**: Comparisons tend toward surface-level listing of differences.
+May not weigh factors or synthesize into a recommendation. Can produce
+unbalanced comparisons (more detail on first item than last).
+
+**Mitigation**: Provide the comparison framework explicitly.
+
+```
+Compare using EXACTLY these dimensions:
+1. Cost (provide specific numbers if available)
+2. Performance (cite metrics from the data)
+3. Ease of use (based on stated requirements)
+
+For each dimension:
+- State Option A's position in one sentence
+- State Option B's position in one sentence
+- Declare a winner for that dimension: A, B, or TIE
+
+After all dimensions, provide:
+Overall recommendation: A or B
+Reasoning: one sentence citing the decisive factor.
+```
+
+For balanced treatment:
+- Use a table format (enforces equal space per option)
+- Specify equal word counts per option
+- Process options in consistent order across dimensions

--- a/down-skilling/gaps/conditional-logic.md
+++ b/down-skilling/gaps/conditional-logic.md
@@ -1,0 +1,37 @@
+# Conditional and Branching Logic
+
+**Opus**: Handles nested if/then/else reliably. Evaluates compound
+conditions. Follows complex decision trees.
+
+**Haiku**: Reliable with simple if/then. Degrades with:
+- Nested conditions (if A then if B then...)
+- Compound conditions (if A AND B OR C)
+- More than 3 branches
+
+**Mitigation**: Flatten decision trees. One condition per step.
+
+```
+BAD (nested):
+If the customer is premium AND the order is > $100 AND it's their
+first return, waive the fee. Otherwise if they're premium but the
+order is < $100, charge half fee. Otherwise charge full fee.
+
+GOOD (flattened):
+Step 1: Is customer premium? YES → go to Step 2. NO → charge full fee.
+Step 2: Is order > $100? YES → go to Step 3. NO → charge half fee.
+Step 3: Is this their first return? YES → waive fee. NO → charge half fee.
+```
+
+For complex branching, use a decision table:
+```
+| Premium? | Order > $100? | First return? | Action      |
+|----------|---------------|---------------|-------------|
+| YES      | YES           | YES           | Waive fee   |
+| YES      | YES           | NO            | Half fee    |
+| YES      | NO            | any           | Half fee    |
+| NO       | any           | any           | Full fee    |
+
+Find the first matching row. Apply that action.
+```
+
+Decision tables eliminate reasoning — Haiku just pattern-matches.

--- a/down-skilling/gaps/context-utilization.md
+++ b/down-skilling/gaps/context-utilization.md
@@ -1,0 +1,18 @@
+# Context Window Utilization
+
+**Opus**: Attends well to information regardless of position in long
+context. Can synthesize across distant sections.
+
+**Haiku**: Strong primacy and recency bias. Information in the middle
+of long contexts may be underweighted.
+
+**Mitigation**: Position-aware prompt design.
+
+- Place critical instructions at the START and END of the prompt
+- Keep context passages short and clearly labeled
+- Repeat key constraints AFTER the context block
+- For long documents, extract relevant snippets rather than full text
+- Use explicit section labels: [Context], [Policy], [Instructions]
+
+Rule of thumb: if the prompt exceeds 2,000 tokens, repeat the most
+important constraint immediately before the output instruction.

--- a/down-skilling/gaps/counting-enumeration.md
+++ b/down-skilling/gaps/counting-enumeration.md
@@ -1,0 +1,34 @@
+# Counting and Enumeration
+
+**Opus**: Counts items accurately. Generates exactly N items when asked.
+Tracks quantities across sections.
+
+**Haiku**: May produce N-1 or N+1 items when asked for exactly N.
+Counting errors increase with N > 5. May lose count in longer outputs.
+
+**Mitigation**: Structure output so counting is mechanical, not cognitive.
+
+For "generate exactly 5 items":
+```
+Output format:
+1. [item]
+2. [item]
+3. [item]
+4. [item]
+5. [item]
+
+Number each item. After writing item 5, stop. Do not continue.
+```
+
+For verification tasks ("how many X in the input"):
+```
+Step 1: List each X found, one per line.
+Step 2: Count the lines from Step 1.
+Step 3: Report the count.
+```
+
+Avoid asking Haiku to count-and-generate simultaneously. Decompose:
+first decide WHAT, then ensure the right NUMBER.
+
+For large N (>10), provide the numbered scaffold in the prompt itself
+and have Haiku fill it in.

--- a/down-skilling/gaps/creative-generation.md
+++ b/down-skilling/gaps/creative-generation.md
@@ -1,0 +1,23 @@
+# Creative and Generative Tasks
+
+**Opus**: Produces varied, stylistically rich output. Maintains
+persona/voice consistently across long outputs.
+
+**Haiku**: Creative output is functional but less distinctive. Voice
+consistency degrades in longer outputs. Falls back to generic phrasing.
+
+**Mitigation**: Provide a style exemplar AND explicit style rules.
+
+```
+Voice: Match the style of this example:
+"[2-3 sentence exemplar in target voice]"
+
+Rules:
+- Use active voice
+- Vary sentence length between 5 and 25 words
+- No cliches from this list: [enumerate]
+- Paragraph length: 3-5 sentences
+```
+
+For Haiku, a concrete exemplar paragraph is worth more than ten
+adjectives describing the desired tone.

--- a/down-skilling/gaps/implicit-constraints.md
+++ b/down-skilling/gaps/implicit-constraints.md
@@ -1,0 +1,20 @@
+# Implicit Constraints
+
+**Opus**: Infers unstated constraints from context. Knows a business
+email should be professional without being told.
+
+**Haiku**: Follows explicit constraints well. May violate implicit ones.
+Tone, formality, and audience-appropriateness can drift.
+
+**Mitigation**: Make every constraint explicit. Enumerate what Opus
+would assume.
+
+```
+Tone: professional and concise.
+Audience: C-suite executives.
+Avoid: jargon, hedging language, bullet points.
+Include: specific metrics where available.
+```
+
+Ask yourself: what would a thoughtful person assume about this task
+that isn't written down? Write those assumptions as rules.

--- a/down-skilling/gaps/instruction-density.md
+++ b/down-skilling/gaps/instruction-density.md
@@ -1,0 +1,38 @@
+# Instruction Density and Rule Dropping
+
+**Opus**: Tracks and satisfies 15+ simultaneous constraints reliably.
+Prioritizes naturally when constraints tension.
+
+**Haiku**: Reliable with 5-7 simultaneous constraints. At 10+,
+may drop rules — particularly those in the middle of a list, those
+phrased passively, or those that conflict with example patterns.
+
+**Mitigation**: Limit rules to 7. Group and prioritize.
+
+```
+BAD: 12 flat rules in a single list
+
+GOOD: 
+CRITICAL (must never violate):
+1. [rule]
+2. [rule]
+
+REQUIRED (always apply):
+3. [rule]
+4. [rule]
+5. [rule]
+
+PREFERRED (apply when possible):
+6. [rule]
+7. [rule]
+```
+
+Additional strategies:
+- Cross-reference rules in process steps: "Apply rules 1-3 to each item"
+- Embed the most important rules in the examples, not just the rule list
+- For complex rule sets, split into multiple prompts (one pass per
+  rule group) rather than asking Haiku to apply all at once
+- Repeat the single most important rule at the END of the prompt
+
+If a rule is never demonstrated in the examples, Haiku is less likely
+to follow it. Every critical rule should appear in at least one example.

--- a/down-skilling/gaps/multi-hop-reasoning.md
+++ b/down-skilling/gaps/multi-hop-reasoning.md
@@ -1,0 +1,22 @@
+# Multi-Hop Reasoning
+
+**Opus**: Chains 5+ reasoning steps naturally. Maintains coherence
+across long inference chains.
+
+**Haiku**: Reliable for 2-3 hops. Degrades at 4+. May skip intermediate
+steps or reach incorrect conclusions.
+
+**Mitigation**: Decompose into sequential sub-tasks with explicit outputs.
+
+```
+Step 1: Extract [A] from the input.
+Step 2: Using [A], determine [B] by [specific method].
+Step 3: Given [B], select [C] from [enumerated options].
+```
+
+Or bound reasoning depth: "Think in exactly 3 steps, writing each step
+before the next."
+
+Never rely on Haiku to chain more than 3 inferences silently. If the
+task requires 4+ hops, split into separate prompts or make intermediate
+results explicit in the process steps.

--- a/down-skilling/gaps/multi-turn-consistency.md
+++ b/down-skilling/gaps/multi-turn-consistency.md
@@ -1,0 +1,38 @@
+# Multi-Turn Consistency
+
+**Opus**: Maintains context, commitments, and style across long
+conversations. Self-consistent even when revisiting earlier topics.
+
+**Haiku**: Context retention degrades over turns. May:
+- Contradict earlier statements
+- Lose track of established facts or agreements
+- Reset persona or tone mid-conversation
+- Forget constraints established in early turns
+
+**Mitigation**: Re-inject critical state at each turn.
+
+For API-based multi-turn:
+```
+<state>
+Established facts:
+- User's name: Alice
+- Project: Q4 dashboard redesign
+- Constraint: Budget is $50K
+- Previous decisions: Chose React over Vue (turn 3)
+
+Active rules:
+- Respond in 2-3 sentences per turn
+- Do not suggest solutions over budget
+</state>
+
+[New user message here]
+```
+
+For single-prompt tasks that simulate multi-turn reasoning:
+- Do not rely on Haiku maintaining context beyond 3-4 exchanges
+- Build each step's output as input to the next step explicitly
+- For chatbot applications, implement a state summary that gets
+  prepended to each turn
+
+For persona consistency: re-state the role in the system prompt
+AND reference it in the first user turn.

--- a/down-skilling/gaps/negation-handling.md
+++ b/down-skilling/gaps/negation-handling.md
@@ -1,0 +1,33 @@
+# Negation and Negative Instructions
+
+**Opus**: Processes negative instructions ("don't include X") reliably.
+Understands complex negations and double negatives.
+
+**Haiku**: Negative instructions are less reliably followed than positive
+ones. "Don't use bullet points" may still produce bullets. Complex
+negations ("never fail to include") can be misinterpreted.
+
+**Mitigation**: Reframe every negative as a positive directive.
+
+```
+BAD:  Don't use jargon.
+GOOD: Use plain language that a high school student would understand.
+
+BAD:  Never include personal opinions.
+GOOD: State only facts supported by the provided data.
+
+BAD:  Don't forget to include the date.
+GOOD: Include the date in YYYY-MM-DD format on the first line.
+```
+
+When a negative constraint is unavoidable, pair it with the positive
+alternative:
+```
+Do not use bullet points. Instead, write in flowing prose paragraphs.
+```
+
+For critical prohibitions, combine rule + example:
+```
+Rule: Do not include prices.
+Example output shows: "Contact sales for pricing." (not "$99/month")
+```

--- a/down-skilling/gaps/nuanced-classification.md
+++ b/down-skilling/gaps/nuanced-classification.md
@@ -1,0 +1,19 @@
+# Nuanced Classification
+
+**Opus**: Handles borderline cases with appropriate hedging or
+multi-label assignment. Understands that categories can overlap.
+
+**Haiku**: Tends toward single-label, definitive classification. May
+force ambiguous cases into the nearest category.
+
+**Mitigation**: Provide a decision rubric with explicit boundary rules.
+
+```
+Categories: [A, B, C, AMBIGUOUS]
+If input matches criteria for exactly one category, assign it.
+If input matches 2+ categories, assign "AMBIGUOUS" and list them.
+If input matches no category, assign "OTHER".
+```
+
+Always include an escape-hatch category (AMBIGUOUS, OTHER, MIXED).
+Without it, Haiku will force borderline cases into arbitrary buckets.

--- a/down-skilling/gaps/output-calibration.md
+++ b/down-skilling/gaps/output-calibration.md
@@ -1,0 +1,20 @@
+# Output Length and Format Calibration
+
+**Opus**: Intuitively matches response length to task complexity and
+user expectations.
+
+**Haiku**: Tends toward either too brief or too verbose. May pad with
+unnecessary caveats or preamble.
+
+**Mitigation**: Specify word/token bounds and structural constraints.
+
+```
+Respond in 80-120 words. Begin with the recommendation.
+End with one supporting reason. Do not include disclaimers.
+```
+
+Always specify:
+- Word or sentence count range
+- What the response should begin with
+- What the response should end with
+- What to omit (preamble, caveats, hedging)

--- a/down-skilling/gaps/parallel-consistency.md
+++ b/down-skilling/gaps/parallel-consistency.md
@@ -1,0 +1,36 @@
+# Parallel Structure and Consistency
+
+**Opus**: Maintains consistent style, format, and level of detail
+across multiple similar outputs within a single response.
+
+**Haiku**: First few items in a list are well-formed. Quality and
+consistency degrade after item 4-5. Later items may be shorter,
+less detailed, or structurally different from earlier ones.
+
+**Mitigation**: Provide a template and enforce it per-item.
+
+```
+For each item, output EXACTLY this structure:
+**Name**: [name]
+**Category**: [one of: A, B, C]
+**Summary**: [one sentence, 10-20 words]
+**Score**: [integer 1-10]
+
+Do not vary this structure between items.
+```
+
+For long lists (>5 items), consider:
+- Processing in batches of 5
+- Including a "format checkpoint" instruction:
+  "After every 5th item, verify your format matches the template."
+- Using JSON arrays (structural enforcement is stronger than prose)
+
+If generating comparative content (pros/cons for multiple options),
+provide the comparison scaffold:
+```
+| Criterion | Option A | Option B | Option C |
+|-----------|----------|----------|----------|
+| Cost      | ...      | ...      | ...      |
+| Speed     | ...      | ...      | ...      |
+```
+Tables enforce parallel structure mechanically.

--- a/down-skilling/gaps/partial-information.md
+++ b/down-skilling/gaps/partial-information.md
@@ -1,0 +1,35 @@
+# Handling Partial or Missing Information
+
+**Opus**: Recognizes when input is incomplete. Gracefully distinguishes
+between "not mentioned" and "doesn't exist." Asks for clarification
+or flags gaps appropriately.
+
+**Haiku**: Tends to either fabricate missing information or silently
+skip it. May not distinguish between "unknown" and "not applicable."
+
+**Mitigation**: Define explicit handling for every expected gap.
+
+```
+REQUIRED fields: name, email, date
+OPTIONAL fields: phone, notes
+
+For REQUIRED fields:
+- If missing, output the field with value "MISSING — [field name] required"
+- Do not skip the field. Do not guess.
+
+For OPTIONAL fields:
+- If missing, output the field with value "N/A"
+- Do not skip the field.
+```
+
+When input quality varies:
+```
+If the input text is:
+- Empty → output: {"status": "error", "message": "No input provided."}
+- Under 10 words → output: {"status": "warning", "message": "Input too short for reliable analysis."}
+- Otherwise → proceed with analysis.
+```
+
+Always provide the full output schema even for error/edge cases.
+Haiku follows "fill in this template" more reliably than "decide
+what to output based on input quality."

--- a/down-skilling/gaps/schema-adherence.md
+++ b/down-skilling/gaps/schema-adherence.md
@@ -1,0 +1,19 @@
+# Schema Adherence Under Pressure
+
+**Opus**: Maintains output format even with unusual or challenging
+inputs. Degrades gracefully.
+
+**Haiku**: Schema adherence is strong for typical inputs but can break
+on edge cases — missing fields, malformed data, empty inputs.
+
+**Mitigation**: Demonstrate edge cases in examples AND specify fallback.
+
+```
+If a required field is missing, output the field with value "N/A".
+Never omit fields from the schema.
+If input is empty, output the complete schema with all values "N/A".
+```
+
+Critical: include at least one edge-case example in the few-shot set.
+Haiku generalizes from examples better than from rules alone for
+format recovery.

--- a/down-skilling/gaps/self-correction.md
+++ b/down-skilling/gaps/self-correction.md
@@ -1,0 +1,20 @@
+# Self-Correction and Verification
+
+**Opus**: Naturally reviews its output and catches errors. Effective
+when prompted to critique and revise.
+
+**Haiku**: Rarely self-corrects unprompted. When prompted to review,
+corrections are shallow (surface-level, not logical).
+
+**Mitigation**: Build verification INTO the process steps.
+
+```
+Step 3: Verify your answer satisfies rules 1, 2, and 3.
+  If all pass, output it.
+  If any fail, identify which rule is violated,
+  revise the answer, then output.
+```
+
+Do NOT use: "Review your output for errors."
+Do use: specific checkable criteria embedded in the workflow.
+Haiku's verification is only as good as the checklist you provide.

--- a/down-skilling/gaps/summarization-fidelity.md
+++ b/down-skilling/gaps/summarization-fidelity.md
@@ -1,0 +1,34 @@
+# Summarization Fidelity
+
+**Opus**: Produces summaries that accurately reflect source material.
+Naturally distinguishes between main claims and supporting detail.
+Maintains appropriate level of abstraction.
+
+**Haiku**: Summaries may:
+- Overweight content from the beginning/end of the source (position bias)
+- Lose nuance (turn hedged claims into definitive statements)
+- Miss the central thesis while including peripheral details
+- Add interpretive framing not present in the source
+
+**Mitigation**: Constrain the summarization process.
+
+```
+Step 1: Identify the single main claim or thesis of the text.
+        Write it in one sentence.
+Step 2: Identify 3 supporting points. Write each in one sentence.
+Step 3: Combine into a coherent paragraph of 60-80 words.
+
+Rules:
+- The main claim MUST appear in the first sentence of your summary.
+- Do not add interpretation or analysis.
+- Do not introduce information not in the source.
+- If the source hedges a claim ("may", "suggests", "could"),
+  preserve the hedging in your summary.
+```
+
+For longer documents, fight position bias:
+```
+Divide the text into thirds (beginning, middle, end).
+Extract one key point from each third.
+Your summary must include content from all three sections.
+```

--- a/down-skilling/gaps/tool-use-planning.md
+++ b/down-skilling/gaps/tool-use-planning.md
@@ -1,0 +1,21 @@
+# Tool Use Planning
+
+**Opus**: Plans tool call sequences strategically. Assesses information
+needs before acting. Batches efficiently.
+
+**Haiku**: May call tools eagerly without planning. Can make redundant
+calls or miss dependencies between calls.
+
+**Mitigation**: Provide an explicit tool-use plan.
+
+```
+Before calling any tool:
+1. List what information you need.
+2. Identify which tool provides each piece.
+3. Determine the correct call order (dependencies first).
+4. Execute in that order.
+Do NOT call a tool until you have completed steps 1-3.
+```
+
+For multi-tool tasks, enumerate the exact sequence in the process
+section rather than letting Haiku decide the order.


### PR DESCRIPTION
## Summary

Adds the **down-skilling** skill for distilling Opus-level reasoning into optimized instructions for Haiku 4.5 (and Sonnet).

## Contents

- `SKILL.md` — Methodology, workflow, and prompt generation patterns
- `examples/` — 12 task-specific worked examples:
  - API orchestration, code review triage, content moderation, creative rewriting, data extraction, document QA, email summarization, meeting notes, resume screening, SQL generation, step-by-step analysis, text classification
- `gaps/` — 19 documented Haiku capability gaps with mitigation strategies:
  - Ambiguity resolution, code generation, comparative analysis, conditional logic, context utilization, counting/enumeration, creative generation, implicit constraints, instruction density, multi-hop reasoning, multi-turn consistency, negation handling, nuanced classification, output calibration, parallel consistency, partial information, schema adherence, self-correction, summarization fidelity

## Trigger phrases

`down-skill`, `distill for Haiku`, `optimize for Haiku`, `make this work on Haiku`, `generate Haiku instructions`

---
*Filed by Muninn*