### PR TITLE
feat(#320): route invoking-gemini through Cloudflare AI Gateway

### DIFF
--- a/invoking-gemini/_MAP.md
+++ b/invoking-gemini/_MAP.md
@@ -16,15 +16,15 @@
 - When to Use Gemini `h2` :12
 - Available Models `h2` :34
 - Setup `h2` :52
-- Basic Usage `h2` :78
-- Structured Output `h2` :95
-- Parallel Invocation `h2` :125
-- Error Handling `h2` :154
-- Advanced Features `h2` :177
-- Comparison: Gemini vs Claude `h2` :211
-- Token Efficiency Pattern `h2` :230
-- Limitations `h2` :251
-- Examples `h2` :267
-- Troubleshooting `h2` :275
-- Cost Comparison `h2` :292
+- Basic Usage `h2` :90
+- Structured Output `h2` :107
+- Parallel Invocation `h2` :137
+- Error Handling `h2` :166
+- Advanced Features `h2` :189
+- Comparison: Gemini vs Claude `h2` :223
+- Token Efficiency Pattern `h2` :242
+- Limitations `h2` :263
+- Examples `h2` :279
+- Troubleshooting `h2` :287
+- Cost Comparison `h2` :315
 

--- a/invoking-gemini/scripts/_MAP.md
+++ b/invoking-gemini/scripts/_MAP.md
@@ -4,8 +4,9 @@
 ## Files
 
 ### gemini_client.py
-> Imports: `json, time, typing, pathlib`
-- **get_google_api_key** (f) `()` :25
+> Imports: `json, os, time, pathlib, typing`
+- **get_cf_credentials** (f) `()` :87
+- **get_google_api_key** (f) `()` :120
 - **invoke_gemini** (f) `(
     prompt: str,
     model: str = DEFAULT_MODEL,
@@ -14,20 +15,20 @@
     top_p: Optional[float] = None,
     top_k: Optional[int] = None,
     image_path: Optional[str] = None,
-)` :107
+)` :301
 - **invoke_with_structured_output** (f) `(
     prompt: str,
-    pydantic_model: Type[BaseModel],
+    pydantic_model: Type,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     image_path: Optional[str] = None,
-)` :183
+)` :384
 - **invoke_parallel** (f) `(
-    prompts: list[str],
+    prompts: list,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     max_workers: int = 5,
-)` :249
-- **get_available_models** (f) `()` :298
-- **verify_setup** (f) `()` :308
+)` :462
+- **get_available_models** (f) `()` :504
+- **verify_setup** (f) `()` :509
 

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -2,33 +2,129 @@
 """
 Gemini API Client
 
-Provides high-level functions for invoking Google Gemini models
-with support for structured outputs, parallel processing, and error handling.
+Routes requests through Cloudflare AI Gateway when configured (preferred)
+or directly to Google's Generative Language API via the google-generativeai
+SDK (fallback).
+
+Credential priority:
+1. CF Gateway: proxy.env with CF_ACCOUNT_ID, CF_GATEWAY_ID, CF_API_TOKEN
+2. Direct API:  GOOGLE_API_KEY.txt or API_CREDENTIALS.json
 """
 
 import json
+import os
 import time
-from typing import Optional, Any, Type, Union
 from pathlib import Path
+from typing import Optional, Type
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
 
 try:
     import google.generativeai as genai
-    from google.generativeai.types import GenerateContentResponse
+    HAS_GENAI = True
+except ImportError:
+    HAS_GENAI = False
+
+try:
     from pydantic import BaseModel
-except ImportError as e:
-    print(f"Error: Required package not installed: {e}")
-    print("Install with: uv pip install google-generativeai pydantic")
+    HAS_PYDANTIC = True
+except ImportError:
+    HAS_PYDANTIC = False
+    BaseModel = object  # type: ignore[assignment,misc]
+
+if not HAS_REQUESTS and not HAS_GENAI:
+    print("Error: neither 'requests' nor 'google-generativeai' is installed.")
+    print("Install with: uv pip install requests google-generativeai pydantic")
     import sys
     sys.exit(1)
 
 
+# ---------------------------------------------------------------------------
+# Model registry
+# ---------------------------------------------------------------------------
+
+MODELS = {
+    "gemini-2.0-flash-exp": "gemini-2.0-flash-exp",
+    "gemini-2.0-flash": "gemini-2.0-flash",
+    "gemini-1.5-pro": "gemini-1.5-pro",
+    "gemini-1.5-flash": "gemini-1.5-flash",
+}
+
+DEFAULT_MODEL = "gemini-2.0-flash-exp"
+
+# ---------------------------------------------------------------------------
+# Cloudflare AI Gateway constants
+# ---------------------------------------------------------------------------
+
+_CF_GATEWAY_BASE = "https://gateway.ai.cloudflare.com/v1"
+
+_PROXY_ENV_PATHS = [
+    Path("/mnt/project/proxy.env"),
+    Path("/mnt/user-data/proxy.env"),
+    Path.home() / ".muninn" / "proxy.env",
+]
+
+
+# ---------------------------------------------------------------------------
+# Credential loading
+# ---------------------------------------------------------------------------
+
+def _parse_env_file(path: Path) -> dict:
+    """Parse a .env-format file into a dict, stripping quotes."""
+    result = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, _, value = line.partition("=")
+            result[key.strip()] = value.strip().strip('"').strip("'")
+    return result
+
+
+def get_cf_credentials() -> Optional[dict]:
+    """
+    Load Cloudflare AI Gateway credentials.
+
+    Searches for proxy.env in well-known paths, then falls back to
+    environment variables.
+
+    Required keys: CF_ACCOUNT_ID, CF_GATEWAY_ID, CF_API_TOKEN
+    Optional key:  GOOGLE_API_KEY (for non-BYOK setups)
+
+    Returns:
+        dict with credentials if fully configured, None otherwise
+    """
+    required = ("CF_ACCOUNT_ID", "CF_GATEWAY_ID", "CF_API_TOKEN")
+
+    for env_path in _PROXY_ENV_PATHS:
+        if env_path.exists():
+            try:
+                creds = _parse_env_file(env_path)
+                if all(creds.get(k) for k in required):
+                    return creds
+            except (IOError, OSError):
+                continue
+
+    # Fall back to environment variables
+    creds = {k: os.environ.get(k, "") for k in required}
+    creds["GOOGLE_API_KEY"] = os.environ.get("GOOGLE_API_KEY", "")
+    if all(creds.get(k) for k in required):
+        return creds
+
+    return None
+
+
 def get_google_api_key() -> str:
     """
-    Get Google API key from project knowledge files.
+    Get Google API key for direct (non-gateway) access.
 
     Priority order:
     1. Individual file: /mnt/project/GOOGLE_API_KEY.txt
-    2. Combined file: /mnt/project/API_CREDENTIALS.json
+    2. Combined file:   /mnt/project/API_CREDENTIALS.json
+    3. Environment variable: GOOGLE_API_KEY
 
     Returns:
         str: Google API key
@@ -36,7 +132,7 @@ def get_google_api_key() -> str:
     Raises:
         ValueError: If no API key found in any source
     """
-    # Pattern 1: Individual key file (recommended)
+    # 1. Individual key file
     key_file = Path("/mnt/project/GOOGLE_API_KEY.txt")
     if key_file.exists():
         try:
@@ -44,57 +140,143 @@ def get_google_api_key() -> str:
             if key:
                 return key
         except (IOError, OSError) as e:
-            raise ValueError(
-                f"Found GOOGLE_API_KEY.txt but couldn't read it: {e}\n"
-                f"Please check file permissions or recreate the file"
-            )
+            raise ValueError(f"Found GOOGLE_API_KEY.txt but couldn't read it: {e}")
 
-    # Pattern 2: Combined credentials file
+    # 2. Combined credentials file
     creds_file = Path("/mnt/project/API_CREDENTIALS.json")
     if creds_file.exists():
         try:
             with open(creds_file) as f:
                 config = json.load(f)
-                key = config.get("google_api_key", "").strip()
-                if key:
-                    return key
+            key = config.get("google_api_key", "").strip()
+            if key:
+                return key
         except (json.JSONDecodeError, IOError, OSError) as e:
-            raise ValueError(
-                f"Found API_CREDENTIALS.json but couldn't parse it: {e}\n"
-                f"Please check file format"
-            )
+            raise ValueError(f"Found API_CREDENTIALS.json but couldn't parse it: {e}")
 
-    # No key found - provide helpful error message
+    # 3. Environment variable
+    key = os.environ.get("GOOGLE_API_KEY", "").strip()
+    if key:
+        return key
+
     raise ValueError(
         "No Google API key found!\n\n"
-        "Add a project knowledge file using one of these methods:\n\n"
-        "Option 1 (recommended): Individual file\n"
-        "  File: GOOGLE_API_KEY.txt\n"
-        "  Content: AIzaSy...\n\n"
-        "Option 2: Combined file\n"
-        "  File: API_CREDENTIALS.json\n"
-        "  Content: {\"google_api_key\": \"AIzaSy...\"}\n\n"
-        "Get your API key from: https://console.cloud.google.com/apis/credentials"
+        "Option A (recommended): Configure Cloudflare AI Gateway\n"
+        "  File: /mnt/project/proxy.env\n"
+        "  Content:\n"
+        "    CF_ACCOUNT_ID=<your-account-id>\n"
+        "    CF_GATEWAY_ID=<your-gateway-id>\n"
+        "    CF_API_TOKEN=<your-cf-api-token>\n\n"
+        "Option B: Direct Google API\n"
+        "  File: GOOGLE_API_KEY.txt  (content: AIzaSy...)\n"
+        "  or\n"
+        "  File: API_CREDENTIALS.json  (content: {\"google_api_key\": \"AIzaSy...\"})\n\n"
+        "Get your Cloudflare token: https://dash.cloudflare.com/profile/api-tokens\n"
+        "Get your Google key: https://console.cloud.google.com/apis/credentials"
     )
 
 
-# Available models
-MODELS = {
-    "gemini-2.0-flash-exp": "gemini-2.0-flash-exp",
-    "gemini-1.5-pro": "gemini-1.5-pro",
-    "gemini-1.5-flash": "gemini-1.5-flash",
-}
+# ---------------------------------------------------------------------------
+# Cloudflare AI Gateway — REST path
+# ---------------------------------------------------------------------------
 
-DEFAULT_MODEL = "gemini-2.0-flash-exp"
-
-
-def _initialize_client() -> bool:
+def _cf_request(
+    model_id: str,
+    contents: list,
+    generation_config: dict,
+    cf_creds: dict,
+) -> dict:
     """
-    Initialize the Gemini API client with credentials.
+    POST a generateContent request via Cloudflare AI Gateway.
+
+    Args:
+        model_id: Gemini model ID (e.g., 'gemini-2.0-flash-exp')
+        contents: Gemini REST API contents array
+        generation_config: generationConfig dict (camelCase keys)
+        cf_creds: dict with CF_ACCOUNT_ID, CF_GATEWAY_ID, CF_API_TOKEN
 
     Returns:
-        True if initialization successful, False otherwise
+        Parsed JSON response dict
+
+    Raises:
+        requests.HTTPError: On non-2xx HTTP response
     """
+    account_id = cf_creds["CF_ACCOUNT_ID"]
+    gateway_id = cf_creds["CF_GATEWAY_ID"]
+    api_token = cf_creds["CF_API_TOKEN"]
+
+    url = (
+        f"{_CF_GATEWAY_BASE}/{account_id}/{gateway_id}"
+        f"/google-ai-studio/v1beta/models/{model_id}:generateContent"
+    )
+
+    # Include Google API key as query param for non-BYOK setups
+    google_key = cf_creds.get("GOOGLE_API_KEY") or os.environ.get("GOOGLE_API_KEY", "")
+    if google_key:
+        url += f"?key={google_key}"
+
+    payload: dict = {"contents": contents}
+    if generation_config:
+        payload["generationConfig"] = generation_config
+
+    headers = {
+        "Content-Type": "application/json",
+        "cf-aig-authorization": f"Bearer {api_token}",
+    }
+
+    response = requests.post(url, json=payload, headers=headers, timeout=120)
+    response.raise_for_status()
+    return response.json()
+
+
+def _extract_text(response: dict) -> Optional[str]:
+    """Extract generated text from a Gemini REST API response."""
+    try:
+        return response["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _build_contents(prompt: str, image_path: Optional[str]) -> list:
+    """Build the Gemini REST API 'contents' array."""
+    parts: list = [{"text": prompt}]
+    if image_path:
+        import base64
+        import mimetypes
+
+        image_data = Path(image_path).read_bytes()
+        mime_type = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+        parts.append({
+            "inline_data": {
+                "mime_type": mime_type,
+                "data": base64.b64encode(image_data).decode(),
+            }
+        })
+    return [{"parts": parts}]
+
+
+def _pydantic_to_schema(model_class: Type) -> dict:
+    """Convert a Pydantic model class to a Gemini-compatible JSON schema dict."""
+    try:
+        schema = model_class.model_json_schema()  # Pydantic v2
+    except AttributeError:
+        schema = model_class.schema()  # Pydantic v1
+
+    # Strip metadata keys that Gemini rejects
+    for key in ("$schema", "title"):
+        schema.pop(key, None)
+
+    return schema
+
+
+# ---------------------------------------------------------------------------
+# Direct SDK path helpers
+# ---------------------------------------------------------------------------
+
+def _initialize_direct_client() -> bool:
+    """Configure google.generativeai SDK for direct API access."""
+    if not HAS_GENAI:
+        return False
     try:
         api_key = get_google_api_key()
         genai.configure(api_key=api_key)
@@ -103,6 +285,18 @@ def _initialize_client() -> bool:
         print(f"Error: {e}")
         return False
 
+
+def _build_genai_content(prompt: str, image_path: Optional[str]):
+    """Build content argument for google.generativeai SDK calls."""
+    if image_path:
+        from PIL import Image  # type: ignore[import]
+        return [prompt, Image.open(image_path)]
+    return prompt
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def invoke_gemini(
     prompt: str,
@@ -114,12 +308,15 @@ def invoke_gemini(
     image_path: Optional[str] = None,
 ) -> Optional[str]:
     """
-    Invoke Gemini model with a text prompt.
+    Invoke Gemini model with a text (or multi-modal) prompt.
+
+    Routes through Cloudflare AI Gateway when proxy.env is configured;
+    falls back to direct Google API via google-generativeai SDK.
 
     Args:
         prompt: The text prompt to send
         model: Model name (default: gemini-2.0-flash-exp)
-        temperature: Sampling temperature (0.0-1.0)
+        temperature: Sampling temperature (0.0–1.0)
         max_output_tokens: Maximum tokens in response
         top_p: Nucleus sampling parameter
         top_k: Top-k sampling parameter
@@ -128,161 +325,170 @@ def invoke_gemini(
     Returns:
         Response text if successful, None if error
     """
-    if not _initialize_client():
-        return None
-
     if model not in MODELS:
         raise ValueError(f"Invalid model: {model}. Choose from {list(MODELS.keys())}")
 
-    try:
-        # Build generation config
-        generation_config = {
-            "temperature": temperature,
-        }
-        if max_output_tokens:
-            generation_config["max_output_tokens"] = max_output_tokens
-        if top_p is not None:
-            generation_config["top_p"] = top_p
-        if top_k is not None:
-            generation_config["top_k"] = top_k
+    model_id = MODELS[model]
+    cf_creds = get_cf_credentials()
 
-        # Initialize model
-        model_instance = genai.GenerativeModel(
-            model_name=MODELS[model],
-            generation_config=generation_config
-        )
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            if cf_creds and HAS_REQUESTS:
+                # --- Cloudflare AI Gateway path ---
+                contents = _build_contents(prompt, image_path)
+                gen_cfg: dict = {"temperature": temperature}
+                if max_output_tokens:
+                    gen_cfg["maxOutputTokens"] = max_output_tokens
+                if top_p is not None:
+                    gen_cfg["topP"] = top_p
+                if top_k is not None:
+                    gen_cfg["topK"] = top_k
 
-        # Prepare content
-        if image_path:
-            # Multi-modal input
-            from PIL import Image
-            image = Image.open(image_path)
-            content = [prompt, image]
-        else:
-            content = prompt
+                response = _cf_request(model_id, contents, gen_cfg, cf_creds)
+                return _extract_text(response)
 
-        # Generate response with retry logic
-        max_retries = 3
-        for attempt in range(max_retries):
-            try:
+            else:
+                # --- Direct SDK path ---
+                if not _initialize_direct_client():
+                    return None
+
+                gen_cfg_sdk = {"temperature": temperature}
+                if max_output_tokens:
+                    gen_cfg_sdk["max_output_tokens"] = max_output_tokens
+                if top_p is not None:
+                    gen_cfg_sdk["top_p"] = top_p
+                if top_k is not None:
+                    gen_cfg_sdk["top_k"] = top_k
+
+                model_instance = genai.GenerativeModel(
+                    model_name=model_id,
+                    generation_config=gen_cfg_sdk,
+                )
+                content = _build_genai_content(prompt, image_path)
                 response = model_instance.generate_content(content)
                 return response.text
-            except Exception as e:
-                if attempt < max_retries - 1:
-                    wait_time = 2 ** attempt  # Exponential backoff
-                    print(f"Retry {attempt + 1}/{max_retries} after {wait_time}s...")
-                    time.sleep(wait_time)
-                else:
-                    raise
 
-    except Exception as e:
-        print(f"Error invoking Gemini: {e}")
-        return None
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2 ** attempt
+                print(f"Retry {attempt + 1}/{max_retries} after {wait_time}s: {e}")
+                time.sleep(wait_time)
+            else:
+                print(f"Error invoking Gemini: {e}")
+                return None
+
+    return None
 
 
 def invoke_with_structured_output(
     prompt: str,
-    pydantic_model: Type[BaseModel],
+    pydantic_model: Type,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     image_path: Optional[str] = None,
-) -> Optional[BaseModel]:
+) -> Optional[object]:
     """
-    Invoke Gemini with structured output using Pydantic model.
+    Invoke Gemini with structured (JSON schema) output using a Pydantic model.
 
     Args:
         prompt: The text prompt to send
         pydantic_model: Pydantic model class for response schema
         model: Model name (default: gemini-2.0-flash-exp)
-        temperature: Sampling temperature (0.0-1.0)
+        temperature: Sampling temperature (0.0–1.0)
         image_path: Optional path to image file for multi-modal input
 
     Returns:
         Instance of pydantic_model if successful, None if error
     """
-    if not _initialize_client():
+    if not HAS_PYDANTIC:
+        print("Error: pydantic not installed. Run: uv pip install pydantic")
         return None
 
     if model not in MODELS:
         raise ValueError(f"Invalid model: {model}. Choose from {list(MODELS.keys())}")
 
-    try:
-        # Initialize model with response schema
-        model_instance = genai.GenerativeModel(
-            model_name=MODELS[model],
-            generation_config={
-                "temperature": temperature,
-                "response_mime_type": "application/json",
-                "response_schema": pydantic_model,
-            }
-        )
+    model_id = MODELS[model]
+    cf_creds = get_cf_credentials()
 
-        # Prepare content
-        if image_path:
-            from PIL import Image
-            image = Image.open(image_path)
-            content = [prompt, image]
-        else:
-            content = prompt
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            if cf_creds and HAS_REQUESTS:
+                # --- Cloudflare AI Gateway path ---
+                contents = _build_contents(prompt, image_path)
+                schema = _pydantic_to_schema(pydantic_model)
+                gen_cfg = {
+                    "temperature": temperature,
+                    "responseMimeType": "application/json",
+                    "responseSchema": schema,
+                }
+                response = _cf_request(model_id, contents, gen_cfg, cf_creds)
+                text = _extract_text(response)
+                if text:
+                    json_data = json.loads(text)
+                    return pydantic_model(**json_data)
 
-        # Generate response with retry logic
-        max_retries = 3
-        for attempt in range(max_retries):
-            try:
+            else:
+                # --- Direct SDK path ---
+                if not _initialize_direct_client():
+                    return None
+
+                model_instance = genai.GenerativeModel(
+                    model_name=model_id,
+                    generation_config={
+                        "temperature": temperature,
+                        "response_mime_type": "application/json",
+                        "response_schema": pydantic_model,
+                    },
+                )
+                content = _build_genai_content(prompt, image_path)
                 response = model_instance.generate_content(content)
-                # Parse JSON response into Pydantic model
                 json_data = json.loads(response.text)
                 return pydantic_model(**json_data)
-            except Exception as e:
-                if attempt < max_retries - 1:
-                    wait_time = 2 ** attempt
-                    print(f"Retry {attempt + 1}/{max_retries} after {wait_time}s...")
-                    time.sleep(wait_time)
-                else:
-                    raise
 
-    except Exception as e:
-        print(f"Error invoking Gemini with structured output: {e}")
-        return None
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2 ** attempt
+                print(f"Retry {attempt + 1}/{max_retries} after {wait_time}s: {e}")
+                time.sleep(wait_time)
+            else:
+                print(f"Error invoking Gemini with structured output: {e}")
+                return None
+
+    return None
 
 
 def invoke_parallel(
-    prompts: list[str],
+    prompts: list,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     max_workers: int = 5,
-) -> list[Optional[str]]:
+) -> list:
     """
     Invoke Gemini with multiple prompts in parallel.
 
     Args:
         prompts: List of text prompts to process
         model: Model name (default: gemini-2.0-flash-exp)
-        temperature: Sampling temperature (0.0-1.0)
+        temperature: Sampling temperature (0.0–1.0)
         max_workers: Maximum concurrent requests
 
     Returns:
-        List of responses in same order as prompts
+        List of response strings (None for failed requests) in prompt order
     """
-    if not _initialize_client():
-        return [None] * len(prompts)
-
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    results = [None] * len(prompts)
+    results: list = [None] * len(prompts)
 
-    def process_prompt(idx: int, prompt: str) -> tuple[int, Optional[str]]:
-        """Process a single prompt and return index with result"""
-        response = invoke_gemini(prompt, model=model, temperature=temperature)
-        return idx, response
+    def _process(idx: int, prompt: str):
+        return idx, invoke_gemini(prompt, model=model, temperature=temperature)
 
-    # Process prompts in parallel
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
-            executor.submit(process_prompt, idx, prompt): idx
+            executor.submit(_process, idx, prompt): idx
             for idx, prompt in enumerate(prompts)
         }
-
         for future in as_completed(futures):
             try:
                 idx, response = future.result()
@@ -295,13 +501,8 @@ def invoke_parallel(
     return results
 
 
-def get_available_models() -> list[str]:
-    """
-    Get list of available Gemini models.
-
-    Returns:
-        List of model names
-    """
+def get_available_models() -> list:
+    """Return list of registered Gemini model names."""
     return list(MODELS.keys())
 
 
@@ -310,12 +511,19 @@ def verify_setup() -> bool:
     Verify that Gemini client is properly configured.
 
     Returns:
-        True if setup is valid, False otherwise
+        True if at least one credential source is valid and a test call succeeds
     """
-    if not _initialize_client():
+    cf_creds = get_cf_credentials()
+    if cf_creds:
+        print(f"Using Cloudflare AI Gateway (account: {cf_creds['CF_ACCOUNT_ID'][:8]}...)")
+    elif HAS_GENAI:
+        if not _initialize_direct_client():
+            return False
+        print("Using direct Google API (google-generativeai SDK)")
+    else:
+        print("Error: no credentials configured and google-generativeai not installed")
         return False
 
-    # Test with minimal prompt
     try:
         test_response = invoke_gemini("Say 'OK'", model=DEFAULT_MODEL)
         return test_response is not None
@@ -324,12 +532,26 @@ def verify_setup() -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+
 if __name__ == "__main__":
-    # Self-test
+    import sys
+
     print("Gemini Client Self-Test")
     print("=" * 50)
 
-    print("\n1. Checking setup...")
+    cf = get_cf_credentials()
+    if cf:
+        print(f"Backend: Cloudflare AI Gateway ({cf['CF_ACCOUNT_ID'][:8]}.../{cf['CF_GATEWAY_ID']})")
+    elif HAS_GENAI:
+        print("Backend: Direct Google API (google-generativeai SDK)")
+    else:
+        print("ERROR: no credentials and google-generativeai not installed")
+        sys.exit(1)
+
+    print("\n1. Verifying setup...")
     if verify_setup():
         print("   ✓ Setup verified")
     else:
@@ -337,47 +559,46 @@ if __name__ == "__main__":
         sys.exit(1)
 
     print("\n2. Available models:")
-    for model_name in get_available_models():
-        print(f"   - {model_name}")
+    for name in get_available_models():
+        print(f"   - {name}")
 
     print("\n3. Testing basic invocation...")
-    response = invoke_gemini("What is 2+2? Answer in one word.", model=DEFAULT_MODEL)
-    if response:
-        print(f"   Response: {response.strip()}")
+    resp = invoke_gemini("What is 2+2? Answer in one word.", model=DEFAULT_MODEL)
+    if resp:
+        print(f"   Response: {resp.strip()}")
     else:
         print("   ✗ Invocation failed")
+        sys.exit(1)
 
-    print("\n4. Testing structured output...")
-    from pydantic import BaseModel, Field
+    if HAS_PYDANTIC:
+        print("\n4. Testing structured output...")
+        from pydantic import BaseModel as PM, Field
 
-    class MathAnswer(BaseModel):
-        result: int = Field(description="The numerical result")
-        explanation: str = Field(description="Brief explanation")
+        class MathAnswer(PM):
+            result: int = Field(description="The numerical result")
+            explanation: str = Field(description="Brief explanation")
 
-    structured = invoke_with_structured_output(
-        prompt="What is 5+7? Provide result and explanation.",
-        pydantic_model=MathAnswer,
-        model=DEFAULT_MODEL
-    )
-
-    if structured:
-        print(f"   Result: {structured.result}")
-        print(f"   Explanation: {structured.explanation}")
-    else:
-        print("   ✗ Structured output failed")
+        structured = invoke_with_structured_output(
+            prompt="What is 5+7? Provide result and explanation.",
+            pydantic_model=MathAnswer,
+            model=DEFAULT_MODEL,
+        )
+        if structured:
+            print(f"   Result: {structured.result}")
+            print(f"   Explanation: {structured.explanation}")
+        else:
+            print("   ✗ Structured output failed")
 
     print("\n5. Testing parallel invocation...")
     test_prompts = [
-        "What is the capital of France? One word.",
-        "What is the capital of Japan? One word.",
-        "What is the capital of Brazil? One word.",
+        "Capital of France? One word.",
+        "Capital of Japan? One word.",
+        "Capital of Brazil? One word.",
     ]
     parallel_results = invoke_parallel(test_prompts, model=DEFAULT_MODEL)
     for prompt, result in zip(test_prompts, parallel_results):
-        if result:
-            print(f"   {prompt[:30]}... → {result.strip()}")
-        else:
-            print(f"   {prompt[:30]}... → Failed")
+        status = result.strip() if result else "Failed"
+        print(f"   {prompt[:35]}... → {status}")
 
     print("\n" + "=" * 50)
     print("Self-test complete!")


### PR DESCRIPTION
## Summary

Closes #320. Replaces direct-to-Google API calls in the `invoking-gemini` skill with routing through **Cloudflare AI Gateway** when credentials are configured, falling back to the existing `google-generativeai` SDK path.

- **CF Gateway path** (`requests` + `proxy.env`): uses the provider-native URL `gateway.ai.cloudflare.com/v1/{account}/{gateway}/google-ai-studio/v1beta/models/{model}:generateContent` with `cf-aig-authorization` header. Supports both BYOK (no local Google key) and non-BYOK (key as query param).
- **Direct SDK fallback**: unchanged — uses `google-generativeai` + `GOOGLE_API_KEY.txt` / `API_CREDENTIALS.json` when no `proxy.env` is found.
- All existing public functions (`invoke_gemini`, `invoke_with_structured_output`, `invoke_parallel`) preserved with identical signatures.

## Changes

| File | Change |
|------|--------|
| `scripts/gemini_client.py` | Add `get_cf_credentials()`, `_cf_request()`, `_build_contents()`, `_pydantic_to_schema()`, `_extract_text()`; refactor `invoke_*` to choose path at runtime |
| `SKILL.md` | v0.0.3 → v0.1.0; document `proxy.env` setup; expand troubleshooting |
| `_MAP.md` files | Regenerated |

## Test plan

- [x] Syntax check passes
- [x] `_parse_env_file` correctly parses key=value
- [x] `get_cf_credentials()` loads from file or env vars, returns None with no credentials
- [x] `_cf_request()` correct gateway URL, `cf-aig-authorization` header, BYOK/non-BYOK modes
- [x] `_extract_text()` handles normal and edge-case responses
- [x] `invoke_gemini()` routes to CF when creds present, graceful fallback
- [x] Retry logic: succeeds after 2 failures on 3rd attempt

## Dashboard setup required (manual, outside code)

1. Create AI Gateway instance in Cloudflare dashboard, enable authentication
2. Store Gemini API key via BYOK (or add `GOOGLE_API_KEY` to `proxy.env`)
3. Create `/mnt/project/proxy.env` with `CF_ACCOUNT_ID`, `CF_GATEWAY_ID`, `CF_API_TOKEN`

https://claude.ai/code/session_01WxMJ6ku8xw4MjDhwMW1FyU