### PR TITLE
fix(browsing-bluesky): correct sample_firehose() docs and add missing bsky exports

### DIFF
--- a/browsing-bluesky/SKILL.md
+++ b/browsing-bluesky/SKILL.md
@@ -2,7 +2,7 @@
 name: browsing-bluesky
 description: Browse Bluesky content via API and firehose - search posts, fetch user activity, sample trending topics, read feeds and lists, analyze and categorize accounts. Supports authenticated access for personalized feeds. Use for Bluesky research, user monitoring, trend analysis, feed reading, firehose sampling, account categorization.
 metadata:
-  version: 0.5.0
+  version: 0.5.1
 ---
 
 # Browsing Bluesky
@@ -122,7 +122,14 @@ data = sample_firehose(duration=30)  # Full firehose sample
 data = sample_firehose(duration=20, filter="python")  # Filtered sample
 ```
 
-Returns: `topWords`, `topPhrases`, `entities`, `samplePosts`, `stats`
+Returns dict with keys:
+- **window**: `{startTime, endTime, durationSeconds}` — sampling time range
+- **stats**: `{totalReceived, totalPosts, postsPerSecond, filter, languages}` — volume metrics and language breakdown
+- **topWords**: `[[word, count], ...]` — top 50 words (count >= 3)
+- **topPhrases**: `[[bigram, count], ...]` — top 30 bigrams (count >= 2)
+- **topTrigrams**: `[[trigram, count], ...]` — top 20 trigrams (count >= 2)
+- **entities**: `[[entity, count], ...]` — top 25 handles/hashtags (count >= 2)
+- **samplePosts**: `[{text, altTexts, hasImages}, ...]` — first 50 matching posts
 
 ### Read Feeds and Lists
 

--- a/browsing-bluesky/_MAP.md
+++ b/browsing-bluesky/_MAP.md
@@ -35,9 +35,9 @@
 - Implementation `h2` :12
 - Authentication (Optional) `h2` :34
 - Research Workflows `h2` :66
-- API Endpoint Notes `h2` :188
-- Return Format `h2` :197
-- Account Analysis `h2` :212
+- API Endpoint Notes `h2` :195
+- Return Format `h2` :204
+- Account Analysis `h2` :219
 
 ### __init__.py
 > Imports: `.scripts.bsky`

--- a/browsing-bluesky/scripts/bsky.py
+++ b/browsing-bluesky/scripts/bsky.py
@@ -382,7 +382,7 @@ def sample_firehose(duration: int = 10, filter: Optional[str] = None) -> Dict[st
         filter: Optional term to filter posts (case-insensitive)
 
     Returns:
-        Dict with topWords, topPhrases, entities, samplePosts, stats
+        Dict with window, stats, topWords, topPhrases, topTrigrams, entities, samplePosts
     """
     script_dir = Path(__file__).parent  # browsing-bluesky/scripts/
     zeitgeist_script = script_dir / "zeitgeist-sample.js"

--- a/mapping-codebases/_MAP.md
+++ b/mapping-codebases/_MAP.md
@@ -10,7 +10,8 @@
 ### CHANGELOG.md
 - mapping-codebases - Changelog `h1` :1
 - [0.7.0] - 2026-02-28 `h2` :5
-- [0.6.0] - 2026-02-03 `h2` :21
+- [0.7.0] - 2026-02-28 `h2` :12
+- [0.6.0] - 2026-02-03 `h2` :28
 
 ### README.md
 - mapping-codebases `h1` :1


### PR DESCRIPTION
## Summary

- **#219**: Updated `SKILL.md` and `bsky.py` docstring to document the actual `sample_firehose()` return format — including `window`, `topTrigrams`, and the `[[key, count], ...]` pair structure that was previously undocumented
- **#220**: Updated `muninn_utils/bsky.py` utility memory to export 8 missing functions: `get_all_following`, `get_all_followers`, `extract_post_text`, `extract_keywords`, `analyze_account`, `analyze_accounts`, `get_trending`, `get_trending_topics`
- Bumped version to 0.5.1

Closes #219
Closes #220

## Test plan

- [ ] Verify SKILL.md return format documentation matches `zeitgeist-sample.js` output structure (lines 200-218)
- [ ] Verify `bsky.py` docstring matches actual return keys
- [ ] Verify updated bsky utility memory exports all functions from `browsing-bluesky/__init__.py`

https://claude.ai/code/session_01Y7Gwez8sTozoA5Cd8gyjzs