### PR TITLE
feat: add create_discussion tool for fly findings delivery

### DIFF
--- a/.github/workflows/perch.yml
+++ b/.github/workflows/perch.yml
@@ -72,6 +72,7 @@ jobs:
           TURSO_URL: ${{ secrets.TURSO_URL }}
           BSKY_HANDLE: ${{ secrets.BSKY_HANDLE }}
           BSKY_APP_PASSWORD: ${{ secrets.BSKY_APP_PASSWORD }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           # Default inputs for scheduled runs (cron doesn't pass inputs)

--- a/.perch/prompts/tasks/fly.md
+++ b/.perch/prompts/tasks/fly.md
@@ -63,8 +63,14 @@ bsky_search("desperate fourth attempt")      → empty
 
 ### Phase 4: Close
 
-Store a session log as `experience` with tags `["perch-time", "session-log", "fly"]` capturing:
-- What thread you explored and why
-- Key findings and connections made
-- Threads worth pursuing in future fly sessions
-- Self-assessment: was this exploration productive?
+1. **Post your findings** as a GitHub Discussion using `create_discussion`:
+   - Title: A clear, descriptive title for the exploration (not "Fly session 2026-03-06")
+   - Body: Your synthesis in markdown — what you explored, key findings, connections to existing knowledge, and threads worth pursuing next
+   - This is the primary deliverable. Oskar gets notified via GitHub.
+
+2. Store a session log as `experience` with tags `["perch-time", "session-log", "fly"]` capturing:
+   - What thread you explored and why
+   - Key findings and connections made
+   - Threads worth pursuing in future fly sessions
+   - Self-assessment: was this exploration productive?
+   - Link to the discussion URL returned by create_discussion

--- a/.perch/tools/world.py
+++ b/.perch/tools/world.py
@@ -97,6 +97,39 @@ WORLD_TOOLS = [
         },
     },
     {
+        "name": "create_discussion",
+        "description": (
+            "Create a GitHub Discussion in the claude-skills repo. Use the Flight Log "
+            "category for fly exploration findings. Title should be descriptive of the "
+            "topic explored. Body should be the synthesis in markdown."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Discussion title — descriptive of the exploration topic",
+                },
+                "body": {
+                    "type": "string",
+                    "description": (
+                        "Discussion body in markdown — the synthesis, key findings, "
+                        "connections made, and threads worth pursuing"
+                    ),
+                },
+                "category_id": {
+                    "type": "string",
+                    "description": (
+                        "Discussion category ID. Defaults to Flight Log "
+                        "(DIC_kwDOQEB8Es4C31s9)"
+                    ),
+                    "default": "DIC_kwDOQEB8Es4C31s9",
+                },
+            },
+            "required": ["title", "body"],
+        },
+    },
+    {
         "name": "fetch_url",
         "description": (
             "Fetch content from a URL and return as clean text. Uses Jina AI "
@@ -196,6 +229,55 @@ def execute_bsky_trending(input: dict) -> str:
     return f"{len(trends)} trending topics:\n\n" + "\n".join(lines)
 
 
+def _create_discussion(input: dict) -> str:
+    """Create a GitHub Discussion in the Flight Log category."""
+    import urllib.request
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        return "Error: No GitHub token available"
+
+    repo_id = "R_kgDOQEB8Eg"
+    category_id = input.get("category_id", "DIC_kwDOQEB8Es4C31s9")
+    title = input.get("title", "Untitled fly exploration")
+    body = input.get("body", "")
+
+    mutation = """mutation($input: CreateDiscussionInput!) {
+      createDiscussion(input: $input) {
+        discussion { id number url }
+      }
+    }"""
+
+    variables = {
+        "input": {
+            "repositoryId": repo_id,
+            "categoryId": category_id,
+            "title": title,
+            "body": body,
+        }
+    }
+
+    payload = json.dumps({"query": mutation, "variables": variables}).encode()
+    req = urllib.request.Request(
+        "https://api.github.com/graphql",
+        data=payload,
+        headers={
+            "Authorization": f"bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    try:
+        resp = urllib.request.urlopen(req)
+        data = json.loads(resp.read())
+        if "errors" in data:
+            return f"GraphQL errors: {data['errors']}"
+        disc = data["data"]["createDiscussion"]["discussion"]
+        return f"Discussion #{disc['number']} created: {disc['url']}"
+    except Exception as e:
+        return f"Failed to create discussion: {e}"
+
+
 def execute_fetch_url(input: dict) -> str:
     """Fetch URL content, with Jina fallback for blocked sites."""
     url = input["url"]
@@ -238,5 +320,6 @@ WORLD_EXECUTORS = {
     "bsky_feed": execute_bsky_feed,
     "bsky_search": execute_bsky_search,
     "bsky_trending": execute_bsky_trending,
+    "create_discussion": _create_discussion,
     "fetch_url": execute_fetch_url,
 }


### PR DESCRIPTION
## Summary

Closes #361

- Added `create_discussion` tool to `.perch/tools/world.py` using GitHub GraphQL `createDiscussion` mutation, targeting the Flight Log category (`DIC_kwDOQEB8Es4C31s9`)
- Updated fly prompt Phase 4 in `.perch/prompts/tasks/fly.md` to post a GitHub Discussion as the primary deliverable before storing the session log memory
- Added `GH_TOKEN` passthrough in `.github/workflows/perch.yml`

## Test plan

- [x] AST parse verification — `world.py` parses cleanly
- [x] Function logic: returns error when no token available
- [x] Tool definition: `create_discussion` in both `WORLD_TOOLS` and `WORLD_EXECUTORS`
- [x] GraphQL read-only verification: repo ID (`R_kgDOQEB8Eg`) and category ID (`DIC_kwDOQEB8Es4C31s9`) confirmed valid against live API
- [ ] Live test: run `python .perch/perch.py --task fly --verbose` and verify discussion appears in Flight Log category

https://claude.ai/code/session_01W33HuQvqR8NQAkN3szekqj