### PR TITLE
feat(#340): add image generation support + fix IMAGE_MODELS registry

### DIFF
--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `invoking-gemini` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-03-01
+
+### Added
+
+- `generate_image()` function for native image generation via Gemini image models
+- `image` and `image-pro` model aliases for image generation
+- `nano-banana` (gemini-2.5-flash-image) to IMAGE_MODELS registry
+- Image generation documentation in SKILL.md with prompt patterns and examples
+
+### Fixed
+
+- IMAGE_MODELS registry now maps display names to actual API model IDs
+  (was mapping names to themselves, causing 404 errors)
+- `nano-banana-2` → `gemini-3.1-flash-image-preview`
+- `nano-banana-pro` → `gemini-3-pro-image-preview`
+- `nano-banana` → `gemini-2.5-flash-image`
+
 ## [0.2.0] - 2026-03-01
 
 ### Added

--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -2,7 +2,7 @@
 name: invoking-gemini
 description: Invokes Google Gemini models for structured outputs, multi-modal tasks, and Google-specific features. Use when users request Gemini, structured JSON output, Google API integration, or cost-effective parallel processing.
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # Invoking Gemini
@@ -64,9 +64,16 @@ Delegate tasks to Google's Gemini models when they offer advantages over Claude.
 
 ### Image Generation Models
 
-**gemini-3-pro-image**: High-fidelity image generation with text rendering and multi-turn editing
+**nano-banana-2** (Default image model): Fast image generation/editing built on Gemini 3.1 Flash Image
+- API model: `gemini-3.1-flash-image-preview`
+- Alias: `image`
 
-**nano-banana-2**: Fast image generation/editing built on Gemini 3.1 Flash Image
+**nano-banana-pro**: High-fidelity image generation with text rendering and multi-turn editing
+- API model: `gemini-3-pro-image-preview`
+- Alias: `image-pro`
+
+**nano-banana**: Image generation on Gemini 2.5 Flash
+- API model: `gemini-2.5-flash-image`
 
 See [references/models.md](references/models.md) for full model details and pricing.
 
@@ -240,6 +247,56 @@ result = invoke_with_structured_output(
 ```
 
 See [references/advanced.md](references/advanced.md) for more patterns.
+
+## Image Generation
+
+Generate images using Gemini's native image models:
+
+```python
+from gemini_client import generate_image
+
+# Basic generation
+result = generate_image("A watercolor painting of a mountain lake at sunset")
+print(result["path"])     # /mnt/user-data/outputs/gemini_image_1740000000.png
+print(result["caption"])  # Optional text the model returns alongside the image
+```
+
+### Model Selection
+
+```python
+# Fast generation (default) — nano-banana-2 → gemini-3.1-flash-image-preview
+result = generate_image("A red bicycle", model="nano-banana-2")
+
+# High-fidelity — nano-banana-pro → gemini-3-pro-image-preview
+result = generate_image("A red bicycle", model="image-pro")
+```
+
+### Custom Output Path
+
+```python
+result = generate_image(
+    "A logo for a coffee shop called 'Bean There'",
+    output_path="/mnt/user-data/outputs/coffee_logo.png"
+)
+```
+
+### Effective Prompt Patterns
+
+- **Be specific about style:** "A watercolor painting of..." vs "A picture of..."
+- **Include composition details:** "centered, wide angle, high contrast"
+- **Specify text rendering:** "A poster with the text 'SALE' in bold red letters"
+- **Multi-turn editing:** Generate once, then refine with follow-up prompts
+
+### Return Value
+
+```python
+{
+    "path": "/mnt/user-data/outputs/gemini_image_1740000000.png",
+    "caption": "Optional descriptive text from the model"  # or None
+}
+```
+
+Returns `None` on failure (credentials missing, API error, no image in response).
 
 ## Comparison: Gemini vs Claude
 

--- a/invoking-gemini/_MAP.md
+++ b/invoking-gemini/_MAP.md
@@ -10,7 +10,9 @@
 
 ### CHANGELOG.md
 - invoking-gemini - Changelog `h1` :1
-- [0.1.0] - 2026-03-01 `h2` :5
+- [0.3.0] - 2026-03-01 `h2` :5
+- [0.2.0] - 2026-03-01 `h2` :22
+- [0.1.0] - 2026-03-01 `h2` :28
 
 ### README.md
 - invoking-gemini `h1` :1
@@ -19,16 +21,17 @@
 - Invoking Gemini `h1` :8
 - When to Use Gemini `h2` :12
 - Available Models `h2` :34
-- Setup `h2` :73
-- Basic Usage `h2` :111
-- Structured Output `h2` :128
-- Parallel Invocation `h2` :158
-- Error Handling `h2` :187
-- Advanced Features `h2` :210
-- Comparison: Gemini vs Claude `h2` :244
-- Token Efficiency Pattern `h2` :263
-- Limitations `h2` :284
-- Examples `h2` :300
-- Troubleshooting `h2` :308
-- Cost Comparison `h2` :336
+- Setup `h2` :80
+- Basic Usage `h2` :118
+- Structured Output `h2` :135
+- Parallel Invocation `h2` :165
+- Error Handling `h2` :194
+- Advanced Features `h2` :217
+- Image Generation `h2` :251
+- Comparison: Gemini vs Claude `h2` :301
+- Token Efficiency Pattern `h2` :320
+- Limitations `h2` :341
+- Examples `h2` :357
+- Troubleshooting `h2` :365
+- Cost Comparison `h2` :393
 

--- a/invoking-gemini/references/_MAP.md
+++ b/invoking-gemini/references/_MAP.md
@@ -30,9 +30,9 @@
 ### models.md
 - Gemini Models Reference `h1` :1
 - Model Comparison `h2` :5
-- Model Selection Guide `h2` :161
-- Multimodal Capabilities `h2` :172
-- Deprecated / Retired Models `h2` :182
-- Cost Optimization Tips `h2` :194
-- Rate Limits `h2` :201
+- Model Selection Guide `h2` :175
+- Multimodal Capabilities `h2` :187
+- Deprecated / Retired Models `h2` :197
+- Cost Optimization Tips `h2` :209
+- Rate Limits `h2` :216
 

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -136,25 +136,39 @@ Detailed information about available Gemini models (as of March 2026).
 
 ### Image Generation Models
 
-#### gemini-3-pro-image
+#### nano-banana-2
 
-**Status:** Production
+**Status:** Preview
+**API Model ID:** `gemini-3.1-flash-image-preview`
+**Alias:** `image`
+
+Fast image generation/editing built on Gemini 3.1 Flash Image platform:
+- Faster performance than previous generation
+- Sharper image-editing capabilities
+- Optimized for speed over maximum quality
+- Default image model in `generate_image()`
+
+#### nano-banana-pro
+
+**Status:** Preview
+**API Model ID:** `gemini-3-pro-image-preview`
+**Alias:** `image-pro`
 
 High-fidelity image generation with reasoning-enhanced composition:
 - Legible text rendering in images
 - Complex multi-turn editing workflows
 - Character consistency using up to 14 reference inputs
 
-**Note:** Image models require different API parameters than text models.
+#### nano-banana
 
-#### nano-banana-2
+**Status:** Stable
+**API Model ID:** `gemini-2.5-flash-image`
 
-**Status:** Preview (Feb 2026)
+Image generation on the Gemini 2.5 Flash platform:
+- Production-grade stability
+- Good balance of quality and speed
 
-Updated image generation built on Gemini 3.1 Flash Image platform:
-- Faster performance than previous generation
-- Sharper image-editing capabilities
-- Optimized for speed over maximum quality
+**Note:** Image models require `responseModalities: ["IMAGE", "TEXT"]` — handled automatically by `generate_image()`.
 
 ---
 
@@ -166,7 +180,8 @@ Need maximum reasoning quality?   → gemini-3.1-pro-preview (alias: pro)
 Production stability required?    → gemini-2.5-flash (alias: stable-flash)
 Ultra-budget batch processing?    → gemini-2.5-flash-lite (alias: lite)
 Complex + stable production?      → gemini-2.5-pro (alias: stable-pro)
-Image generation?                 → gemini-3-pro-image or nano-banana-2
+Image generation (fast)?           → nano-banana-2 (alias: image)
+Image generation (high-fidelity)?  → nano-banana-pro (alias: image-pro)
 ```
 
 ## Multimodal Capabilities

--- a/invoking-gemini/scripts/_MAP.md
+++ b/invoking-gemini/scripts/_MAP.md
@@ -5,8 +5,8 @@
 
 ### gemini_client.py
 > Imports: `json, os, time, pathlib, typing`
-- **get_cf_credentials** (f) `()` :106
-- **get_google_api_key** (f) `()` :139
+- **get_cf_credentials** (f) `()` :109
+- **get_google_api_key** (f) `()` :142
 - **invoke_gemini** (f) `(
     prompt: str,
     model: str = DEFAULT_MODEL,
@@ -15,20 +15,26 @@
     top_p: Optional[float] = None,
     top_k: Optional[int] = None,
     image_path: Optional[str] = None,
-)` :346
+)` :351
+- **generate_image** (f) `(
+    prompt: str,
+    output_path: Optional[str] = None,
+    model: str = "nano-banana-2",
+    temperature: float = 0.7,
+)` :432
 - **invoke_with_structured_output** (f) `(
     prompt: str,
     pydantic_model: Type,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     image_path: Optional[str] = None,
-)` :427
+)` :581
 - **invoke_parallel** (f) `(
     prompts: list,
     model: str = DEFAULT_MODEL,
     temperature: float = 0.7,
     max_workers: int = 5,
-)` :503
-- **get_available_models** (f) `()` :546
-- **verify_setup** (f) `()` :559
+)` :657
+- **get_available_models** (f) `()` :700
+- **verify_setup** (f) `()` :713
 


### PR DESCRIPTION
## Summary

- **Fix IMAGE_MODELS registry bug**: Display names were mapping to themselves instead of actual API model IDs, causing 404 errors. Now correctly maps:
  - `nano-banana-2` → `gemini-3.1-flash-image-preview`
  - `nano-banana-pro` → `gemini-3-pro-image-preview`
  - `nano-banana` → `gemini-2.5-flash-image`
- **Add `generate_image()` function**: New public API for image generation with support for both CF Gateway and SDK fallback paths. Sends `responseModalities: ["IMAGE", "TEXT"]`, extracts base64 image data, auto-generates output paths, and returns `{"path": str, "caption": str|None}`
- **Add `image`/`image-pro` aliases** and fix `_resolve_model()` to chain alias → display name → API model ID
- **Add documentation** to SKILL.md with model selection guidance, effective prompt patterns, and usage examples

## Test plan

- [x] AST parse verification — no syntax errors
- [x] `_resolve_model()` correctly chains: `"image"` → `"nano-banana-2"` → `"gemini-3.1-flash-image-preview"`
- [x] All text model aliases still resolve correctly (`flash`, `pro`, `lite`, etc.)
- [x] `generate_image()` rejects text models with clear ValueError
- [x] `generate_image()` accepts valid image aliases and display names
- [x] `get_available_models()` returns all three image models
- [ ] Live API test: `generate_image("A red bicycle")` produces valid PNG (requires credentials)

Closes #340

https://claude.ai/code/session_01PE1uTDX2rznf5AMaYjv6N2