### PR TITLE
fix: remove tiling-tree workarounds for #311 and #312

### DIFF
--- a/orchestrating-agents/_MAP.md
+++ b/orchestrating-agents/_MAP.md
@@ -11,7 +11,8 @@
 ### CHANGELOG.md
 - orchestrating-agents - Changelog `h1` :1
 - [0.3.0] - 2026-03-05 `h2` :5
-- [0.2.0] - 2026-02-28 `h2` :21
+- [0.3.0] - 2026-03-05 `h2` :12
+- [0.2.0] - 2026-02-28 `h2` :28
 
 ### README.md
 - orchestrating-agents `h1` :1

--- a/orchestrating-agents/scripts/_MAP.md
+++ b/orchestrating-agents/scripts/_MAP.md
@@ -38,7 +38,7 @@
     max_workers: int = 5,
     shared_system: Union[str, list[dict], None] = None,
     cache_shared_system: bool = False
-)` :403
+)` :406
 - **invoke_parallel_streaming** (f) `(
     prompts: list[dict],
     callbacks: list[callable] = None,
@@ -47,20 +47,20 @@
     max_workers: int = 5,
     shared_system: Union[str, list[dict], None] = None,
     cache_shared_system: bool = False
-)` :532
-- **StallDetector** (C) :603
-  - **__init__** (m) `(self, timeout: float = 60.0, on_stall: callable = None)` :616
-  - **register** (m) `(self, task_id: str)` :624
-  - **heartbeat** (m) `(self, task_id: str)` :629
-  - **unregister** (m) `(self, task_id: str)` :635
-  - **check_stalled** (m) `(self)` :640
-  - **start_monitoring** (m) `(self, poll_interval: float = 5.0)` :656
-  - **stop_monitoring** (m) `(self)` :679
-- **InterruptToken** (C) :687
-  - **__init__** (m) `(self)` :689
-  - **interrupt** (m) `(self)` :692
-  - **is_interrupted** (m) `(self)` :696
-  - **reset** (m) `(self)` :700
+)` :535
+- **StallDetector** (C) :606
+  - **__init__** (m) `(self, timeout: float = 60.0, on_stall: callable = None)` :619
+  - **register** (m) `(self, task_id: str)` :627
+  - **heartbeat** (m) `(self, task_id: str)` :632
+  - **unregister** (m) `(self, task_id: str)` :638
+  - **check_stalled** (m) `(self)` :643
+  - **start_monitoring** (m) `(self, poll_interval: float = 5.0)` :659
+  - **stop_monitoring** (m) `(self)` :682
+- **InterruptToken** (C) :690
+  - **__init__** (m) `(self)` :692
+  - **interrupt** (m) `(self)` :695
+  - **is_interrupted** (m) `(self)` :699
+  - **reset** (m) `(self)` :703
 - **invoke_parallel_interruptible** (f) `(
     prompts: list[dict],
     interrupt_token: InterruptToken = None,
@@ -69,8 +69,8 @@
     max_workers: int = 5,
     shared_system: Union[str, list[dict], None] = None,
     cache_shared_system: bool = False
-)` :705
-- **ConversationThread** (C) :781
+)` :708
+- **ConversationThread** (C) :784
   - **__init__** (m) `(
         self,
         system: Union[str, list[dict], None] = None,
@@ -80,18 +80,18 @@
         cache_system: bool = True,
         max_turns: int | None = None,
         continuation_prompt: str | None = None
-    )` :793
-  - **send** (m) `(self, user_message: Union[str, list[dict]], cache_history: bool = True)` :827
+    )` :796
+  - **send** (m) `(self, user_message: Union[str, list[dict]], cache_history: bool = True)` :830
   - **send_continuation** (m) `(
         self,
         guidance: str | None = None,
         cache_history: bool = True
-    )` :881
-  - **get_messages** (m) `(self)` :916
-  - **clear** (m) `(self)` :920
-  - **__len__** (m) `(self)` :924
-- **get_available_models** (f) `()` :929
-- **parse_json_response** (f) `(raw: str)` :946
+    )` :884
+  - **get_messages** (m) `(self)` :919
+  - **clear** (m) `(self)` :923
+  - **__len__** (m) `(self)` :927
+- **get_available_models** (f) `()` :932
+- **parse_json_response** (f) `(raw: str)` :949
 - **invoke_claude_json** (f) `(
     prompt: Union[str, list[dict]],
     model: str = "claude-sonnet-4-6",
@@ -102,7 +102,7 @@
     cache_prompt: bool = False,
     messages: list[dict] | None = None,
     **kwargs
-)` :972
+)` :975
 
 ### orchestration.py
 > Imports: `time, threading, typing, concurrent.futures, claude_client`...

--- a/tiling-tree/SKILL.md
+++ b/tiling-tree/SKILL.md
@@ -2,7 +2,7 @@
 name: tiling-tree
 description: Exhaustive problem space exploration using the MIT Synthetic Neurobiology "tiling tree" method. Partitions a problem into MECE (Mutually Exclusive, Collectively Exhaustive) subsets recursively via parallel subagents, then evaluates leaf ideas against specified criteria. Use when users say "tiling tree", "tile the solution space", "exhaustively explore approaches to", "what are all the ways to", or request a MECE breakdown of a problem. Requires orchestrating-agents skill.
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   depends_on: orchestrating-agents
 ---
 
@@ -30,12 +30,8 @@ Requires `orchestrating-agents` skill to be installed. Load it first:
 ```python
 import sys
 sys.path.insert(0, '/mnt/skills/user/orchestrating-agents/scripts')
-sys.path.insert(0, '/home/claude')  # for muninn_utils shim if needed
 
-import claude_client as cc
-# Apply API key shim if credentials aren't in ANTHROPIC_API_KEY env var:
-# from muninn_utils.orchestrating_agents_shim import patch_orchestrating_agents
-# patch_orchestrating_agents(cc)
+from claude_client import invoke_claude, invoke_parallel, parse_json_response
 ```
 
 ## Running the Tiling Tree
@@ -76,10 +72,6 @@ Parallel splitting happens level-by-level (not node-by-node), so a depth-2 tree 
 A markdown file containing:
 1. Full tree diagram with split criteria and evaluation scores at leaves
 2. Ranked leaf table sorted by overall score
-
-## JSON Parsing Note
-
-Branch agents return JSON. Claude frequently wraps JSON in markdown fences despite instructions. The script handles this with `_parse_json()`. When issue #312 is resolved and `parse_json_response()` is added to `orchestrating-agents`, update the import accordingly.
 
 ## Interpreting Results
 

--- a/tiling-tree/_MAP.md
+++ b/tiling-tree/_MAP.md
@@ -12,10 +12,9 @@
 - Core Concept `h2` :13
 - When to Use `h2` :19
 - Setup `h2` :26
-- Running the Tiling Tree `h2` :41
-- Parameters `h2` :55
-- Architecture `h2` :66
-- Output `h2` :74
-- JSON Parsing Note `h2` :80
-- Interpreting Results `h2` :84
+- Running the Tiling Tree `h2` :37
+- Parameters `h2` :51
+- Architecture `h2` :62
+- Output `h2` :70
+- Interpreting Results `h2` :76
 

--- a/tiling-tree/scripts/_MAP.md
+++ b/tiling-tree/scripts/_MAP.md
@@ -5,10 +5,10 @@
 
 ### tiling_tree.py
 > Imports: `sys, json, argparse, dataclasses, typing`
-- **build_tree** (f) `(problem: str, max_depth: int = 2)` :138
-- **collect_leaves** (f) `(node: Node)` :202
-- **evaluate_leaves** (f) `(leaves: list, criteria: list[str])` :208
-- **render_tree** (f) `(node: Node, prefix: str = "", is_last: bool = True)` :234
-- **render_markdown** (f) `(root: Node, problem: str, criteria: list[str])` :261
-- **main** (f) `()` :288
+- **build_tree** (f) `(problem: str, max_depth: int = 2)` :116
+- **collect_leaves** (f) `(node: Node)` :180
+- **evaluate_leaves** (f) `(leaves: list, criteria: list[str])` :186
+- **render_tree** (f) `(node: Node, prefix: str = "", is_last: bool = True)` :212
+- **render_markdown** (f) `(root: Node, problem: str, criteria: list[str])` :239
+- **main** (f) `()` :266
 

--- a/tiling-tree/scripts/tiling_tree.py
+++ b/tiling-tree/scripts/tiling_tree.py
@@ -19,19 +19,10 @@ from typing import Optional
 sys.path.insert(0, '/mnt/skills/user/orchestrating-agents/scripts')
 
 try:
-    import claude_client as cc
-    from claude_client import invoke_claude, invoke_parallel
+    from claude_client import invoke_claude, invoke_parallel, parse_json_response
 except ImportError as e:
     print(f"ERROR: orchestrating-agents skill not found at /mnt/skills/user/orchestrating-agents/\n{e}")
     sys.exit(1)
-
-# Apply key shim if needed (workaround until issue #311 is resolved)
-try:
-    sys.path.insert(0, '/home/claude')
-    from muninn_utils.orchestrating_agents_shim import patch_orchestrating_agents
-    patch_orchestrating_agents(cc)
-except ImportError:
-    pass  # Shim not available; assume ANTHROPIC_API_KEY is set in environment
 
 
 # ── Data model ────────────────────────────────────────────────────────────────
@@ -48,19 +39,6 @@ class Node:
     is_leaf: bool = False
     exclusions: str = ""
     evaluation: dict = field(default_factory=dict)
-
-
-# ── JSON parsing (workaround for issue #312) ──────────────────────────────────
-
-def _parse_json(raw: str) -> dict:
-    """Strip markdown fences and parse JSON. Workaround until orchestrating-agents
-    exposes parse_json_response() (issue #312)."""
-    raw = raw.strip()
-    if raw.startswith("```"):
-        raw = raw.split("\n", 1)[1]
-    if raw.endswith("```"):
-        raw = raw.rsplit("```", 1)[0]
-    return json.loads(raw.strip())
 
 
 # ── Prompts ───────────────────────────────────────────────────────────────────
@@ -171,7 +149,7 @@ def build_tree(problem: str, max_depth: int = 2) -> Node:
         next_frontier = []
         for node, raw in zip(to_split, raw_results):
             try:
-                data = _parse_json(raw)
+                data = parse_json_response(raw)
             except (json.JSONDecodeError, Exception) as e:
                 print(f"  ✗ Parse failed for '{node.label}': {e}", file=sys.stderr)
                 node.is_leaf = True
@@ -215,7 +193,7 @@ def evaluate_leaves(leaves: list, criteria: list[str]) -> None:
             max_tokens=4096,
             temperature=0.8,
         )
-        data = _parse_json(raw)
+        data = parse_json_response(raw)
         leaf_map = {l.id: l for l in leaves}
         for ev in data.get("evaluations", []):
             node = leaf_map.get(ev["id"])


### PR DESCRIPTION
## Summary
- Removed the `patch_orchestrating_agents` shim block that worked around API key discovery before #311 was resolved
- Removed the local `_parse_json()` function, now importing `parse_json_response` from `claude_client` (#312)
- Cleaned up SKILL.md: removed shim setup instructions and JSON Parsing Note section
- Bumped version to 1.0.1

## Test plan
- [x] Python syntax verified via `ast.parse()`
- [ ] Run tiling tree against a simple problem to verify end-to-end functionality

Closes #314

https://claude.ai/code/session_018xXwmU8KqdG7WPSHz94qe9