### PR TITLE
feat(perch): add web search via Anthropic server tool, re-enable fly

### DIFF
--- a/.perch/perch.py
+++ b/.perch/perch.py
@@ -87,6 +87,7 @@ def build_session_record(
     total_input_tokens: int, total_output_tokens: int,
     errors: list, summary: str, started_at: str,
     routed_from: str = None, routed_task: str = None,
+    web_search_requests: int = 0,
 ) -> dict:
     """Build the session.json record."""
     ended_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -96,6 +97,8 @@ def build_session_record(
         cost = (total_input_tokens * 0.80 + total_output_tokens * 4.0) / 1_000_000
     else:
         cost = (total_input_tokens * 3.0 + total_output_tokens * 15.0) / 1_000_000
+    # Web search: $10 per 1K searches
+    cost += web_search_requests * 0.01
 
     record = {
         "task": task,
@@ -106,6 +109,7 @@ def build_session_record(
         "tool_calls": tool_calls,
         "total_input_tokens": total_input_tokens,
         "total_output_tokens": total_output_tokens,
+        "web_search_requests": web_search_requests,
         "estimated_cost_usd": round(cost, 4),
         "errors": errors,
         "summary": summary,
@@ -162,6 +166,7 @@ def run_loop(client: anthropic.Anthropic, model: str, system_prompt: str,
 
     total_input_tokens = 0
     total_output_tokens = 0
+    web_search_requests = 0
     all_tool_calls = []
     errors = []
     final_summary = ""
@@ -187,6 +192,7 @@ def run_loop(client: anthropic.Anthropic, model: str, system_prompt: str,
         # Track token usage
         total_input_tokens += response.usage.input_tokens
         total_output_tokens += response.usage.output_tokens
+        web_search_requests += getattr(response.usage, "web_search_requests", 0) or 0
 
         # Process response content
         assistant_content = response.content
@@ -200,13 +206,27 @@ def run_loop(client: anthropic.Anthropic, model: str, system_prompt: str,
             elif block.type == "tool_use":
                 log(f"ASSISTANT: [tool_use] {block.name} {json.dumps(block.input)[:100]}")
                 tool_uses.append(block)
+            elif block.type == "server_tool_use":
+                # Server-side tool (e.g. web_search) — Anthropic executes these,
+                # we just log and let the response flow through.
+                log(f"ASSISTANT: [server_tool_use] {block.name} (id={block.id})")
+            elif block.type == "web_search_tool_result":
+                # Result from server-side web search — already in assistant_content,
+                # included in conversation history automatically.
+                log(f"ASSISTANT: [web_search_result] (id={block.tool_use_id})")
 
-        # If no tool calls, the session is done
-        if not tool_uses:
+        # If no local tool calls and stop_reason is end_turn, the session is done
+        if not tool_uses and response.stop_reason == "end_turn":
             log(f"LOOP END: {turn} turns, {len(all_tool_calls)} tool calls", always=True)
             break
 
-        # Execute tools and build results
+        # If no local tool calls but stop_reason is tool_use (server tool),
+        # continue the loop — the server tool results are already in the content
+        if not tool_uses:
+            log(f"LOOP CONTINUE: server tool processed, no local tools to execute")
+            continue
+
+        # Execute local tools and build results
         tool_results = []
         for tu in tool_uses:
             t0 = time.monotonic()
@@ -241,6 +261,7 @@ def run_loop(client: anthropic.Anthropic, model: str, system_prompt: str,
         "tool_calls": all_tool_calls,
         "input_tokens": total_input_tokens,
         "output_tokens": total_output_tokens,
+        "web_search_requests": web_search_requests,
         "errors": errors,
         "summary": final_summary,
     }
@@ -317,11 +338,13 @@ def run_perch(task: str, model: str, max_turns: int) -> dict:
         total_output_tokens=result["output_tokens"],
         errors=result["errors"], summary=result["summary"][:500],
         started_at=started_at,
+        web_search_requests=result["web_search_requests"],
     )
 
     cost = record["estimated_cost_usd"]
     log(f"SUMMARY: {result['turns']} turns, {len(result['tool_calls'])} tool calls, "
-        f"{result['input_tokens']}+{result['output_tokens']} tokens, ${cost:.4f}",
+        f"{result['input_tokens']}+{result['output_tokens']} tokens, "
+        f"{result['web_search_requests']} web searches, ${cost:.4f}",
         always=True)
 
     store_session_log(task, model, result["turns"], result["tool_calls"],
@@ -373,6 +396,7 @@ def _run_dispatch(client, model, boot_output, tools, decision_budget,
             summary=decision_result["summary"][:500],
             started_at=started_at,
             routed_from="dispatch", routed_task="homework",
+            web_search_requests=decision_result["web_search_requests"],
         )
 
         cost = record["estimated_cost_usd"]
@@ -404,6 +428,7 @@ def _run_dispatch(client, model, boot_output, tools, decision_budget,
     total_tool_calls = decision_result["tool_calls"] + task_result["tool_calls"]
     total_input = decision_result["input_tokens"] + task_result["input_tokens"]
     total_output = decision_result["output_tokens"] + task_result["output_tokens"]
+    total_web_searches = decision_result["web_search_requests"] + task_result["web_search_requests"]
     all_errors = decision_result["errors"] + task_result["errors"]
 
     record = build_session_record(
@@ -413,6 +438,7 @@ def _run_dispatch(client, model, boot_output, tools, decision_budget,
         errors=all_errors, summary=task_result["summary"][:500],
         started_at=started_at,
         routed_from="dispatch", routed_task=chosen_task,
+        web_search_requests=total_web_searches,
     )
 
     cost = record["estimated_cost_usd"]

--- a/.perch/prompts/tasks/dispatch.md
+++ b/.perch/prompts/tasks/dispatch.md
@@ -28,6 +28,7 @@ The runner does not have a "homework" task type — this signals you to execute 
 
 - **sleep**: Memory maintenance — pruning, connections, deduplication. Run if >24h since last sleep, or if prior sessions noted issues.
 - **zeitgeist**: News and discourse awareness via Bluesky feeds. Run if >24h since last scan, or if something notable is happening.
+- **fly**: Autonomous exploration — follow intellectual threads, search the web, make connections. Run if there's an interesting thread to pursue, a question worth researching, or if sleep and zeitgeist are both recent.
 
 If nothing is pressing, default to **sleep**.
 

--- a/.perch/prompts/tasks/fly.md
+++ b/.perch/prompts/tasks/fly.md
@@ -13,28 +13,34 @@ You are exploring freely — following intellectual threads, making connections,
 Use your tools in this priority order:
 
 1. **recall** — What do you already know? Connect new findings to existing memories.
-2. **bsky_feed** — Read curated feeds (ai_list, paperskygest) for recent discourse.
-3. **bsky_search** — Search Bluesky for specific topics. Use SHORT queries (2-3 words).
-4. **fetch_url** — Follow promising links from feed/search results to full articles.
+2. **web_search** — Search the web for your topic. This is a server-side tool — just call it and the results appear automatically. Use it for broad research, finding articles, papers, and recent developments.
+3. **bsky_feed** — Read curated feeds (ai_list, paperskygest) for recent discourse.
+4. **bsky_search** — Search Bluesky for specific topics. Use SHORT queries (2-3 words).
+5. **fetch_url** — Follow promising links from web search, feed, or search results to full articles.
 
-#### CRITICAL: Search pivot rule
+#### Web search tips
+
+- `web_search` is your primary exploration tool — it searches the entire web, not just one platform.
+- Use it early to orient on a topic before diving into Bluesky or specific URLs.
+- You get up to 5 web searches per session. Use them deliberately — each one should advance your thread.
+- Combine with `fetch_url` to read full articles from search results.
+
+#### CRITICAL: Bluesky search pivot rule
 
 bsky_search covers Bluesky only — it has limited coverage of most topics. Apply this rule strictly:
 
 - If a bsky_search returns empty or near-empty results (under 100 chars), that query has no Bluesky coverage.
 - After **2 empty bsky_search results in a row**, STOP searching Bluesky for that subtopic. Do not rephrase and retry — the content is not there.
-- Pivot to: `bsky_feed` for curated content, `recall` for deeper memory exploration, or `fetch_url` on a known URL (blog, arxiv, etc.) related to your thread.
+- Pivot to: `web_search` for broader results, `bsky_feed` for curated content, `recall` for deeper memory exploration, or `fetch_url` on a known URL.
 - You have a limited turn budget. Every search that returns nothing is a wasted turn.
 
 #### Good exploration pattern
 
 ```
 recall(thread topic)          → find what you know
+web_search("focused query")   → search the web for recent info
 bsky_feed("ai_list")          → scan curated content for related posts
-bsky_search("short query")    → try ONE focused search
-bsky_search("different angle")→ try ONE more if first was empty
-  → if both empty: STOP bsky_search, pivot to recall or fetch_url
-fetch_url(interesting_link)   → read something promising from feed results
+fetch_url(interesting_link)   → read something promising from search/feed results
 recall(new concept found)     → connect to existing knowledge
 ```
 
@@ -45,7 +51,7 @@ bsky_search("very specific long query")     → empty
 bsky_search("slightly different long query") → empty
 bsky_search("yet another rephrasing")        → empty
 bsky_search("desperate fourth attempt")      → empty
-  → This wastes 4 turns learning nothing. Stop after 2.
+  → This wastes 4 turns learning nothing. Use web_search instead.
 ```
 
 ### Phase 3: Synthesize

--- a/.perch/tools/__init__.py
+++ b/.perch/tools/__init__.py
@@ -8,9 +8,22 @@ from .memory import MEMORY_TOOLS, MEMORY_EXECUTORS
 from .world import WORLD_TOOLS, WORLD_EXECUTORS
 from .filesystem import FILESYSTEM_TOOLS, FILESYSTEM_EXECUTORS
 
-# All tools indexed by name
+# All local tools indexed by name
 _ALL_TOOLS = {t["name"]: t for t in MEMORY_TOOLS + WORLD_TOOLS + FILESYSTEM_TOOLS}
 _ALL_EXECUTORS = {**MEMORY_EXECUTORS, **WORLD_EXECUTORS, **FILESYSTEM_EXECUTORS}
+
+# Anthropic server-side web search tool (no local executor needed)
+WEB_SEARCH_TOOL = {
+    "type": "web_search_20250305",
+    "name": "web_search",
+    "max_uses": 5,
+    "user_location": {
+        "type": "approximate",
+        "country": "US",
+        "region": "Maryland",
+        "timezone": "America/New_York",
+    },
+}
 
 
 def get_tool_definitions(task: str) -> list:
@@ -18,8 +31,9 @@ def get_tool_definitions(task: str) -> list:
 
     All tools are available in every mode. The task prompt guides which tools
     are most relevant, but the LLM can use any tool if the situation calls for it.
+    Includes the Anthropic server-side web search tool.
     """
-    return list(_ALL_TOOLS.values())
+    return list(_ALL_TOOLS.values()) + [WEB_SEARCH_TOOL]
 
 
 def execute_tool(name: str, input: dict) -> str:


### PR DESCRIPTION
## Summary

- Adds Anthropic's native server-side `web_search_20250305` tool to perch, enabling autonomous web exploration without external search APIs (no Brave API key or Cloudflare proxy needed)
- Updates `run_loop` to handle `server_tool_use` and `web_search_tool_result` content blocks — logs them but skips local execution since Anthropic handles it server-side
- Re-enables **fly** as a routable task in dispatch, with web_search as the primary exploration tool
- Tracks `web_search_requests` in session records for cost monitoring ($10/1K searches)

## Changes

| File | What |
|------|------|
| `.perch/tools/__init__.py` | `WEB_SEARCH_TOOL` definition with `max_uses=5` and US/Maryland location |
| `.perch/perch.py` | Handle `server_tool_use`/`web_search_tool_result` blocks in loop; track `web_search_requests` in stats + session record; include search cost in estimates |
| `.perch/prompts/tasks/dispatch.md` | Re-add fly to standard decision criteria |
| `.perch/prompts/tasks/fly.md` | Add `web_search` as priority-2 tool with usage tips; update exploration patterns |

## Test plan

- [ ] Run `python .perch/perch.py --task fly --verbose` and verify web_search tool is available and server_tool_use blocks are handled correctly
- [ ] Run `python .perch/perch.py --task dispatch --verbose` and verify fly is a valid routing option
- [ ] Check session.json includes `web_search_requests` field
- [ ] Verify cost estimate includes web search pricing

Closes #357

https://claude.ai/code/session_01HXmdYqdwSc3au6nvaQcgU1