### PR TITLE
docs(remembering): rewrite _ARCH.md for v5.0.0 Turso-only architecture

### DIFF
--- a/remembering/_MAP.md
+++ b/remembering/_MAP.md
@@ -95,12 +95,13 @@
 - Advanced Topics `h2` :362
 
 ### _ARCH.md
-- Remembering - Architecture Reference `h1` :1
+- Remembering — Architecture Reference `h1` :1
 - Schema Overview `h2` :5
-- Module Map `h2` :70
-- Data Flow `h2` :113
-- Key Design Decisions `h2` :172
-- Deprecated / Removed `h2` :185
-- Credential Resolution Order `h2` :196
-- Performance Characteristics `h2` :209
+- Module Map `h2` :48
+- Data Flow `h2` :92
+- Runtime Utilities (muninn_utils) `h2` :154
+- Key Design Decisions `h2` :186
+- Performance Characteristics `h2` :202
+- Credential Resolution Order `h2` :213
+- Deprecated / Removed `h2` :226
 


### PR DESCRIPTION
## Summary

- Rewrites `remembering/_ARCH.md` to accurately reflect the v5.0.0 Turso-only architecture after Phase 4 cache removal (#301)
- Document stands on its own — no references to the removed local cache
- Adds `muninn_utils` section documenting the runtime utility system
- Updates module map, data flows, dependency graph, and performance table
- Refreshes `_MAP.md` files

## Changes

**_ARCH.md** (major rewrite):
- Removed local SQLite cache schema, data flow, and module references
- Updated boot/write/read data flows to Turso-only paths
- Added retry logic section (new in v5.0.0)
- Added muninn_utils section with utility inventory table
- Updated performance table (single latency path, no cache-hit vs miss)
- Moved cache to Deprecated/Removed table with context

## Test plan

- [ ] _ARCH.md accurately reflects current code (no cache.py references in active sections)
- [ ] Module map matches actual scripts/ directory
- [ ] Data flows match memory.py/boot.py/turso.py implementation
- [ ] muninn_utils table matches utilities materialized at boot

https://claude.ai/code/session_01Srfm2uzEWmmqFbnfAnJX3Z