### PR TITLE
Automate Muninn boot via SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Muninn boot: load profile + ops from Turso into the session.
+# This replaces the manual "python3 << EOF ... boot() ... EOF" block
+# that was previously in CLAUDE.md's "Muninn Boot" section.
+#
+# The boot output is printed to stdout so the agent sees the profile
+# and operational context at session start.
+
+python3 - <<'PYEOF'
+import sys, os
+
+# Ensure the remembering skill package is importable
+skill_dir = os.path.join(os.environ.get("CLAUDE_PROJECT_DIR", "/home/user/claude-skills"), "remembering")
+sys.path.insert(0, skill_dir)
+
+try:
+    from scripts import boot
+    print(boot())
+except Exception as e:
+    # Non-fatal: not all sessions need memory access (missing creds, network, etc.)
+    print(f"Muninn boot skipped: {e}", file=sys.stderr)
+PYEOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,11 @@ Gemini produces actual pixel images. SVG stick figures are not a substitute.
 
 This repository is developed by two wings of the same raven. Claude Code implements; Claude.ai (Muninn) plans, tests, and operates the memory system. Both share a persistent memory store — boot it to maintain continuity.
 
-Unless the message contains "skip boot", execute at session start:
+**Boot is automatic.** The SessionStart hook (`.claude/hooks/session-start.sh`) runs `boot()` at the beginning of every Claude Code on the web session. No manual invocation needed.
+
+Credentials auto-detect from environment or well-known paths (`/mnt/project/turso.env`, `/mnt/project/muninn.env`, `~/.muninn/.env`). If boot fails on missing credentials, the hook logs a warning to stderr and continues — not all sessions require memory access.
+
+For local Claude Code sessions (not on the web), boot can be invoked manually if needed:
 
 ```bash
 python3 << 'EOF'
@@ -35,8 +39,6 @@ from scripts import boot
 print(boot())
 EOF
 ```
-
-Credentials auto-detect from environment or well-known paths (`/mnt/project/turso.env`, `/mnt/project/muninn.env`, `~/.muninn/.env`). If boot fails on missing credentials, note it and continue — not all sessions require memory access.
 
 ### Decision Traces
 

--- a/_MAP.md
+++ b/_MAP.md
@@ -71,13 +71,13 @@
 ### CLAUDE.md
 - ⚠️ Image & Art Generation: Use Gemini, Not SVG `h2` :3
 - Muninn Boot `h2` :24
-- Claude Code on the Web Development `h2` :58
-- Test Before PR `h2` :91
-- Environment-Specific Tips `h2` :104
-- Code Maps `h2` :151
-- Skill Development Workflow `h2` :207
-- PR Reviews and Code Testing `h2` :318
-- Remembering Skill and Handoff Process `h2` :459
+- Claude Code on the Web Development `h2` :60
+- Test Before PR `h2` :93
+- Environment-Specific Tips `h2` :106
+- Code Maps `h2` :153
+- Skill Development Workflow `h2` :209
+- PR Reviews and Code Testing `h2` :320
+- Remembering Skill and Handoff Process `h2` :461
 
 ### README.md
 - claude-skills `h1` :1

--- a/developing-preact/_MAP.md
+++ b/developing-preact/_MAP.md
@@ -1,5 +1,5 @@
 # developing-preact/
-*Files: 2 | Subdirectories: 2*
+*Files: 3 | Subdirectories: 2*
 
 ## Subdirectories
 
@@ -7,6 +7,10 @@
 - [scripts/](./scripts/_MAP.md)
 
 ## Files
+
+### CHANGELOG.md
+- developing-preact - Changelog `h1` :1
+- [1.2.0] - 2026-03-08 `h2` :5
 
 ### README.md
 - developing-preact `h1` :1


### PR DESCRIPTION
## Summary
Automates the Muninn memory system boot process by implementing a SessionStart hook that runs at the beginning of every Claude Code on the web session, eliminating the need for manual invocation.

## Key Changes
- **Added `.claude/hooks/session-start.sh`**: New hook script that automatically executes `boot()` from the remembering skill at session start. The script gracefully handles missing credentials by logging a warning to stderr and continuing, since not all sessions require memory access.
- **Added `.claude/settings.json`**: Configuration file that registers the session-start hook to run on SessionStart events in Claude Code on the web environments.
- **Updated CLAUDE.md**: Clarified that boot is now automatic via the hook for web sessions, with credentials auto-detecting from environment or well-known paths. Documented that local Claude Code sessions can still invoke boot manually if needed.
- **Updated documentation maps**: Adjusted line numbers in `_MAP.md` and added CHANGELOG.md entry to `developing-preact/_MAP.md` to reflect documentation changes.

## Implementation Details
- The hook only executes in remote (Claude Code on the web) environments by checking the `CLAUDE_CODE_REMOTE` environment variable.
- The Python boot script safely handles import errors and missing credentials, printing diagnostic messages to stderr without interrupting the session.
- Skill directory is resolved from `CLAUDE_PROJECT_DIR` environment variable with a fallback to `/home/user/claude-skills`.
- Boot output is printed to stdout so the agent sees the profile and operational context at session start.

https://claude.ai/code/session_015Eo3ZPB7ivW7y52qGxMDGC