### PR TITLE
feat(developing-preact): replace esm.sh CDN with vendored deps + container testing

### DIFF
--- a/developing-preact/SKILL.md
+++ b/developing-preact/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: developing-preact
-description: Specialized Preact development skill for standards-based web applications with native-first architecture and minimal dependency footprint. Use when building Preact projects, particularly those involving data visualization, interactive applications, single-page apps with HTM syntax, Web Components integration, CSV/JSON data parsing, WebGL shader visualizations, or zero-build solutions with CDN imports.
+description: Specialized Preact development skill for standards-based web applications with native-first architecture and minimal dependency footprint. Use when building Preact projects, particularly those involving data visualization, interactive applications, single-page apps with HTM syntax, Web Components integration, CSV/JSON data parsing, WebGL shader visualizations, or zero-build solutions with vendored ESM imports.
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Preact Developer
@@ -13,7 +13,7 @@ Transform Claude into a specialized Preact developer with expertise in building 
 
 ## Core Philosophy
 
-**Native-First Development**: Leverage ES modules, Import Maps, Web Components, native form validation, Fetch API, and built-in DOM methods before reaching for external libraries. Default to zero-build solutions with HTM and CDN imports for rapid prototyping and small-to-medium applications.
+**Native-First Development**: Leverage ES modules, Import Maps, Web Components, native form validation, Fetch API, and built-in DOM methods before reaching for external libraries. Default to zero-build solutions with HTM and vendored ESM imports for rapid prototyping and small-to-medium applications.
 
 **Always Deliver in Artifacts**: All code should be created as artifacts to enable iterative editing across sessions.
 
@@ -39,12 +39,12 @@ Follow this decision tree to determine the optimal architecture:
 
 **Architecture**:
 - HTM syntax with import maps
-- CDN-based dependencies (esm.sh)
-- Tailwind CSS via CDN
+- Vendored ESM dependencies (fetched from npm registry via `scripts/vendor.sh`)
+- Tailwind CSS via CLI (purged, minified)
 - Single HTML file or minimal file structure
 - No build process
 
-**Start with**: Use `assets/boilerplate.html` as the foundation
+**Start with**: Run `bash scripts/vendor.sh` to fetch dependencies, then use `assets/boilerplate.html` as the foundation
 
 ### 2. Small-to-Medium Application (No Build Tooling)
 
@@ -80,22 +80,26 @@ Follow this decision tree to determine the optimal architecture:
 
 ### Import Map Configuration
 
-Always use this exact import map structure for standalone examples:
+Always use this exact import map structure for standalone examples. Dependencies are vendored locally via `scripts/vendor.sh` (fetched from `registry.npmjs.org`):
 
 ```html
 <script type="importmap">
   {
     "imports": {
-      "preact": "https://esm.sh/*preact@10.23.1",
-      "preact/": "https://esm.sh/*preact@10.23.1/",
-      "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
-      "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
+      "preact": "./vendor/preact.module.js",
+      "preact/hooks": "./vendor/hooks.module.js",
+      "@preact/signals-core": "./vendor/signals-core.mjs",
+      "@preact/signals": "./vendor/signals.mjs",
+      "htm": "./vendor/htm.module.js",
+      "htm/preact": "./vendor/htm.module.js"
     }
   }
 </script>
 ```
 
-**Critical**: Always use the `*` prefix in esm.sh URLs to mark all dependencies as external, preventing duplicate Preact instances.
+**Critical — modular files, not standalone bundle**: Do NOT use `htm/preact/standalone.module.js`. The standalone bundle embeds its own Preact copy, which causes `@preact/signals` to get a different Preact instance (it imports `from 'preact'` as a bare specifier). Modular files + import map = one shared Preact instance for everything.
+
+**Why vendored, not CDN**: `esm.sh` is a pass-through to the entire npm registry — allowlisting it opens arbitrary code execution surface. `registry.npmjs.org` is already on the container egress allowlist and provides scoped, versioned tarballs.
 
 ### Syntax Preference
 
@@ -179,9 +183,10 @@ Use function components with:
 
 ### Styling Strategy
 
-**Default**: Tailwind CSS via CDN for standalone examples
-**Avoid**: Inline styles except for dynamic values impossible to express through utilities
-**Alternative**: CSS modules or styled-components only when project requires scoped styling
+**Default**: Tailwind CSS via CLI — install with `npm install tailwindcss@3 --save-dev`, then generate purged CSS with `npx tailwindcss -o vendor/tailwind.css --content "*.html" --minify`. This produces ~6KB of CSS containing only used classes.
+**Avoid**: Tailwind CDN (`cdn.tailwindcss.com`) — not on container egress allowlist, and loads the full 100KB+ JIT compiler.
+**Avoid**: Inline styles except for dynamic values impossible to express through utilities.
+**Alternative**: CSS modules or styled-components only when project requires scoped styling.
 
 ## Dependency Evaluation Framework
 
@@ -374,12 +379,16 @@ import { users, isAuthenticated } from './state.js';
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Run: bash scripts/vendor.sh -->
   <script type="importmap">
     {
       "imports": {
-        "preact": "https://esm.sh/*preact@10.23.1",
-        "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
-        "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
+        "preact": "./vendor/preact.module.js",
+        "preact/hooks": "./vendor/hooks.module.js",
+        "@preact/signals-core": "./vendor/signals-core.mjs",
+        "@preact/signals": "./vendor/signals.mjs",
+        "htm": "./vendor/htm.module.js",
+        "htm/preact": "./vendor/htm.module.js"
       }
     }
   </script>
@@ -429,7 +438,7 @@ For mathematical visualizations using WebGL shaders, create a canvas element, in
 
 Before delivering code, verify:
 
-- [ ] Import map uses `*` prefix for all esm.sh URLs
+- [ ] Import map uses vendored local paths (no CDN URLs)
 - [ ] HTM syntax is used (unless JSX explicitly requested)
 - [ ] Keys provided for all mapped elements
 - [ ] Signals used for reactive state
@@ -440,13 +449,72 @@ Before delivering code, verify:
 - [ ] Comments explain non-obvious patterns
 - [ ] No unnecessary dependencies included
 
+## Container Testing
+
+Test Preact apps locally in Claude.ai containers using Playwright. This workflow avoids external CDNs entirely — all dependencies are vendored from `registry.npmjs.org`.
+
+### Setup (one-time per session)
+
+```bash
+# 1. Vendor JS dependencies
+bash scripts/vendor.sh
+
+# 2. Generate Tailwind CSS (if using Tailwind)
+npm install tailwindcss@3 --save-dev
+npx tailwindcss -o vendor/tailwind.css --content "*.html" --minify
+```
+
+### Serve and Test
+
+```bash
+# 3. Serve locally
+python3 -m http.server 8765 &
+
+# 4. Test with Playwright
+python3 << 'PYEOF'
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+    page = browser.new_page()
+
+    errors = []
+    page.on("console", lambda m: errors.append(m.text) if m.type == "error" else None)
+    page.on("pageerror", lambda e: errors.append(str(e)))
+
+    page.goto("http://localhost:8765", wait_until="networkidle")
+
+    # Verify no console errors (catches import failures immediately)
+    assert not errors, f"Console errors: {errors}"
+
+    # Verify app rendered
+    assert page.locator("#app").inner_html() != "", "App did not render"
+
+    # Example: test interaction
+    # page.click("button")
+    # assert "Count: 1" in page.content()
+
+    browser.close()
+    print("All tests passed")
+PYEOF
+```
+
+### Key guidance
+
+- **Use Playwright directly** for local testing — not webctl (webctl is for external sites through the proxy)
+- **`python3 -m http.server`** is sufficient — no npm server needed
+- **Console error capture** via `page.on("console")` and `page.on("pageerror")` catches import failures immediately
+- **`--no-sandbox`** is required in container environments
+
 ## Getting Started
 
 For immediate implementation:
 
-1. Copy `assets/boilerplate.html` as the starting point
-2. Read `references/preact-v10-guide.md` for API details
-3. Reference `assets/component-patterns.md` for common UI patterns
-4. Consult `references/architecture-patterns.md` for advanced scenarios
+1. Run `bash scripts/vendor.sh` to fetch vendored dependencies
+2. (Optional) Generate Tailwind CSS: `npm install tailwindcss@3 --save-dev && npx tailwindcss -o vendor/tailwind.css --content "*.html" --minify`
+3. Copy `assets/boilerplate.html` as the starting point
+4. Read `references/preact-v10-guide.md` for API details
+5. Reference `assets/component-patterns.md` for common UI patterns
+6. Consult `references/architecture-patterns.md` for advanced scenarios
 
 The skill is designed to enable rapid development of high-quality Preact applications with minimal friction and maximum standards compliance.

--- a/developing-preact/_MAP.md
+++ b/developing-preact/_MAP.md
@@ -1,9 +1,10 @@
 # developing-preact/
-*Files: 2 | Subdirectories: 1*
+*Files: 2 | Subdirectories: 2*
 
 ## Subdirectories
 
 - [references/](./references/_MAP.md)
+- [scripts/](./scripts/_MAP.md)
 
 ## Files
 
@@ -17,15 +18,16 @@
 - When to Use This Skill `h2` :20
 - Project Type Decision Tree `h2` :32
 - Technical Standards `h2` :79
-- Dependency Evaluation Framework `h2` :186
-- Architecture Considerations `h2` :196
-- Domain Standards `h2` :207
-- Development Workflow `h2` :226
-- Common Patterns `h2` :267
-- Constraints `h2` :340
-- Resources `h2` :355
-- Examples `h2` :369
-- Best Practices Summary `h2` :417
-- Validation Checklist `h2` :428
-- Getting Started `h2` :443
+- Dependency Evaluation Framework `h2` :191
+- Architecture Considerations `h2` :201
+- Domain Standards `h2` :212
+- Development Workflow `h2` :231
+- Common Patterns `h2` :272
+- Constraints `h2` :345
+- Resources `h2` :360
+- Examples `h2` :374
+- Best Practices Summary `h2` :426
+- Validation Checklist `h2` :437
+- Container Testing `h2` :452
+- Getting Started `h2` :509
 

--- a/developing-preact/assets/boilerplate.html
+++ b/developing-preact/assets/boilerplate.html
@@ -4,22 +4,24 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Preact App</title>
-  
-  <!-- Tailwind CSS via CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
-  
-  <!-- Import Map Configuration -->
+
+  <!-- Tailwind CSS — generated via: npx tailwindcss -o vendor/tailwind.css --content "*.html" --minify -->
+  <link rel="stylesheet" href="vendor/tailwind.css">
+
+  <!-- Import Map — vendor deps fetched via: bash scripts/vendor.sh -->
   <script type="importmap">
     {
       "imports": {
-        "preact": "https://esm.sh/*preact@10.23.1",
-        "preact/": "https://esm.sh/*preact@10.23.1/",
-        "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
-        "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
+        "preact": "./vendor/preact.module.js",
+        "preact/hooks": "./vendor/hooks.module.js",
+        "@preact/signals-core": "./vendor/signals-core.mjs",
+        "@preact/signals": "./vendor/signals.mjs",
+        "htm": "./vendor/htm.module.js",
+        "htm/preact": "./vendor/htm.module.js"
       }
     }
   </script>
-  
+
   <style>
     /* Custom styles if needed */
     body {
@@ -29,7 +31,7 @@
 </head>
 <body>
   <div id="app"></div>
-  
+
   <script type="module">
     import { render } from 'preact';
     import { useSignal } from '@preact/signals';

--- a/developing-preact/references/_MAP.md
+++ b/developing-preact/references/_MAP.md
@@ -22,13 +22,13 @@
 ### preact-v10-guide.md
 - Preact v10 - Comprehensive Reference Guide `h1` :1
 - Import Map Configuration `h2` :3
-- HTM Syntax (Default Preference) `h2` :40
-- Key Differences from React `h2` :97
-- Signals API `h2` :171
-- Web Components Integration `h2` :259
-- Performance Patterns `h2` :295
-- Context API `h2` :322
-- Error Boundaries `h2` :344
-- Common Gotchas `h2` :370
-- Version Info `h2` :407
+- HTM Syntax (Default Preference) `h2` :47
+- Key Differences from React `h2` :104
+- Signals API `h2` :178
+- Web Components Integration `h2` :266
+- Performance Patterns `h2` :302
+- Context API `h2` :329
+- Error Boundaries `h2` :351
+- Common Gotchas `h2` :377
+- Version Info `h2` :414
 

--- a/developing-preact/references/architecture-patterns.md
+++ b/developing-preact/references/architecture-patterns.md
@@ -19,10 +19,10 @@ Before adding any external package, verify:
 ## Zero-Build Architecture
 
 For prototypes, demos, and small applications, use:
-- ES modules via CDN (esm.sh)
+- ES modules vendored from npm registry (`scripts/vendor.sh`)
 - Import maps for dependency management
 - HTM for zero-transpilation JSX-like syntax
-- Inline or linked CSS (Tailwind via CDN)
+- Tailwind CSS via CLI (purged, minified to `vendor/tailwind.css`)
 
 ### When to Introduce Build Tools
 

--- a/developing-preact/references/preact-v10-guide.md
+++ b/developing-preact/references/preact-v10-guide.md
@@ -4,14 +4,18 @@
 
 ### Standard Setup (Use for all standalone examples)
 
+Vendor dependencies first: `bash scripts/vendor.sh`
+
 ```html
 <script type="importmap">
   {
     "imports": {
-      "preact": "https://esm.sh/*preact@10.23.1",
-      "preact/": "https://esm.sh/*preact@10.23.1/",
-      "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
-      "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
+      "preact": "./vendor/preact.module.js",
+      "preact/hooks": "./vendor/hooks.module.js",
+      "@preact/signals-core": "./vendor/signals-core.mjs",
+      "@preact/signals": "./vendor/signals.mjs",
+      "htm": "./vendor/htm.module.js",
+      "htm/preact": "./vendor/htm.module.js"
     }
   }
 </script>
@@ -19,23 +23,26 @@
 
 ### With React Aliasing (for React ecosystem compatibility)
 
+For compat mode, vendor additional files from the preact package (`compat/dist/compat.module.js`) and add to the import map:
+
 ```html
 <script type="importmap">
   {
     "imports": {
-      "preact": "https://esm.sh/*preact@10.23.1",
-      "preact/": "https://esm.sh/*preact@10.23.1/",
-      "react": "https://esm.sh/*preact@10.23.1/compat",
-      "react/": "https://esm.sh/*preact@10.23.1/compat/",
-      "react-dom": "https://esm.sh/*preact@10.23.1/compat",
-      "@preact/signals": "https://esm.sh/*@preact/signals@1.3.0",
-      "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
+      "preact": "./vendor/preact.module.js",
+      "preact/hooks": "./vendor/hooks.module.js",
+      "react": "./vendor/compat.module.js",
+      "react-dom": "./vendor/compat.module.js",
+      "@preact/signals-core": "./vendor/signals-core.mjs",
+      "@preact/signals": "./vendor/signals.mjs",
+      "htm": "./vendor/htm.module.js",
+      "htm/preact": "./vendor/htm.module.js"
     }
   }
 </script>
 ```
 
-**Critical Note**: Always use the `*` prefix in esm.sh URLs to mark all dependencies as external, preventing duplicate Preact instances.
+**Critical Note**: Use modular vendor files (not standalone bundles) so all packages share a single Preact instance via import map resolution. See SKILL.md for rationale.
 
 ## HTM Syntax (Default Preference)
 

--- a/developing-preact/scripts/_MAP.md
+++ b/developing-preact/scripts/_MAP.md
@@ -1,0 +1,7 @@
+# scripts/
+*Files: 1*
+
+## Other Files
+
+- vendor.sh
+

--- a/developing-preact/scripts/vendor.sh
+++ b/developing-preact/scripts/vendor.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# vendor.sh — Download Preact ecosystem ESM modules from npm registry
+#
+# Usage: ./vendor.sh [output_dir]
+#   output_dir: where to write vendor files (default: ./vendor)
+#
+# Downloads modular ESM files (not standalone bundles) so that
+# @preact/signals can resolve 'preact' and 'preact/hooks' via
+# import map to a single shared Preact instance.
+
+set -euo pipefail
+
+VENDOR_DIR="${1:-./vendor}"
+mkdir -p "$VENDOR_DIR"
+
+# Package versions — update these as needed
+PREACT_VER="10.23.1"
+SIGNALS_CORE_VER="1.8.0"
+SIGNALS_VER="1.3.0"
+HTM_VER="3.1.1"
+
+# Fetch a single file from an npm package tarball.
+# Args: package_name version tarball_path output_filename
+fetch_npm_file() {
+  local pkg="$1" ver="$2" tpath="$3" outfile="$4"
+  local tarball_url
+
+  # Get tarball URL from registry metadata
+  tarball_url=$(curl -sL "https://registry.npmjs.org/${pkg}/${ver}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['dist']['tarball'])")
+
+  # Download tarball and extract the single file we need
+  curl -sL "$tarball_url" \
+    | tar -xzf - --to-stdout "package/${tpath}" \
+    > "${VENDOR_DIR}/${outfile}"
+
+  local size
+  size=$(wc -c < "${VENDOR_DIR}/${outfile}")
+  echo "  ✓ ${outfile} (${size} bytes)"
+}
+
+echo "Vendoring Preact ecosystem into ${VENDOR_DIR}/"
+echo ""
+
+echo "Preact ${PREACT_VER}:"
+fetch_npm_file "preact" "$PREACT_VER" \
+  "dist/preact.module.js" "preact.module.js"
+fetch_npm_file "preact" "$PREACT_VER" \
+  "hooks/dist/hooks.module.js" "hooks.module.js"
+
+echo ""
+echo "@preact/signals-core ${SIGNALS_CORE_VER}:"
+fetch_npm_file "@preact/signals-core" "$SIGNALS_CORE_VER" \
+  "dist/signals-core.mjs" "signals-core.mjs"
+
+echo ""
+echo "@preact/signals ${SIGNALS_VER}:"
+fetch_npm_file "@preact/signals" "$SIGNALS_VER" \
+  "dist/signals.mjs" "signals.mjs"
+
+echo ""
+echo "HTM ${HTM_VER}:"
+fetch_npm_file "htm" "$HTM_VER" \
+  "dist/htm.module.js" "htm.module.js"
+
+echo ""
+echo "Done. Total vendored size:"
+du -sh "$VENDOR_DIR"
+
+echo ""
+echo "Use this import map in your HTML:"
+cat << 'IMPORTMAP'
+<script type="importmap">
+  {
+    "imports": {
+      "preact": "./vendor/preact.module.js",
+      "preact/hooks": "./vendor/hooks.module.js",
+      "@preact/signals-core": "./vendor/signals-core.mjs",
+      "@preact/signals": "./vendor/signals.mjs",
+      "htm": "./vendor/htm.module.js",
+      "htm/preact": "./vendor/htm.module.js"
+    }
+  }
+</script>
+IMPORTMAP

--- a/remembering/scripts/_MAP.md
+++ b/remembering/scripts/_MAP.md
@@ -22,23 +22,23 @@
 - **profile** (f) `()` :382
 - **ops** (f) `(include_reference: bool = False)` :387
 - **boot** (f) `(mode: str = None)` :461
-- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :717
-- **journal_recent** (f) `(n: int = 10)` :734
-- **journal_prune** (f) `(keep: int = 40)` :750
-- **therapy_scope** (f) `()` :764
-- **therapy_session_count** (f) `()` :779
-- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :788
+- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :765
+- **journal_recent** (f) `(n: int = 10)` :782
+- **journal_prune** (f) `(keep: int = 40)` :798
+- **therapy_scope** (f) `()` :812
+- **therapy_session_count** (f) `()` :827
+- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :836
 - **therapy_reflect** (f) `(*, n_sample: int = 20, similarity_threshold: int = 3,
-                     dry_run: bool = True)` :801
-- **group_by_type** (f) `(memories: list)` :931
-- **group_by_tag** (f) `(memories: list)` :947
-- **muninn_export** (f) `()` :967
-- **session_save** (f) `(summary: str = None, context: dict = None)` :984
-- **session_resume** (f) `(session_id: str = None)` :1034
-- **sessions** (f) `(n: int = 10, *, include_counts: bool = False)` :1106
-- **handoff_pending** (f) `()` :1171
-- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :1186
-- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :1218
+                     dry_run: bool = True)` :849
+- **group_by_type** (f) `(memories: list)` :979
+- **group_by_tag** (f) `(memories: list)` :995
+- **muninn_export** (f) `()` :1015
+- **session_save** (f) `(summary: str = None, context: dict = None)` :1032
+- **session_resume** (f) `(session_id: str = None)` :1082
+- **sessions** (f) `(n: int = 10, *, include_counts: bool = False)` :1154
+- **handoff_pending** (f) `()` :1219
+- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :1234
+- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :1266
 
 ### bootstrap.py
 > Imports: `sys, os, scripts`


### PR DESCRIPTION
Replace esm.sh and cdn.tailwindcss.com references with vendored local
dependencies fetched from registry.npmjs.org. esm.sh is a pass-through
to the entire npm registry making it impossible to scope allowlisting,
and neither CDN is on the container egress allowlist.

Changes:
- Add scripts/vendor.sh to fetch ESM modules from npm tarballs
- Update assets/boilerplate.html with local import map paths
- Update SKILL.md: vendored imports, Tailwind CLI, container testing section
- Update references to match vendored approach
- Bump version to 1.2.0

Closes #370

https://claude.ai/code/session_01YSZtUbexPNYUHSSHyVLAn8