### PR TITLE
feat(#338): Update invoking-gemini model registry to Gemini 3.x/2.5

### DIFF
--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -2,7 +2,7 @@
 name: invoking-gemini
 description: Invokes Google Gemini models for structured outputs, multi-modal tasks, and Google-specific features. Use when users request Gemini, structured JSON output, Google API integration, or cost-effective parallel processing.
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # Invoking Gemini
@@ -33,21 +33,42 @@ Delegate tasks to Google's Gemini models when they offer advantages over Claude.
 
 ## Available Models
 
-**gemini-2.0-flash-exp** (Recommended):
-- Fast, cost-effective
-- Native JSON Schema support
-- Good for structured outputs
+### Gemini 3.x — Frontier (Preview)
 
-**gemini-1.5-pro**:
-- More capable reasoning
-- Better for complex tasks
-- Higher cost
+**gemini-3-flash-preview** (Default / Recommended):
+- Frontier-class performance at flash-tier cost
+- Upgraded visual and spatial reasoning
+- Agentic coding capabilities
+- Alias: `flash`
 
-**gemini-1.5-flash**:
-- Balanced speed/quality
-- Good for most tasks
+**gemini-3.1-pro-preview**:
+- Most capable model available
+- Deep reasoning and complex problem solving
+- Alias: `pro`
 
-See [references/models.md](references/models.md) for full model details.
+### Gemini 2.5 — Stable Production
+
+**gemini-2.5-flash**:
+- Best price-performance for high-volume tasks
+- 1M token context window
+- Alias: `stable-flash`
+
+**gemini-2.5-flash-lite**:
+- Ultra-budget option ($0.10/$0.40 per 1M tokens)
+- Good for simple, high-throughput tasks
+- Alias: `lite`
+
+**gemini-2.5-pro**:
+- Advanced reasoning for complex tasks
+- Alias: `stable-pro`
+
+### Image Generation Models
+
+**gemini-3-pro-image**: High-fidelity image generation with text rendering and multi-turn editing
+
+**nano-banana-2**: Fast image generation/editing built on Gemini 3.1 Flash Image
+
+See [references/models.md](references/models.md) for full model details and pricing.
 
 ## Setup
 
@@ -99,7 +120,7 @@ from gemini_client import invoke_gemini
 # Simple prompt
 response = invoke_gemini(
     prompt="Explain quantum computing in 3 bullet points",
-    model="gemini-2.0-flash-exp"
+    model="gemini-3-flash-preview"
 )
 print(response)
 ```
@@ -149,7 +170,7 @@ prompts = [
 
 results = invoke_parallel(
     prompts=prompts,
-    model="gemini-2.0-flash-exp"
+    model="gemini-3-flash-preview"
 )
 
 for prompt, result in zip(prompts, results):
@@ -172,7 +193,7 @@ from gemini_client import invoke_gemini
 
 response = invoke_gemini(
     prompt="Your prompt here",
-    model="gemini-2.0-flash-exp"
+    model="gemini-3-flash-preview"
 )
 
 if response is None:
@@ -193,7 +214,7 @@ if response is None:
 ```python
 response = invoke_gemini(
     prompt="Write a haiku",
-    model="gemini-2.0-flash-exp",
+    model="gemini-3-flash-preview",
     temperature=0.9,
     max_output_tokens=100,
     top_p=0.95
@@ -269,8 +290,8 @@ for file in uploaded_files:
 - Subjective creative writing
 
 **Token limits:**
-- gemini-2.0-flash-exp: ~1M input tokens
-- gemini-1.5-pro: ~2M input tokens
+- gemini-3-flash-preview: ~1M input tokens
+- gemini-2.5-pro: ~1M input tokens (2x pricing above 200K)
 
 **Rate limits:**
 - Vary by API tier
@@ -314,18 +335,18 @@ uv pip install google-generativeai
 
 ## Cost Comparison
 
-Approximate pricing (as of 2024):
+Approximate pricing (as of early 2026):
 
-**Gemini 2.0 Flash:**
-- Input: $0.15 / 1M tokens
-- Output: $0.60 / 1M tokens
-
-**Claude Sonnet:**
-- Input: $3.00 / 1M tokens
-- Output: $15.00 / 1M tokens
+| Model | Input / 1M tokens | Output / 1M tokens |
+|---|---|---|
+| Gemini 3 Flash | $0.50 | $3.00 |
+| Gemini 3.1 Pro | $2.00 | $12.00 |
+| Gemini 2.5 Flash | $0.30 | $2.50 |
+| Gemini 2.5 Flash-Lite | $0.10 | $0.40 |
+| Gemini 2.5 Pro | $1.25 | $10.00 |
 
 For 1000 simple extraction tasks (100 tokens each):
-- Gemini Flash: ~$0.10
-- Claude Sonnet: ~$2.00
+- Gemini 2.5 Flash-Lite: ~$0.05
+- Gemini 3 Flash: ~$0.35
 
 **Strategy:** Use Claude for complex reasoning, Gemini for high-volume simple tasks.

--- a/invoking-gemini/_MAP.md
+++ b/invoking-gemini/_MAP.md
@@ -1,5 +1,5 @@
 # invoking-gemini/
-*Files: 2 | Subdirectories: 2*
+*Files: 3 | Subdirectories: 2*
 
 ## Subdirectories
 
@@ -8,6 +8,10 @@
 
 ## Files
 
+### CHANGELOG.md
+- invoking-gemini - Changelog `h1` :1
+- [0.1.0] - 2026-03-01 `h2` :5
+
 ### README.md
 - invoking-gemini `h1` :1
 
@@ -15,16 +19,16 @@
 - Invoking Gemini `h1` :8
 - When to Use Gemini `h2` :12
 - Available Models `h2` :34
-- Setup `h2` :52
-- Basic Usage `h2` :90
-- Structured Output `h2` :107
-- Parallel Invocation `h2` :137
-- Error Handling `h2` :166
-- Advanced Features `h2` :189
-- Comparison: Gemini vs Claude `h2` :223
-- Token Efficiency Pattern `h2` :242
-- Limitations `h2` :263
-- Examples `h2` :279
-- Troubleshooting `h2` :287
-- Cost Comparison `h2` :315
+- Setup `h2` :73
+- Basic Usage `h2` :111
+- Structured Output `h2` :128
+- Parallel Invocation `h2` :158
+- Error Handling `h2` :187
+- Advanced Features `h2` :210
+- Comparison: Gemini vs Claude `h2` :244
+- Token Efficiency Pattern `h2` :263
+- Limitations `h2` :284
+- Examples `h2` :300
+- Troubleshooting `h2` :308
+- Cost Comparison `h2` :336
 

--- a/invoking-gemini/references/_MAP.md
+++ b/invoking-gemini/references/_MAP.md
@@ -30,12 +30,9 @@
 ### models.md
 - Gemini Models Reference `h1` :1
 - Model Comparison `h2` :5
-- Model Selection Guide `h2` :80
-- Multimodal Capabilities `h2` :91
-- Context Windows `h2` :103
-- Rate Limits `h2` :116
-- Performance Characteristics `h2` :125
-- Versioning `h2` :137
-- Safety Settings `h2` :146
-- Experimental Features `h2` :179
+- Model Selection Guide `h2` :161
+- Multimodal Capabilities `h2` :172
+- Deprecated / Retired Models `h2` :182
+- Cost Optimization Tips `h2` :194
+- Rate Limits `h2` :201
 

--- a/invoking-gemini/references/advanced.md
+++ b/invoking-gemini/references/advanced.md
@@ -103,9 +103,9 @@ text = "Analyze the sentiment of this review: ..."
 
 with ThreadPoolExecutor(max_workers=3) as executor:
     futures = {
-        executor.submit(process_with_model, text, "gemini-2.0-flash-exp"): "flash-exp",
-        executor.submit(process_with_model, text, "gemini-1.5-flash"): "flash",
-        executor.submit(process_with_model, text, "gemini-1.5-pro"): "pro",
+        executor.submit(process_with_model, text, "gemini-3-flash-preview"): "3-flash",
+        executor.submit(process_with_model, text, "gemini-2.5-flash"): "2.5-flash",
+        executor.submit(process_with_model, text, "gemini-2.5-pro"): "2.5-pro",
     }
 
     for future in as_completed(futures):
@@ -321,14 +321,14 @@ balanced = invoke_gemini(
 ```python
 import google.generativeai as genai
 
-model = genai.GenerativeModel("gemini-2.0-flash-exp")
+model = genai.GenerativeModel("gemini-3-flash-preview")
 
 # Count tokens before sending
 token_count = model.count_tokens("Your prompt here")
 print(f"Input tokens: {token_count.total_tokens}")
 
 # Estimate cost
-input_cost = (token_count.total_tokens / 1_000_000) * 0.15
+input_cost = (token_count.total_tokens / 1_000_000) * 0.50
 print(f"Estimated input cost: ${input_cost:.4f}")
 ```
 

--- a/invoking-gemini/references/examples.md
+++ b/invoking-gemini/references/examples.md
@@ -298,7 +298,7 @@ prompts = [
 
 translations = invoke_parallel(
     prompts=prompts,
-    model="gemini-2.0-flash-exp",
+    model="gemini-3-flash-preview",
     temperature=0.3,
     max_workers=10
 )

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -1,117 +1,202 @@
 # Gemini Models Reference
 
-Detailed information about available Gemini models.
+Detailed information about available Gemini models (as of March 2026).
 
 ## Model Comparison
 
-### gemini-2.0-flash-exp
+### Gemini 3.x — Frontier (Preview)
 
-**Status:** Experimental (recommended)
+#### gemini-3-flash-preview
+
+**Status:** Preview (Default)
+**Alias:** `flash`
 
 **Strengths:**
-- Fast response times (~1-2s)
-- Native JSON Schema support
-- Property ordering guarantees
-- Cost-effective for batch processing
+- Frontier-class performance rivaling larger models at flash-tier cost
+- Upgraded visual and spatial reasoning
+- Agentic coding capabilities
+- Computer Use support (built-in)
 
 **Specifications:**
 - Context window: ~1M tokens input
-- Output limit: ~8K tokens
 - Multimodal: Yes (text, image, video, audio)
 
 **Best for:**
+- Default choice for most tasks
 - Structured data extraction
-- High-volume simple tasks
-- JSON output requirements
-- Budget-conscious projects
+- High-volume tasks needing strong reasoning
+- Agentic workflows
 
-**Pricing (approximate):**
-- Input: $0.15 / 1M tokens
-- Output: $0.60 / 1M tokens
+**Pricing:**
+- Input: $0.50 / 1M tokens
+- Output: $3.00 / 1M tokens
 
-### gemini-1.5-pro
+#### gemini-3.1-pro-preview
 
-**Status:** Production
+**Status:** Preview
+**Alias:** `pro`
 
 **Strengths:**
-- Superior reasoning capabilities
-- Larger context window (2M tokens)
-- Better for complex tasks
-- More nuanced understanding
+- Most capable Gemini model available
+- Advanced intelligence and complex problem-solving
+- Powerful agentic and vibe coding capabilities
+- Computer Use support (built-in)
 
 **Specifications:**
-- Context window: ~2M tokens input
-- Output limit: ~8K tokens
+- Context window: ~1M tokens input
+- Long context surcharge: 2x above 200K tokens
 - Multimodal: Yes (text, image, video, audio)
 
 **Best for:**
-- Complex analysis requiring reasoning
+- Complex analysis requiring deep reasoning
+- Tasks where quality matters more than cost
+- Advanced coding tasks
+
+**Pricing:**
+- Input: $2.00 / 1M tokens (≤200K), $4.00 (>200K)
+- Output: $12.00 / 1M tokens (≤200K), $24.00 (>200K)
+
+**Note:** Replaces the deprecated `gemini-3-pro-preview` (shutting down March 9, 2026).
+
+---
+
+### Gemini 2.5 — Stable Production
+
+#### gemini-2.5-flash
+
+**Status:** Stable
+**Alias:** `stable-flash`
+
+**Strengths:**
+- Best price-performance for reasoning tasks
+- Production-grade stability
+- Large context window
+
+**Specifications:**
+- Context window: ~1M tokens input
+- Multimodal: Yes (text, image, video, audio)
+
+**Best for:**
+- Production workloads needing stability
+- High-volume tasks with budget constraints
+- When preview models are too volatile
+
+**Pricing:**
+- Input: $0.30 / 1M tokens
+- Output: $2.50 / 1M tokens
+
+#### gemini-2.5-flash-lite
+
+**Status:** Stable
+**Alias:** `lite`
+
+**Strengths:**
+- Cheapest model in the lineup
+- Fast response times
+- Good quality for straightforward tasks
+
+**Specifications:**
+- Context window: ~1M tokens input
+- Multimodal: Yes (text, image, video, audio)
+
+**Best for:**
+- Ultra-budget batch processing
+- Simple classification and extraction
+- Maximum throughput at minimum cost
+
+**Pricing:**
+- Input: $0.10 / 1M tokens
+- Output: $0.40 / 1M tokens
+
+#### gemini-2.5-pro
+
+**Status:** Stable
+**Alias:** `stable-pro`
+
+**Strengths:**
+- Advanced reasoning with production stability
+- Deep reasoning and coding capabilities
+- Well-documented behavior
+
+**Specifications:**
+- Context window: ~1M tokens input
+- Long context surcharge: 2x above 200K tokens
+- Multimodal: Yes (text, image, video, audio)
+
+**Best for:**
+- Complex tasks requiring production stability
 - Long document processing
-- Tasks requiring deep understanding
 - Quality-critical applications
 
-**Pricing (approximate):**
-- Input: $1.25 / 1M tokens
-- Output: $5.00 / 1M tokens
+**Pricing:**
+- Input: $1.25 / 1M tokens (≤200K), $2.50 (>200K)
+- Output: $10.00 / 1M tokens (≤200K), $20.00 (>200K)
 
-### gemini-1.5-flash
+---
+
+### Image Generation Models
+
+#### gemini-3-pro-image
 
 **Status:** Production
 
-**Strengths:**
-- Balanced speed and quality
-- Good general-purpose model
-- Reliable for most tasks
+High-fidelity image generation with reasoning-enhanced composition:
+- Legible text rendering in images
+- Complex multi-turn editing workflows
+- Character consistency using up to 14 reference inputs
 
-**Specifications:**
-- Context window: ~1M tokens input
-- Output limit: ~8K tokens
-- Multimodal: Yes (text, image, video, audio)
+**Note:** Image models require different API parameters than text models.
 
-**Best for:**
-- General-purpose tasks
-- When 2.0-flash-exp feels too experimental
-- Production stability required
+#### nano-banana-2
 
-**Pricing (approximate):**
-- Input: $0.075 / 1M tokens
-- Output: $0.30 / 1M tokens
+**Status:** Preview (Feb 2026)
+
+Updated image generation built on Gemini 3.1 Flash Image platform:
+- Faster performance than previous generation
+- Sharper image-editing capabilities
+- Optimized for speed over maximum quality
+
+---
 
 ## Model Selection Guide
 
 ```
-Need structured JSON output? → gemini-2.0-flash-exp
-Processing >1M tokens? → gemini-1.5-pro
-Complex reasoning required? → gemini-1.5-pro
-Cost is primary concern? → gemini-1.5-flash
-Experimental OK, want latest? → gemini-2.0-flash-exp
-Production stability critical? → gemini-1.5-flash
+Default / general purpose?        → gemini-3-flash-preview (alias: flash)
+Need maximum reasoning quality?   → gemini-3.1-pro-preview (alias: pro)
+Production stability required?    → gemini-2.5-flash (alias: stable-flash)
+Ultra-budget batch processing?    → gemini-2.5-flash-lite (alias: lite)
+Complex + stable production?      → gemini-2.5-pro (alias: stable-pro)
+Image generation?                 → gemini-3-pro-image or nano-banana-2
 ```
 
 ## Multimodal Capabilities
 
-All models support:
+All text models support:
 - **Images:** JPEG, PNG, WebP, HEIC, HEIF
 - **Video:** MP4, MPEG, MOV, AVI, FLV, MPG, WebM, WMV, 3GPP
 - **Audio:** WAV, MP3, AIFF, AAC, OGG, FLAC
 
-**Input limits:**
-- Images: Up to 16 per request
-- Video: Up to 1 hour total
-- Audio: Up to 9.5 hours
+**Audio input pricing:**
+- Audio input is priced higher than text (e.g., $1.00/1M tokens for Flash models)
 
-## Context Windows
+## Deprecated / Retired Models
 
-**Understanding token counts:**
-- 1 token ≈ 4 characters
-- 1 token ≈ 0.75 words
-- 100 tokens ≈ 75 words
+| Model | Status | Migration Target |
+|---|---|---|
+| gemini-3-pro-preview | Deprecated (shutdown March 9, 2026) | gemini-3.1-pro-preview |
+| gemini-2.0-flash-exp | Retiring June 1, 2026 | gemini-3-flash-preview |
+| gemini-2.0-flash | Retiring June 1, 2026 | gemini-2.5-flash |
+| gemini-2.0-flash-lite | Retiring June 1, 2026 | gemini-2.5-flash-lite |
+| gemini-1.5-pro | Retired (404) | gemini-2.5-pro |
+| gemini-1.5-flash | Retired (404) | gemini-2.5-flash |
+| gemini-1.0-* | Retired (404) | — |
 
-**Examples:**
-- Short email: ~200 tokens
-- Blog post: ~800 tokens
-- Research paper: ~8,000 tokens
-- Full book: ~100,000 tokens
+## Cost Optimization Tips
+
+- **Batch API:** 50% discount on all paid models for async processing
+- **Context caching:** Up to 75-90% savings for repeated large prompts
+- **Long context:** Pro models charge 2x above 200K tokens — keep prompts concise
+- **Free tier:** All models include up to 1,000 daily requests on the free tier
 
 ## Rate Limits
 
@@ -121,66 +206,3 @@ Vary by API tier (default free tier):
 - **Requests per day:** 1,500
 
 Client automatically handles rate limiting with exponential backoff.
-
-## Performance Characteristics
-
-**Latency (typical):**
-- gemini-2.0-flash-exp: 1-2s
-- gemini-1.5-flash: 2-3s
-- gemini-1.5-pro: 3-5s
-
-**Throughput (parallel requests):**
-- Rate limit is shared across parallel requests
-- Optimal concurrency: 5-10 workers
-- Use `max_workers` parameter in `invoke_parallel()`
-
-## Versioning
-
-**Model naming:**
-- `-exp` suffix: Experimental, may change
-- `-latest` suffix: Auto-updates to latest version
-- Version numbers (e.g., `001`): Stable, frozen
-
-**Recommendation:** Use explicit model names for reproducibility.
-
-## Safety Settings
-
-Default safety settings are moderate. Adjust if needed:
-
-```python
-import google.generativeai as genai
-
-safety_settings = [
-    {
-        "category": "HARM_CATEGORY_HARASSMENT",
-        "threshold": "BLOCK_MEDIUM_AND_ABOVE"
-    },
-    # ... other categories
-]
-
-model = genai.GenerativeModel(
-    model_name="gemini-2.0-flash-exp",
-    safety_settings=safety_settings
-)
-```
-
-Categories:
-- HARM_CATEGORY_HARASSMENT
-- HARM_CATEGORY_HATE_SPEECH
-- HARM_CATEGORY_SEXUALLY_EXPLICIT
-- HARM_CATEGORY_DANGEROUS_CONTENT
-
-Thresholds:
-- BLOCK_NONE
-- BLOCK_LOW_AND_ABOVE
-- BLOCK_MEDIUM_AND_ABOVE
-- BLOCK_ONLY_HIGH
-
-## Experimental Features
-
-**gemini-2.0-flash-exp only:**
-- Native JSON Schema with property ordering
-- Enhanced multimodal understanding
-- Improved instruction following
-
-**Note:** Experimental features may change without notice.

--- a/invoking-gemini/scripts/_MAP.md
+++ b/invoking-gemini/scripts/_MAP.md
@@ -5,8 +5,8 @@
 
 ### gemini_client.py
 > Imports: `json, os, time, pathlib, typing`
-- **get_cf_credentials** (f) `()` :87
-- **get_google_api_key** (f) `()` :120
+- **get_cf_credentials** (f) `()` :106
+- **get_google_api_key** (f) `()` :139
 - **invoke_gemini** (f) `(
     prompt: str,
     model: str = DEFAULT_MODEL,
@@ -15,20 +15,20 @@
     top_p: Optional[float] = None,
     top_k: Optional[int] = None,
     image_path: Optional[str] = None,
-)` :301
+)` :346
 - **invoke_with_structured_output** (f) `(
     prompt: str,
     pydantic_model: Type,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     image_path: Optional[str] = None,
-)` :384
+)` :427
 - **invoke_parallel** (f) `(
     prompts: list,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     max_workers: int = 5,
-)` :462
-- **get_available_models** (f) `()` :504
-- **verify_setup** (f) `()` :509
+)` :503
+- **get_available_models** (f) `()` :546
+- **verify_setup** (f) `()` :559
 


### PR DESCRIPTION
## Summary

- **Replaced deprecated model registry** — removed gemini-2.0-flash-exp, gemini-2.0-flash, gemini-1.5-pro, gemini-1.5-flash (all retired or retiring)
- **Added current models** — Gemini 3 Flash Preview (default), Gemini 3.1 Pro Preview, Gemini 2.5 Flash/Flash-Lite/Pro as stable production tier
- **Added image generation models** — gemini-3-pro-image and nano-banana-2 in new `IMAGE_MODELS` registry
- **Added convenience aliases** — `flash`, `pro`, `lite`, `stable-flash`, `stable-pro` via `MODEL_ALIASES` dict and `_resolve_model()` helper
- **Updated all documentation** — SKILL.md (v0.2.0), references/models.md (full rewrite with pricing), references/advanced.md, references/examples.md
- **Updated all docstrings** — lines 193, 318, 397, 473 per issue specification

Closes #338

## Test plan

- [ ] Verify `gemini-3-flash-preview` and `gemini-2.5-flash` work via CF AI Gateway (confirmed in #320)
- [ ] Test alias resolution: `invoke_gemini("test", model="flash")` resolves correctly
- [ ] Test `get_available_models()` returns new dict structure with text/image/aliases keys
- [ ] Verify invalid model names still raise `ValueError` with helpful message

https://claude.ai/code/session_01CR8MaDq8XEjJm1q8Dy6nme