### PR TITLE
feat: Add orchestrating-skills skill (#319)

### DIFF
--- a/_MAP.md
+++ b/_MAP.md
@@ -1,5 +1,5 @@
 # claude-skills/
-*Files: 4 | Subdirectories: 45*
+*Files: 4 | Subdirectories: 46*
 
 ## Subdirectories
 
@@ -39,6 +39,7 @@
 - [making-waffles/](./making-waffles/_MAP.md)
 - [mapping-codebases/](./mapping-codebases/_MAP.md)
 - [orchestrating-agents/](./orchestrating-agents/_MAP.md)
+- [orchestrating-skills/](./orchestrating-skills/_MAP.md)
 - [remembering/](./remembering/_MAP.md)
 - [reviewing-ai-papers/](./reviewing-ai-papers/_MAP.md)
 - [sampling-bluesky-zeitgeist/](./sampling-bluesky-zeitgeist/_MAP.md)

--- a/orchestrating-agents/_MAP.md
+++ b/orchestrating-agents/_MAP.md
@@ -1,5 +1,5 @@
 # orchestrating-agents/
-*Files: 2 | Subdirectories: 2*
+*Files: 3 | Subdirectories: 2*
 
 ## Subdirectories
 
@@ -7,6 +7,10 @@
 - [scripts/](./scripts/_MAP.md)
 
 ## Files
+
+### CHANGELOG.md
+- orchestrating-agents - Changelog `h1` :1
+- [0.2.0] - 2026-02-28 `h2` :5
 
 ### README.md
 - orchestrating-agents `h1` :1

--- a/orchestrating-skills/SKILL.md
+++ b/orchestrating-skills/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: orchestrating-skills
+description: >-
+  Skill-aware orchestration with bash-mediated context routing. Decomposes complex
+  tasks into skill-typed subtasks, extracts targeted context subsets without redundant
+  reparsing, executes subagents in parallel with specialized instructions, and
+  synthesizes results. Self-answers trivial subtasks inline. Use when tasks require
+  multiple analytical perspectives (comparison + critique + synthesis), when context
+  is large and subtasks only need portions, or when orchestrating-agents spawns too
+  many redundant subagents.
+metadata:
+  version: 0.1.0
+  depends_on:
+    - orchestrating-agents
+---
+
+# Skill-Aware Orchestration
+
+Orchestrate complex multi-step tasks through a four-phase pipeline that eliminates
+redundant context processing and reflexive subagent spawning.
+
+## When to Use
+
+- Task requires **multiple analytical perspectives** (e.g., compare + critique + synthesize)
+- Context is large and **subtasks only need portions** of it
+- Simple subtasks should be **self-answered** without spawning subagents
+- Current `orchestrating-agents` + `tiling-tree` pattern produces too many redundant calls
+
+## When NOT to Use
+
+- Single-skill tasks (just use the skill directly)
+- Tasks requiring tool use or code execution (this is text-analysis orchestration)
+- Real-time streaming requirements (this is batch-oriented)
+
+## Quick Start
+
+```python
+import sys
+sys.path.insert(0, "/mnt/skills/user/orchestrating-skills/scripts")
+from orchestrate import orchestrate
+
+result = orchestrate(
+    context=open("report.md").read(),
+    task="Compare the two proposed architectures, extract cost figures, and recommend one",
+    verbose=True,
+)
+print(result["result"])
+```
+
+## Four-Phase Pipeline
+
+### Phase 1: Planning (LLM)
+
+The orchestrator reads the full context **once** and produces a JSON plan:
+
+```json
+{
+  "subtasks": [
+    {
+      "task": "Compare architecture A vs B on scalability, cost, and complexity",
+      "skill": "analytical_comparison",
+      "context_pointers": {"sections": ["Architecture A", "Architecture B"]}
+    },
+    {
+      "task": "Extract all cost figures and projections",
+      "skill": "fact_extraction",
+      "context_pointers": {"sections": ["Cost Analysis"]}
+    },
+    {
+      "task": "What is the team's current headcount?",
+      "skill": "self",
+      "answer": "12 engineers (stated in paragraph 2)"
+    }
+  ]
+}
+```
+
+Key behaviors:
+- Assigns exactly one skill per subtask from the built-in library
+- Uses `"self"` for trivial lookups (avoids spawning a subagent for simple questions)
+- Context pointers use **section headers** (structural, edit-resilient) as primary method
+
+### Phase 2: Assembly (Deterministic Code)
+
+No LLM calls. The assembler:
+1. Extracts context subsets using section headers or line ranges
+2. Pairs each subset with the assigned skill's system prompt
+3. Builds prompt dicts ready for `invoke_parallel`
+
+### Phase 3: Execution (Parallel LLM)
+
+Subagent prompts run in parallel via `orchestrating-agents.invoke_parallel`.
+Each subagent receives **only its context slice** and **skill-specific instructions**.
+
+### Phase 4: Synthesis (Deterministic Code + LLM)
+
+1. Code collects results and interleaves self-answered results
+2. A synthesizer LLM combines all results into a coherent response
+
+## Built-in Skill Library
+
+Eight task-oriented skills, each with specialized system prompt and output schema:
+
+| Skill | Purpose | Self-answer ceiling |
+|-------|---------|-------------------|
+| `analytical_comparison` | Compare items along dimensions with trade-offs | 2 sentences |
+| `fact_extraction` | Extract facts with source attribution | 3 sentences |
+| `structured_synthesis` | Combine multiple sources into narrative | 1 sentence |
+| `causal_reasoning` | Identify cause-effect chains | 1 sentence |
+| `critique` | Evaluate arguments for soundness | 1 sentence |
+| `classification` | Categorize items with rationale | 5 sentences |
+| `summarization` | Produce concise summaries | 4 sentences |
+| `gap_analysis` | Identify missing information | 2 sentences |
+
+The self-answer ceiling determines when the orchestrator handles a subtask inline
+rather than spawning a subagent.
+
+## API Reference
+
+### `orchestrate(context, task, **kwargs) -> dict`
+
+Main entry point. Returns:
+
+```python
+{
+    "result": "Final synthesized response",
+    "plan": {...},           # Orchestrator's decomposition
+    "subtask_count": 4,      # Total subtasks
+    "self_answered": 1,      # Handled inline
+    "delegated": 3,          # Sent to subagents
+}
+```
+
+Parameters:
+- `context` (str): Full context to process
+- `task` (str): What to accomplish
+- `model` (str): Claude model, default `claude-sonnet-4-6`
+- `max_tokens` (int): Per-subagent token limit, default 4096
+- `synthesis_max_tokens` (int): Synthesis token limit, default 8192
+- `max_workers` (int): Parallel subagent limit, default 5
+- `self_answer_ceiling` (int): Sentence threshold for self-answering, default 3
+- `skills` (dict): Custom skill library (overrides built-in)
+- `verbose` (bool): Print progress to stderr
+
+### CLI
+
+```bash
+python orchestrate.py \
+    --context-file report.md \
+    --task "Analyze this report" \
+    --verbose \
+    --json
+```
+
+## Extending the Skill Library
+
+Add custom skills by passing a dict to `orchestrate(skills=...)`:
+
+```python
+custom_skills = {
+    "code_review": {
+        "description": "Review code for bugs, style, and security",
+        "system_prompt": "You are a code review specialist...",
+        "output_hint": "issues_list with severity and fix suggestions",
+        "self_answer_ceiling": 1,
+    }
+}
+
+# Merge with built-in skills
+from skill_library import SKILLS
+all_skills = {**SKILLS, **custom_skills}
+
+result = orchestrate(context=code, task="Review this PR", skills=all_skills)
+```
+
+## Architecture Details
+
+See [references/architecture.md](references/architecture.md) for:
+- Context pointer design decisions
+- Self-answering heuristics
+- Token efficiency analysis
+- Comparison with SkillOrchestra (arXiv 2602.19672)

--- a/orchestrating-skills/_MAP.md
+++ b/orchestrating-skills/_MAP.md
@@ -1,0 +1,21 @@
+# orchestrating-skills/
+*Files: 1 | Subdirectories: 2*
+
+## Subdirectories
+
+- [references/](./references/_MAP.md)
+- [scripts/](./scripts/_MAP.md)
+
+## Files
+
+### SKILL.md
+- Skill-Aware Orchestration `h1` :17
+- When to Use `h2` :22
+- When NOT to Use `h2` :29
+- Quick Start `h2` :35
+- Four-Phase Pipeline `h2` :50
+- Built-in Skill Library `h2` :100
+- API Reference `h2` :118
+- Extending the Skill Library `h2` :155
+- Architecture Details `h2` :176
+

--- a/orchestrating-skills/references/_MAP.md
+++ b/orchestrating-skills/references/_MAP.md
@@ -1,0 +1,13 @@
+# references/
+*Files: 1*
+
+## Files
+
+### architecture.md
+- Architecture: Skill-Aware Orchestration `h1` :1
+- Problem Statement `h2` :3
+- Design Decisions `h2` :15
+- Pipeline Flow `h2` :111
+- Comparison with SkillOrchestra `h2` :158
+- Error Handling `h2` :171
+

--- a/orchestrating-skills/references/architecture.md
+++ b/orchestrating-skills/references/architecture.md
@@ -1,0 +1,178 @@
+# Architecture: Skill-Aware Orchestration
+
+## Problem Statement
+
+The existing `orchestrating-agents` + `tiling-tree` pattern exhibits two inefficiencies
+identified in SkillOrchestra (arXiv 2602.19672):
+
+1. **Reflexive spawning**: Every leaf task spawns a subagent regardless of difficulty.
+   The orchestrator never self-answers, even for trivial lookups.
+
+2. **Context re-processing**: Each subagent independently reparses the full context,
+   wasting tokens on redundant work. For N subagents with context C, total context
+   processing is O(N*C) instead of O(C + N*c_i) where c_i << C.
+
+## Design Decisions
+
+### Context Pointers: Section Headers as Primary
+
+Three options were considered:
+
+| Method | Pros | Cons |
+|--------|------|------|
+| Section headers | Structural, edit-resilient, human-readable | Requires markdown headers |
+| Line ranges | Works on any text, precise | Brittle to edits, opaque |
+| Hybrid | Best of both | More complex pointer format |
+
+**Decision**: Section headers as primary, line ranges as fallback.
+
+Rationale: Most context in Claude workflows is markdown or markdown-like. Section
+headers are resilient to line insertions/deletions and readable in the orchestrator
+plan JSON. Line ranges serve as escape hatch for headerless content.
+
+Implementation in `assembler.py`:
+- `extract_sections()` matches headers case-insensitively, captures content through
+  next equal-or-higher-level header
+- `extract_lines()` uses 1-indexed inclusive ranges
+- `extract_context_subset()` tries sections first, then line ranges, falls back to
+  full context
+
+### Self-Answering Heuristics
+
+The orchestrator uses a **sentence ceiling** per skill to decide whether to self-answer:
+
+```
+If estimated_answer_length < skill.self_answer_ceiling sentences:
+    Use skill="self" and provide inline answer
+Else:
+    Delegate to subagent
+```
+
+Ceilings vary by skill complexity:
+- `classification` (5): Simple categorization often needs one word
+- `summarization` (4): Brief summaries can be inline
+- `fact_extraction` (3): Single-fact lookups are trivial
+- `analytical_comparison` (2): Even short comparisons benefit from structure
+- `critique`, `causal_reasoning`, `structured_synthesis` (1): Almost always needs depth
+
+The orchestrator LLM makes this judgment during planning. The ceiling is guidance,
+not a hard rule — the LLM can override based on context complexity.
+
+### Skill Granularity: Broad Taxonomy
+
+**Decision**: 8 broad skills covering analytical primitives.
+
+Rationale: The orchestrator LLM has limited attention budget for skill selection.
+A library of 6-8 well-defined skills is matchable in a single pass. Fine-grained
+libraries (50+ skills) require multi-hop retrieval that defeats the "touch context
+once" principle.
+
+The 8 skills cover the analytical primitives that compose into complex tasks:
+
+```
+fact_extraction    → What does the context say?
+summarization      → What's the gist?
+classification     → What category does this fall into?
+analytical_comparison → How do X and Y compare?
+causal_reasoning   → Why did X happen? What follows from Y?
+critique           → Is this argument sound?
+gap_analysis       → What's missing?
+structured_synthesis → How do these pieces fit together?
+```
+
+Custom skills can be added via the `skills` parameter without modifying the library.
+
+### Token Efficiency Analysis
+
+For a task with context C (tokens) decomposed into N subtasks:
+
+**Without orchestration** (naive parallel):
+```
+Total context tokens = N * C  (each subagent gets full context)
+```
+
+**With skill-aware orchestration**:
+```
+Phase 1: C (orchestrator reads once)
+Phase 2: 0 (deterministic code)
+Phase 3: Σ c_i where c_i = context slice for subtask i
+Phase 4: Σ r_i (response collection) + synthesis prompt
+
+Total ≈ C + Σ c_i + Σ r_i
+```
+
+If context slices average 30% of full context:
+- Naive: 5 * 10K = 50K context tokens
+- Orchestrated: 10K + 5 * 3K = 25K context tokens (50% reduction)
+
+Self-answering further reduces by eliminating subagent calls entirely for
+trivial subtasks.
+
+## Pipeline Flow
+
+```
+┌─────────────────────────────────────────────┐
+│ Phase 1: Orchestrator (LLM)                 │
+│                                             │
+│ Input: Full context + task                  │
+│ Output: JSON plan with skill assignments    │
+│                                             │
+│ - Reads context ONCE                        │
+│ - Decomposes into 1-6 subtasks             │
+│ - Assigns skills from library               │
+│ - Self-answers trivial subtasks inline      │
+│ - Specifies context pointers per subtask    │
+└──────────────────┬──────────────────────────┘
+                   │ JSON plan
+                   ▼
+┌─────────────────────────────────────────────┐
+│ Phase 2: Assembler (Deterministic Code)     │
+│                                             │
+│ For each delegated subtask:                 │
+│ 1. Extract context subset via pointers      │
+│ 2. Look up skill system prompt              │
+│ 3. Build prompt dict for invoke_parallel    │
+│                                             │
+│ NO LLM CALLS                               │
+└──────────────────┬──────────────────────────┘
+                   │ Prompt dicts
+                   ▼
+┌─────────────────────────────────────────────┐
+│ Phase 3: Subagents (Parallel LLM)           │
+│                                             │
+│ invoke_parallel() with:                     │
+│ - Targeted context slices (not full)        │
+│ - Skill-specific system prompts             │
+│ - Low temperature (0.3) for consistency     │
+└──────────────────┬──────────────────────────┘
+                   │ Responses
+                   ▼
+┌─────────────────────────────────────────────┐
+│ Phase 4: Collection + Synthesis             │
+│                                             │
+│ Code: Interleave self-answers + responses   │
+│ LLM:  Synthesize into coherent final answer │
+└─────────────────────────────────────────────┘
+```
+
+## Comparison with SkillOrchestra
+
+This implementation adapts the SkillOrchestra approach (arXiv 2602.19672) to Claude's
+skill system with key differences:
+
+| Aspect | SkillOrchestra | This Skill |
+|--------|---------------|------------|
+| Skill source | Learned from training data | Explicit skill library with system prompts |
+| Context routing | Embedding-based retrieval | Structural extraction (headers/lines) |
+| Self-answering | Confidence threshold | Sentence ceiling per skill type |
+| Parallelism | Framework-dependent | ThreadPoolExecutor via orchestrating-agents |
+| Extensibility | Requires retraining | Pass custom skill dict at runtime |
+
+## Error Handling
+
+- **Orchestrator produces invalid JSON**: `invoke_claude_json` retries with fence-stripping
+- **Unknown skill in plan**: Falls back to generic "helpful assistant" system prompt
+- **Subagent failure**: `invoke_parallel` raises `ClaudeInvocationError`; caller can
+  retry or degrade gracefully
+- **Empty context slice**: If section headers don't match, falls back to full context
+  (logged as warning in verbose mode)

--- a/orchestrating-skills/scripts/_MAP.md
+++ b/orchestrating-skills/scripts/_MAP.md
@@ -1,0 +1,54 @@
+# scripts/
+*Files: 4*
+
+## Files
+
+### __init__.py
+> Imports: `.orchestrate, .skill_library, .assembler`
+- *No top-level symbols*
+
+### assembler.py
+> Imports: `re, typing`
+- **extract_sections** (f) `(context: str, headers: list[str])` :21
+- **extract_lines** (f) `(context: str, ranges: list[tuple[int, int]])` :78
+- **extract_context_subset** (f) `(
+    context: str,
+    sections: Optional[list[str]] = None,
+    line_ranges: Optional[list[tuple[int, int]]] = None,
+)` :101
+- **build_subagent_prompt** (f) `(
+    task_description: str,
+    context_slice: str,
+    skill_system: str,
+    output_hint: str,
+)` :143
+- **build_all_prompts** (f) `(plan: dict, context: str, skills: dict)` :176
+- **collect_results** (f) `(
+    plan: dict,
+    subagent_responses: list[str],
+)` :238
+- **build_synthesis_prompt** (f) `(
+    original_task: str,
+    collected_results: str,
+)` :284
+
+### orchestrate.py
+> Imports: `argparse, json, sys, os, pathlib`...
+- **orchestrate** (f) `(
+    context: str,
+    task: str,
+    model: str = "claude-sonnet-4-6",
+    max_tokens: int = 4096,
+    synthesis_max_tokens: int = 8192,
+    max_workers: int = 5,
+    self_answer_ceiling: int = 3,
+    skills: Optional[dict] = None,
+    verbose: bool = False,
+)` :230
+- **main** (f) `()` :336
+
+### skill_library.py
+- **get_skill** (f) `(name: str)` :162
+- **list_skills** (f) `()` :167
+- **skill_catalog** (f) `()` :172
+

--- a/orchestrating-skills/scripts/__init__.py
+++ b/orchestrating-skills/scripts/__init__.py
@@ -1,0 +1,30 @@
+"""
+orchestrating-skills: Skill-aware orchestration with bash-mediated context routing.
+"""
+
+from .orchestrate import orchestrate
+from .skill_library import SKILLS, get_skill, list_skills, skill_catalog
+from .assembler import (
+    extract_sections,
+    extract_lines,
+    extract_context_subset,
+    build_subagent_prompt,
+    build_all_prompts,
+    collect_results,
+    build_synthesis_prompt,
+)
+
+__all__ = [
+    "orchestrate",
+    "SKILLS",
+    "get_skill",
+    "list_skills",
+    "skill_catalog",
+    "extract_sections",
+    "extract_lines",
+    "extract_context_subset",
+    "build_subagent_prompt",
+    "build_all_prompts",
+    "collect_results",
+    "build_synthesis_prompt",
+]

--- a/orchestrating-skills/scripts/assembler.py
+++ b/orchestrating-skills/scripts/assembler.py
@@ -1,0 +1,318 @@
+"""
+Deterministic context assembly and result collection.
+
+This module handles the "bash-mediated" phases of the orchestration pipeline:
+- Phase 2: Extract context subsets, locate skills, assemble per-task prompts
+- Phase 4 (partial): Collect and format subagent results for synthesis
+
+No LLM calls happen here — only string manipulation and data routing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Context extraction
+# ---------------------------------------------------------------------------
+
+def extract_sections(context: str, headers: list[str]) -> str:
+    """
+    Extract named sections from markdown-style context.
+
+    Uses section headers as structural pointers. Each requested header pulls
+    everything from that header to the next header of equal or higher level.
+
+    Args:
+        context: Full context string (markdown with ## headers)
+        headers: List of section header strings to extract (case-insensitive)
+
+    Returns:
+        Concatenated extracted sections separated by blank lines.
+        If no headers match, returns empty string.
+    """
+    if not headers:
+        return ""
+
+    # Normalize requested headers for matching
+    wanted = {h.strip().lower().lstrip("#").strip() for h in headers}
+
+    lines = context.split("\n")
+    sections: list[str] = []
+    current_section: list[str] = []
+    capturing = False
+    capture_level = 0
+
+    for line in lines:
+        header_match = re.match(r"^(#{1,6})\s+(.+)$", line)
+
+        if header_match:
+            level = len(header_match.group(1))
+            title = header_match.group(2).strip().lower()
+
+            # If we were capturing and hit same or higher level, stop
+            if capturing and level <= capture_level:
+                sections.append("\n".join(current_section))
+                current_section = []
+                capturing = False
+
+            # Check if this header is one we want
+            if title in wanted:
+                capturing = True
+                capture_level = level
+                current_section.append(line)
+                continue
+
+        if capturing:
+            current_section.append(line)
+
+    # Flush last section
+    if capturing and current_section:
+        sections.append("\n".join(current_section))
+
+    return "\n\n".join(sections)
+
+
+def extract_lines(context: str, ranges: list[tuple[int, int]]) -> str:
+    """
+    Extract line ranges from context (1-indexed, inclusive).
+
+    Args:
+        context: Full context string
+        ranges: List of (start, end) tuples, 1-indexed inclusive
+
+    Returns:
+        Extracted lines joined by newlines
+    """
+    lines = context.split("\n")
+    extracted: list[str] = []
+
+    for start, end in sorted(ranges):
+        # Clamp to valid range (1-indexed → 0-indexed)
+        s = max(0, start - 1)
+        e = min(len(lines), end)
+        extracted.extend(lines[s:e])
+
+    return "\n".join(extracted)
+
+
+def extract_context_subset(
+    context: str,
+    sections: Optional[list[str]] = None,
+    line_ranges: Optional[list[tuple[int, int]]] = None,
+) -> str:
+    """
+    Extract a context subset using section headers (primary) or line ranges (fallback).
+
+    Section headers are preferred as they're structural and resilient to edits.
+    Line ranges serve as fallback when content lacks headers.
+
+    Args:
+        context: Full context string
+        sections: Section headers to extract
+        line_ranges: Line ranges as fallback
+
+    Returns:
+        Extracted context subset. Returns full context if no pointers given.
+    """
+    parts = []
+
+    if sections:
+        section_text = extract_sections(context, sections)
+        if section_text:
+            parts.append(section_text)
+
+    if line_ranges:
+        line_text = extract_lines(context, line_ranges)
+        if line_text:
+            parts.append(line_text)
+
+    if parts:
+        return "\n\n".join(parts)
+
+    # No pointers → return full context
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+def build_subagent_prompt(
+    task_description: str,
+    context_slice: str,
+    skill_system: str,
+    output_hint: str,
+) -> dict:
+    """
+    Assemble a single subagent prompt dict ready for invoke_parallel.
+
+    Args:
+        task_description: What the subagent should do
+        context_slice: Pre-extracted context subset
+        skill_system: System prompt from the skill library
+        output_hint: Expected output structure hint
+
+    Returns:
+        Dict with 'system' and 'prompt' keys for invoke_parallel
+    """
+    user_prompt = (
+        f"## Task\n{task_description}\n\n"
+        f"## Context\n{context_slice}\n\n"
+        f"## Expected Output\n"
+        f"Produce output matching this structure: {output_hint}\n"
+        f"Be concrete and cite the context. Do not fabricate information."
+    )
+
+    return {
+        "system": skill_system,
+        "prompt": user_prompt,
+        "temperature": 0.3,
+    }
+
+
+def build_all_prompts(plan: dict, context: str, skills: dict) -> list[dict]:
+    """
+    Build prompt dicts for all subtasks in a plan.
+
+    Args:
+        plan: Orchestrator output with 'subtasks' list, each containing:
+            - task: description string
+            - skill: skill name from library
+            - context_pointers: dict with optional 'sections' and 'line_ranges'
+        context: Full original context
+        skills: Skill library dict (name → skill definition)
+
+    Returns:
+        List of prompt dicts for invoke_parallel, preserving subtask order.
+        Subtasks marked for self-answer (skill == "self") are excluded.
+    """
+    prompts = []
+
+    for subtask in plan.get("subtasks", []):
+        skill_name = subtask.get("skill", "")
+
+        # Skip self-answered tasks — they don't get subagents
+        if skill_name == "self":
+            continue
+
+        skill = skills.get(skill_name)
+        if not skill:
+            # Unknown skill — use a generic system prompt
+            skill = {
+                "system_prompt": (
+                    "You are a helpful assistant. Complete the task using "
+                    "only the provided context."
+                ),
+                "output_hint": "structured response",
+            }
+
+        # Extract context subset
+        pointers = subtask.get("context_pointers", {})
+        context_slice = extract_context_subset(
+            context,
+            sections=pointers.get("sections"),
+            line_ranges=[
+                tuple(r) for r in pointers.get("line_ranges", [])
+            ] if pointers.get("line_ranges") else None,
+        )
+
+        prompt = build_subagent_prompt(
+            task_description=subtask["task"],
+            context_slice=context_slice,
+            skill_system=skill["system_prompt"],
+            output_hint=skill.get("output_hint", "structured response"),
+        )
+
+        prompts.append(prompt)
+
+    return prompts
+
+
+# ---------------------------------------------------------------------------
+# Result collection
+# ---------------------------------------------------------------------------
+
+def collect_results(
+    plan: dict,
+    subagent_responses: list[str],
+) -> str:
+    """
+    Merge self-answered tasks and subagent responses into a synthesis prompt.
+
+    Args:
+        plan: Original orchestrator plan
+        subagent_responses: Responses from invoke_parallel (ordered)
+
+    Returns:
+        Formatted string combining all results for the synthesizer
+    """
+    parts = []
+    response_idx = 0
+
+    for i, subtask in enumerate(plan.get("subtasks", []), 1):
+        task_desc = subtask.get("task", f"Subtask {i}")
+        skill_name = subtask.get("skill", "")
+
+        if skill_name == "self":
+            # Self-answered by orchestrator
+            answer = subtask.get("answer", "(no answer provided)")
+            parts.append(
+                f"### Subtask {i}: {task_desc}\n"
+                f"**Skill**: self-answered by orchestrator\n"
+                f"**Result**:\n{answer}"
+            )
+        else:
+            # Subagent response
+            if response_idx < len(subagent_responses):
+                response = subagent_responses[response_idx]
+                response_idx += 1
+            else:
+                response = "(no response — subagent may have failed)"
+
+            parts.append(
+                f"### Subtask {i}: {task_desc}\n"
+                f"**Skill**: {skill_name}\n"
+                f"**Result**:\n{response}"
+            )
+
+    return "\n\n---\n\n".join(parts)
+
+
+def build_synthesis_prompt(
+    original_task: str,
+    collected_results: str,
+) -> dict:
+    """
+    Build the final synthesis prompt from collected results.
+
+    Args:
+        original_task: The user's original request
+        collected_results: Output from collect_results()
+
+    Returns:
+        Dict with 'system' and 'prompt' for invoke_claude
+    """
+    system = (
+        "You are a synthesis specialist. You receive results from multiple "
+        "subtask agents and combine them into a single coherent response "
+        "that directly addresses the original task.\n\n"
+        "Requirements:\n"
+        "- Integrate results, don't just concatenate\n"
+        "- Resolve any contradictions between subtask results\n"
+        "- Maintain the user's original framing and intent\n"
+        "- Produce a response that reads as if a single expert wrote it"
+    )
+
+    prompt = (
+        f"## Original Task\n{original_task}\n\n"
+        f"## Subtask Results\n\n{collected_results}\n\n"
+        f"## Instructions\n"
+        f"Synthesize the above subtask results into a single, coherent "
+        f"response that fully addresses the original task. Integrate the "
+        f"findings — don't just list them sequentially."
+    )
+
+    return {"system": system, "prompt": prompt}

--- a/orchestrating-skills/scripts/orchestrate.py
+++ b/orchestrating-skills/scripts/orchestrate.py
@@ -1,0 +1,404 @@
+"""
+Skill-aware orchestration with bash-mediated context routing.
+
+Four-phase pipeline:
+  Phase 1 (LLM):  Orchestrator decomposes task → JSON plan with skill assignments
+  Phase 2 (code): Assembler extracts context subsets, builds per-task prompts
+  Phase 3 (LLM):  Parallel subagent calls with targeted context slices
+  Phase 4 (code + LLM): Collect results → synthesizer produces final answer
+
+Design principle: LLMs touch context once each. All shuffling, assembly,
+and collection is deterministic code.
+
+Requires: orchestrating-agents skill (for invoke_parallel, invoke_claude_json)
+
+Usage:
+    from orchestrating_skills.scripts.orchestrate import orchestrate
+
+    result = orchestrate(
+        context="<your full context here>",
+        task="Compare approaches A and B, extract key metrics, and synthesize a recommendation",
+        model="claude-sonnet-4-6",
+    )
+    print(result)
+
+CLI:
+    python orchestrate.py --context-file input.md --task "Analyze this document"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import os
+from pathlib import Path
+from typing import Optional
+
+# Add orchestrating-agents to path for imports
+_SKILL_ROOTS = [
+    Path(__file__).resolve().parent.parent.parent / "orchestrating-agents" / "scripts",
+    Path("/mnt/skills/user/orchestrating-agents/scripts"),
+]
+for _root in _SKILL_ROOTS:
+    if _root.exists() and str(_root) not in sys.path:
+        sys.path.insert(0, str(_root))
+        break
+
+from claude_client import invoke_claude, invoke_claude_json, invoke_parallel  # noqa: E402
+
+# Local imports — support both package and direct execution
+try:
+    from .skill_library import SKILLS, skill_catalog  # noqa: E402
+    from .assembler import (  # noqa: E402
+        build_all_prompts,
+        collect_results,
+        build_synthesis_prompt,
+    )
+except ImportError:
+    from skill_library import SKILLS, skill_catalog  # noqa: E402
+    from assembler import (  # noqa: E402
+        build_all_prompts,
+        collect_results,
+        build_synthesis_prompt,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Orchestrator — task decomposition
+# ---------------------------------------------------------------------------
+
+ORCHESTRATOR_SYSTEM = """\
+You are an orchestration planner. Given a task and context, you decompose the \
+task into subtasks and assign each to the most appropriate skill.
+
+## Available Skills
+{catalog}
+
+## Rules
+1. Each subtask gets exactly ONE skill assignment.
+2. Use "self" as the skill for trivial subtasks (lookups, simple math, \
+definitions) — you answer these inline rather than spawning a subagent.
+3. For "self" tasks, include an "answer" field with your direct response.
+4. Context pointers use section headers (preferred) or line ranges (fallback). \
+   Only include sections/lines actually needed — don't pass everything.
+5. Produce 1-6 subtasks. If the task is simple enough for one skill, use one.
+6. Self-answer threshold: if a subtask needs fewer than {self_answer_ceiling} \
+sentences to answer correctly, prefer "self".
+
+## Output Schema
+Return ONLY valid JSON:
+{{
+  "subtasks": [
+    {{
+      "task": "description of what this subtask should accomplish",
+      "skill": "skill_name or self",
+      "context_pointers": {{
+        "sections": ["Header 1", "Header 2"],
+        "line_ranges": [[1, 50]]
+      }},
+      "answer": "inline answer (only for skill=self)"
+    }}
+  ],
+  "reasoning": "brief explanation of decomposition strategy"
+}}"""
+
+
+def _plan(
+    context: str,
+    task: str,
+    model: str = "claude-sonnet-4-6",
+    self_answer_ceiling: int = 3,
+) -> dict:
+    """
+    Phase 1: LLM reads full context once and produces a task decomposition plan.
+
+    Args:
+        context: Full context to analyze
+        task: User's task description
+        model: Model for the orchestrator
+        self_answer_ceiling: Sentence threshold for self-answering
+
+    Returns:
+        Plan dict with 'subtasks' list and 'reasoning'
+
+    Raises:
+        json.JSONDecodeError: If orchestrator output isn't valid JSON
+        ClaudeInvocationError: If API call fails
+    """
+    system = ORCHESTRATOR_SYSTEM.format(
+        catalog=skill_catalog(),
+        self_answer_ceiling=self_answer_ceiling,
+    )
+
+    prompt = (
+        f"## Task\n{task}\n\n"
+        f"## Context\n{context}"
+    )
+
+    plan = invoke_claude_json(
+        prompt=prompt,
+        system=system,
+        model=model,
+        max_tokens=4096,
+        temperature=0.2,
+    )
+
+    # Validate plan structure
+    if "subtasks" not in plan:
+        raise ValueError("Orchestrator plan missing 'subtasks' key")
+
+    for i, st in enumerate(plan["subtasks"]):
+        if "task" not in st:
+            raise ValueError(f"Subtask {i} missing 'task' key")
+        if "skill" not in st:
+            raise ValueError(f"Subtask {i} missing 'skill' key")
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Parallel subagent execution
+# ---------------------------------------------------------------------------
+
+def _execute(
+    prompts: list[dict],
+    model: str = "claude-sonnet-4-6",
+    max_tokens: int = 4096,
+    max_workers: int = 5,
+) -> list[str]:
+    """
+    Phase 3: Run subagent prompts in parallel.
+
+    Args:
+        prompts: List of prompt dicts from assembler.build_all_prompts
+        model: Model for subagents
+        max_tokens: Max tokens per subagent response
+        max_workers: Concurrent API calls
+
+    Returns:
+        List of response strings, ordered to match prompts
+    """
+    if not prompts:
+        return []
+
+    return invoke_parallel(
+        prompts=prompts,
+        model=model,
+        max_tokens=max_tokens,
+        max_workers=max_workers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Synthesis
+# ---------------------------------------------------------------------------
+
+def _synthesize(
+    original_task: str,
+    collected: str,
+    model: str = "claude-sonnet-4-6",
+    max_tokens: int = 8192,
+) -> str:
+    """
+    Phase 4: Synthesize collected results into a final response.
+
+    Args:
+        original_task: The user's original request
+        collected: Formatted results from collect_results
+        model: Model for synthesis
+        max_tokens: Max tokens for final response
+
+    Returns:
+        Synthesized response string
+    """
+    synth = build_synthesis_prompt(original_task, collected)
+
+    return invoke_claude(
+        prompt=synth["prompt"],
+        system=synth["system"],
+        model=model,
+        max_tokens=max_tokens,
+        temperature=0.3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def orchestrate(
+    context: str,
+    task: str,
+    model: str = "claude-sonnet-4-6",
+    max_tokens: int = 4096,
+    synthesis_max_tokens: int = 8192,
+    max_workers: int = 5,
+    self_answer_ceiling: int = 3,
+    skills: Optional[dict] = None,
+    verbose: bool = False,
+) -> dict:
+    """
+    Run the full four-phase orchestration pipeline.
+
+    Args:
+        context: Full context to process
+        task: What to accomplish with the context
+        model: Claude model for all phases
+        max_tokens: Max tokens per subagent response
+        synthesis_max_tokens: Max tokens for final synthesis
+        max_workers: Max concurrent subagent calls
+        self_answer_ceiling: Sentence count below which orchestrator self-answers
+        skills: Optional custom skill library (defaults to built-in SKILLS)
+        verbose: Print phase progress to stderr
+
+    Returns:
+        Dict with:
+            - result: Final synthesized response
+            - plan: Orchestrator's decomposition plan
+            - subtask_count: Total subtasks
+            - self_answered: Count of self-answered subtasks
+            - delegated: Count of delegated subtasks
+    """
+    skill_lib = skills or SKILLS
+
+    def log(msg: str):
+        if verbose:
+            print(f"[orchestrate] {msg}", file=sys.stderr)
+
+    # Phase 1: Orchestrator decomposes task
+    log("Phase 1: Planning task decomposition...")
+    plan = _plan(context, task, model=model, self_answer_ceiling=self_answer_ceiling)
+
+    subtasks = plan.get("subtasks", [])
+    self_answered = sum(1 for st in subtasks if st.get("skill") == "self")
+    delegated = len(subtasks) - self_answered
+
+    log(f"  {len(subtasks)} subtasks: {self_answered} self-answered, {delegated} delegated")
+
+    if delegated == 0:
+        # All subtasks self-answered — skip phases 2-4, just collect
+        log("All subtasks self-answered. Collecting results...")
+        collected = collect_results(plan, [])
+
+        # Still synthesize if multiple self-answered subtasks
+        if len(subtasks) > 1:
+            log("Phase 4: Synthesizing self-answered results...")
+            result = _synthesize(
+                task, collected,
+                model=model, max_tokens=synthesis_max_tokens,
+            )
+        else:
+            # Single self-answered task — just return the answer
+            result = subtasks[0].get("answer", collected)
+
+        return {
+            "result": result,
+            "plan": plan,
+            "subtask_count": len(subtasks),
+            "self_answered": self_answered,
+            "delegated": 0,
+        }
+
+    # Phase 2: Assemble subagent prompts (deterministic — no LLM)
+    log("Phase 2: Assembling subagent prompts...")
+    prompts = build_all_prompts(plan, context, skill_lib)
+    log(f"  Built {len(prompts)} prompts")
+
+    # Phase 3: Execute subagents in parallel
+    log(f"Phase 3: Executing {len(prompts)} subagents in parallel...")
+    responses = _execute(
+        prompts, model=model, max_tokens=max_tokens, max_workers=max_workers,
+    )
+    log(f"  Received {len(responses)} responses")
+
+    # Phase 4: Collect and synthesize
+    log("Phase 4: Collecting results and synthesizing...")
+    collected = collect_results(plan, responses)
+    result = _synthesize(
+        task, collected,
+        model=model, max_tokens=synthesis_max_tokens,
+    )
+
+    return {
+        "result": result,
+        "plan": plan,
+        "subtask_count": len(subtasks),
+        "self_answered": self_answered,
+        "delegated": delegated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Skill-aware orchestration with context routing"
+    )
+    parser.add_argument(
+        "--context-file", "-c",
+        required=True,
+        help="Path to context file (markdown or text)",
+    )
+    parser.add_argument(
+        "--task", "-t",
+        required=True,
+        help="Task description",
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default="claude-sonnet-4-6",
+        help="Claude model to use (default: claude-sonnet-4-6)",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=4096,
+        help="Max tokens per subagent (default: 4096)",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=5,
+        help="Max parallel subagents (default: 5)",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Print phase progress to stderr",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output full result as JSON (includes plan metadata)",
+    )
+
+    args = parser.parse_args()
+
+    # Read context
+    context_path = Path(args.context_file)
+    if not context_path.exists():
+        print(f"Error: context file not found: {context_path}", file=sys.stderr)
+        sys.exit(1)
+
+    context = context_path.read_text()
+
+    result = orchestrate(
+        context=context,
+        task=args.task,
+        model=args.model,
+        max_tokens=args.max_tokens,
+        max_workers=args.max_workers,
+        verbose=args.verbose,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(result["result"])
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrating-skills/scripts/skill_library.py
+++ b/orchestrating-skills/scripts/skill_library.py
@@ -1,0 +1,177 @@
+"""
+Task-oriented skill library for orchestrated workflows.
+
+Each skill defines a system prompt, output schema hint, and self-answer threshold
+that the orchestrator uses to route subtasks to appropriately-instructed subagents.
+"""
+
+SKILLS = {
+    "analytical_comparison": {
+        "description": "Compare two or more items along specified dimensions, producing a structured evaluation with trade-offs.",
+        "system_prompt": (
+            "You are an analytical comparison specialist. Your task is to compare "
+            "the given items along the dimensions specified, producing a structured "
+            "evaluation.\n\n"
+            "Requirements:\n"
+            "- Evaluate each item on every dimension\n"
+            "- State trade-offs explicitly (what you gain vs. lose)\n"
+            "- Avoid false equivalences — if one option dominates, say so\n"
+            "- Use concrete evidence from the provided context, not general knowledge\n\n"
+            "Output format:\n"
+            "1. Dimension-by-dimension analysis\n"
+            "2. Trade-off summary\n"
+            "3. Recommendation with confidence level (high/medium/low)"
+        ),
+        "output_hint": "comparison_table + trade_offs + recommendation",
+        "self_answer_ceiling": 2,
+    },
+    "fact_extraction": {
+        "description": "Extract specific facts, data points, or claims from context, with source attribution.",
+        "system_prompt": (
+            "You are a fact extraction specialist. Your task is to identify and "
+            "extract specific facts, data points, or claims from the provided context.\n\n"
+            "Requirements:\n"
+            "- Extract only what is explicitly stated — no inferences\n"
+            "- Attribute each fact to its source location (section header or line)\n"
+            "- Flag ambiguous or contradictory statements\n"
+            "- Preserve exact numbers, dates, and proper nouns\n\n"
+            "Output format:\n"
+            "Return a list of extracted facts, each with:\n"
+            "- fact: The extracted statement\n"
+            "- source: Where in the context it appears\n"
+            "- confidence: high (verbatim) / medium (paraphrased) / low (implied)"
+        ),
+        "output_hint": "list of {fact, source, confidence}",
+        "self_answer_ceiling": 3,
+    },
+    "structured_synthesis": {
+        "description": "Combine information from multiple sources into a coherent narrative or document section.",
+        "system_prompt": (
+            "You are a synthesis specialist. Your task is to combine information "
+            "from multiple context sections into a coherent, well-structured output.\n\n"
+            "Requirements:\n"
+            "- Integrate, don't concatenate — find connections between sources\n"
+            "- Resolve contradictions by noting both positions\n"
+            "- Maintain logical flow (cause→effect, general→specific, or chronological)\n"
+            "- Cite which source contributed each point\n\n"
+            "Output format:\n"
+            "A structured narrative with clear sections, each drawing from "
+            "multiple sources where relevant."
+        ),
+        "output_hint": "structured_narrative with source_citations",
+        "self_answer_ceiling": 1,
+    },
+    "causal_reasoning": {
+        "description": "Identify causal chains, mechanisms, and dependencies in the context.",
+        "system_prompt": (
+            "You are a causal reasoning specialist. Your task is to identify and "
+            "articulate cause-effect relationships in the provided context.\n\n"
+            "Requirements:\n"
+            "- Distinguish correlation from causation\n"
+            "- Identify mediating variables and confounders when present\n"
+            "- Map causal chains: A → B → C, not just A → C\n"
+            "- Note where causal claims lack evidence\n\n"
+            "Output format:\n"
+            "1. Causal chain diagram (text-based: A → B → C)\n"
+            "2. Evidence supporting each link\n"
+            "3. Confidence assessment per link\n"
+            "4. Alternative explanations considered"
+        ),
+        "output_hint": "causal_chains + evidence + confidence + alternatives",
+        "self_answer_ceiling": 1,
+    },
+    "critique": {
+        "description": "Evaluate arguments, proposals, or claims for logical soundness, completeness, and practical viability.",
+        "system_prompt": (
+            "You are a critical evaluation specialist. Your task is to evaluate "
+            "the given argument, proposal, or claim.\n\n"
+            "Requirements:\n"
+            "- Identify logical fallacies or gaps\n"
+            "- Assess evidence quality (anecdotal, empirical, theoretical)\n"
+            "- Check for unstated assumptions\n"
+            "- Evaluate practical viability and implementation risks\n"
+            "- Be constructive — identify what's strong as well as what's weak\n\n"
+            "Output format:\n"
+            "1. Strengths (what holds up)\n"
+            "2. Weaknesses (logical gaps, missing evidence, risks)\n"
+            "3. Unstated assumptions\n"
+            "4. Suggested improvements"
+        ),
+        "output_hint": "strengths + weaknesses + assumptions + improvements",
+        "self_answer_ceiling": 1,
+    },
+    "classification": {
+        "description": "Categorize items into a taxonomy, with rationale for each assignment.",
+        "system_prompt": (
+            "You are a classification specialist. Your task is to categorize "
+            "the given items into the specified taxonomy (or derive one if not given).\n\n"
+            "Requirements:\n"
+            "- Each item gets exactly one primary category\n"
+            "- Provide rationale for each classification decision\n"
+            "- Flag borderline cases with secondary category\n"
+            "- If taxonomy is not given, derive one that is MECE\n\n"
+            "Output format:\n"
+            "A list of items with:\n"
+            "- item: The classified item\n"
+            "- category: Primary category\n"
+            "- rationale: Why this category\n"
+            "- secondary: Alternative category if borderline (optional)"
+        ),
+        "output_hint": "list of {item, category, rationale, secondary?}",
+        "self_answer_ceiling": 5,
+    },
+    "summarization": {
+        "description": "Produce a concise summary of the context at a specified level of detail.",
+        "system_prompt": (
+            "You are a summarization specialist. Your task is to produce a "
+            "concise, accurate summary of the provided context.\n\n"
+            "Requirements:\n"
+            "- Preserve key claims, numbers, and conclusions\n"
+            "- Maintain the source's emphasis and framing\n"
+            "- Scale detail to the requested length\n"
+            "- Do not introduce information not in the context\n\n"
+            "Output format:\n"
+            "A summary at the requested granularity. If no length is specified, "
+            "default to ~20% of the original length."
+        ),
+        "output_hint": "concise_summary",
+        "self_answer_ceiling": 4,
+    },
+    "gap_analysis": {
+        "description": "Identify what's missing, unstated, or incomplete in the context relative to the task requirements.",
+        "system_prompt": (
+            "You are a gap analysis specialist. Your task is to identify what "
+            "information, arguments, or evidence is missing from the context.\n\n"
+            "Requirements:\n"
+            "- Compare what's present against what's needed for the task\n"
+            "- Distinguish 'not mentioned' from 'implied but unstated'\n"
+            "- Prioritize gaps by impact on task completion\n"
+            "- Suggest where missing information might be found\n\n"
+            "Output format:\n"
+            "1. Critical gaps (blocks task completion)\n"
+            "2. Important gaps (reduces quality)\n"
+            "3. Minor gaps (nice to have)\n"
+            "Each with: what's missing, why it matters, where to look"
+        ),
+        "output_hint": "gaps_by_severity with impact + source_suggestions",
+        "self_answer_ceiling": 2,
+    },
+}
+
+
+def get_skill(name: str) -> dict:
+    """Get a skill by name. Returns None if not found."""
+    return SKILLS.get(name)
+
+
+def list_skills() -> list[str]:
+    """List all available skill names."""
+    return list(SKILLS.keys())
+
+
+def skill_catalog() -> str:
+    """Return a compact catalog string for inclusion in orchestrator prompts."""
+    lines = []
+    for name, skill in SKILLS.items():
+        lines.append(f"- {name}: {skill['description']}")
+    return "\n".join(lines)


### PR DESCRIPTION
New skill implementing skill-aware orchestration with bash-mediated context
routing, addressing reflexive spawning and context re-processing inefficiencies
in the current orchestrating-agents + tiling-tree pattern.

Four-phase pipeline:
- Phase 1 (LLM): Orchestrator decomposes task into skill-typed subtasks
- Phase 2 (code): Assembler extracts context subsets, builds per-task prompts
- Phase 3 (LLM): Parallel subagent calls with targeted context slices
- Phase 4 (code + LLM): Collect results and synthesize final answer

Includes 8 task-oriented skills (analytical_comparison, fact_extraction,
structured_synthesis, causal_reasoning, critique, classification,
summarization, gap_analysis), self-answering for trivial subtasks, and
section-header-based context routing.

Closes #319

https://claude.ai/code/session_018NtymXV62fH7K1YtWKoECX