### PR TITLE
feat: tag co-occurrence expansion and boost-aware scoring for recall()

### DIFF
--- a/remembering/scripts/_MAP.md
+++ b/remembering/scripts/_MAP.md
@@ -43,9 +43,9 @@
 ### bootstrap.py
 > Imports: `sys, os, scripts`
 - **create_tables** (f) `()` :17
-- **migrate_schema** (f) `()` :65
-- **seed_config** (f) `()` :127
-- **verify** (f) `()` :173
+- **migrate_schema** (f) `()` :78
+- **seed_config** (f) `()` :157
+- **verify** (f) `()` :203
 
 ### config.py
 > Imports: `datetime, .turso`
@@ -70,11 +70,11 @@
              sync: bool = True, session_id: str = None,
              alternatives: list = None,
              # Deprecated parameters (ignored in v2.0.0, kept for backward compat)
-             entities: list = None, importance: float = None, memory_class: str = None)` :106
+             entities: list = None, importance: float = None, memory_class: str = None)` :111
 - **remember_bg** (f) `(what: str, type: str, *, tags: list = None, conf: float = None,
                 entities: list = None, refs: list = None,
-                importance: float = None, memory_class: str = None, valid_from: str = None)` :222
-- **flush** (f) `(timeout: float = 5.0)` :239
+                importance: float = None, memory_class: str = None, valid_from: str = None)` :236
+- **flush** (f) `(timeout: float = 5.0)` :253
 - **recall** (f) `(search: str = None, *, n: int = 10, tags: list = None,
            type: str = None, conf: float = None, tag_mode: str = "any",
            strict: bool = False, session_id: str = None,
@@ -85,39 +85,39 @@
            tags_all: list = None, tags_any: list = None,
            episodic: bool = False,
            # Deprecated parameters (kept for backward compat)
-           use_cache: bool = True)` :271
+           use_cache: bool = True)` :285
 - **recall_since** (f) `(after: str, *, search: str = None, n: int = 50,
                  type: str = None, tags: list = None, tag_mode: str = "any",
-                 session_id: str = None, raw: bool = False)` :534
+                 session_id: str = None, raw: bool = False)` :630
 - **recall_between** (f) `(after: str, before: str, *, search: str = None,
                    n: int = 100, type: str = None, tags: list = None,
-                   tag_mode: str = "any", session_id: str = None, raw: bool = False)` :601
-- **forget** (f) `(memory_id: str)` :670
+                   tag_mode: str = "any", session_id: str = None, raw: bool = False)` :697
+- **forget** (f) `(memory_id: str)` :766
 - **supersede** (f) `(original_id: str, summary: str, type: str, *,
-              tags: list = None, conf: float = None)` :696
-- **reprioritize** (f) `(memory_id: str, priority: int)` :749
-- **memory_histogram** (f) `()` :773
-- **prune_by_age** (f) `(older_than_days: int, priority_floor: int = 0, dry_run: bool = True)` :829
-- **prune_by_priority** (f) `(max_priority: int = -1, dry_run: bool = True)` :875
-- **strengthen** (f) `(memory_id: str, boost: int = 1)` :914
-- **weaken** (f) `(memory_id: str, drop: int = 1)` :957
+              tags: list = None, conf: float = None)` :817
+- **reprioritize** (f) `(memory_id: str, priority: int)` :870
+- **memory_histogram** (f) `()` :894
+- **prune_by_age** (f) `(older_than_days: int, priority_floor: int = 0, dry_run: bool = True)` :950
+- **prune_by_priority** (f) `(max_priority: int = -1, dry_run: bool = True)` :996
+- **strengthen** (f) `(memory_id: str, boost: int = 1)` :1035
+- **weaken** (f) `(memory_id: str, drop: int = 1)` :1078
 - **recall_batch** (f) `(queries: list, *, n: int = 10, type: str = None,
                  tags: list = None, tag_mode: str = "any",
                  conf: float = None, session_id: str = None,
-                 raw: bool = False)` :994
-- **remember_batch** (f) `(items: list, *, sync: bool = True)` :1123
-- **get_alternatives** (f) `(memory_id: str)` :1265
-- **get_chain** (f) `(memory_id: str, depth: int = 3)` :1304
+                 raw: bool = False)` :1115
+- **remember_batch** (f) `(items: list, *, sync: bool = True)` :1244
+- **get_alternatives** (f) `(memory_id: str)` :1386
+- **get_chain** (f) `(memory_id: str, depth: int = 3)` :1425
 - **consolidate** (f) `(*, tags: list = None, min_cluster: int = 3, dry_run: bool = True,
-                session_id: str = None)` :1374
+                session_id: str = None)` :1495
 - **curate** (f) `(*, dry_run: bool = True, consolidation_threshold: int = 3,
            stale_days: int = 90, low_priority_cap: int = -1,
-           max_actions: int = 20)` :1519
+           max_actions: int = 20)` :1640
 - **decision_trace** (f) `(choice: str, context: str, rationale: str, *,
                    alternatives: list = None, tradeoffs: str = None,
                    contraindications: str = None, tags: list = None,
                    refs: list = None, conf: float = 0.9,
-                   priority: int = 1)` :1644
+                   priority: int = 1)` :1765
 
 ### result.py
 > Imports: `typing`

--- a/remembering/scripts/__init__.py
+++ b/remembering/scripts/__init__.py
@@ -1,5 +1,6 @@
 """Remembering - Minimal persistent memory for Claude.
 
+v5.4.0: Enhanced retrieval with tag co-occurrence expansion and boost-aware scoring (#383).
 v5.3.0: Task discipline (#332) — type-specific checklists, verification reports,
         cross-session persistence, recall_gate context manager, boot surfacing.
 v5.1.0: Partial ID support (#244), autonomous curation (#295), episodic scoring (#296),
@@ -23,7 +24,9 @@ from .state import TYPES, get_session_id, set_session_id
 from .turso import (
     _init, _retry_with_backoff,
     _exec, _exec_batch, _parse_memory_row,
-    _fts5_search  # v4.5.0: Server-side FTS5 search (#298)
+    _fts5_search,  # v4.5.0: Server-side FTS5 search (#298)
+    _build_cooccurrence, _cooccurrence_expand,  # v5.4.0: Tag co-occurrence (#383)
+    _update_cooccurrence_add, _update_cooccurrence_remove,
 )
 
 # Import memory layer
@@ -109,6 +112,7 @@ __all__ = [
     # v3.4.0: Type-safe results and proactive hints
     "MemoryResult", "MemoryResultList", "VALID_FIELDS", "recall_hints",
     "_exec",  # v3.9.0: Raw SQL execution for utilities
+    "_build_cooccurrence", "_cooccurrence_expand",  # v5.4.0: Tag co-occurrence (#383)
     "r", "q", "j", "TYPES",  # aliases & constants
     # v5.2.0: Task discipline (#332)
     "task", "Task", "task_resume", "incomplete_tasks",

--- a/remembering/scripts/bootstrap.py
+++ b/remembering/scripts/bootstrap.py
@@ -60,6 +60,19 @@ def create_tables():
         )
     """)
 
+    # v5.4.0: Tag co-occurrence index (#383)
+    _exec("""
+        CREATE TABLE IF NOT EXISTS tag_cooccurrence (
+            tag1 TEXT NOT NULL,
+            tag2 TEXT NOT NULL,
+            count INTEGER NOT NULL,
+            pmi REAL,
+            PRIMARY KEY (tag1, tag2)
+        )
+    """)
+    _exec("CREATE INDEX IF NOT EXISTS idx_cooccurrence_tag1 ON tag_cooccurrence(tag1)")
+    _exec("CREATE INDEX IF NOT EXISTS idx_cooccurrence_tag2 ON tag_cooccurrence(tag2)")
+
     print("Tables created/verified")
 
 def migrate_schema():
@@ -121,6 +134,23 @@ def migrate_schema():
         print("Added index on priority column")
     except:
         pass  # Index already exists
+
+    # v5.4.0: Tag co-occurrence table (#383)
+    try:
+        _exec("""
+            CREATE TABLE IF NOT EXISTS tag_cooccurrence (
+                tag1 TEXT NOT NULL,
+                tag2 TEXT NOT NULL,
+                count INTEGER NOT NULL,
+                pmi REAL,
+                PRIMARY KEY (tag1, tag2)
+            )
+        """)
+        _exec("CREATE INDEX IF NOT EXISTS idx_cooccurrence_tag1 ON tag_cooccurrence(tag1)")
+        _exec("CREATE INDEX IF NOT EXISTS idx_cooccurrence_tag2 ON tag_cooccurrence(tag2)")
+        print("Added tag_cooccurrence table")
+    except:
+        pass  # Table/indexes already exist
 
     print("Schema migration complete")
 

--- a/remembering/scripts/memory.py
+++ b/remembering/scripts/memory.py
@@ -10,6 +10,7 @@ This module handles:
 
 Imports from: state, turso, config
 
+v5.4.0: Enhanced retrieval with tag co-occurrence expansion and boost-aware scoring (#383).
 v5.0.0: Removed local cache dependency. All queries go through Turso FTS5.
 """
 
@@ -22,7 +23,11 @@ from datetime import datetime, UTC
 
 from . import state
 from .state import TYPES, get_session_id
-from .turso import _exec, _exec_batch, _fts5_search, _retry_with_backoff
+from .turso import (
+    _exec, _exec_batch, _fts5_search, _retry_with_backoff,
+    _build_cooccurrence, _update_cooccurrence_add, _update_cooccurrence_remove,
+    _cooccurrence_expand
+)
 # Import config_get and config_set for recall-triggers management
 from .config import config_get, config_set
 from .result import wrap_results, MemoryResult, MemoryResultList
@@ -216,6 +221,15 @@ def remember(what: str, type: str, *, tags: list = None, conf: float = None,
             # Don't fail remember() if trigger update fails
             pass
 
+    # v5.4.0: Incremental co-occurrence update (#383)
+    if tags and len(tags) >= 2:
+        def _bg_cooccurrence():
+            try:
+                _update_cooccurrence_add(tags)
+            except Exception:
+                pass  # Best-effort; don't fail remember()
+        threading.Thread(target=_bg_cooccurrence, daemon=True).start()
+
     return mem_id
 
 
@@ -380,33 +394,115 @@ def recall(search: str = None, *, n: int = 10, tags: list = None,
             else:
                 raise
 
-        # Query expansion: if FTS5 returns few results, search by extracted tags
+        # v5.4.0: Multi-stage query expansion with co-occurrence and boost-aware scoring (#383)
+        #
+        # Boost weights for different match provenance:
+        BOOST_PRIMARY = 3.0     # original query terms
+        BOOST_STAGE1_TAG = 2.0  # tags from initial results
+        BOOST_COOCCUR = 1.5     # co-occurrence expanded terms
+        BOOST_HOP2 = 1.0        # second-hop discovered terms
+
         if expansion_threshold > 0 and len(results) < expansion_threshold:
-            expansion_tags = set()
+            seen_ids = {r['id'] for r in results}
+            # Track boost scores per memory id
+            boost_scores = {}
+            for r in results:
+                # Primary results get highest boost
+                score = abs(float(r.get('bm25_score', 0) or 0))
+                boost_scores[r['id']] = score * BOOST_PRIMARY
+
+            # Stage 2: Extract tags from Stage 1 results
+            stage1_tags = set()
             for r in results:
                 result_tags = r.get('tags', [])
                 if isinstance(result_tags, list):
-                    expansion_tags.update(result_tags)
+                    stage1_tags.update(result_tags)
 
-            if expansion_tags:
-                seen_ids = {r['id'] for r in results}
-                for tag in expansion_tags:
-                    try:
-                        tag_results = _fts5_search(
-                            tag, n=n - len(results), type=type, tags=tags,
-                            tag_mode=tag_mode, conf=conf, since=since, until=until
-                        )
-                    except RuntimeError:
-                        # FTS5 unavailable for expansion; skip
-                        break
-                    for tr in tag_results:
-                        if tr['id'] not in seen_ids:
-                            results.append(tr)
-                            seen_ids.add(tr['id'])
-                            if len(results) >= n:
-                                break
-                    if len(results) >= n:
-                        break
+            # Stage 2b: Co-occurrence expansion — find related tags via PMI
+            cooccur_tags = set()
+            if stage1_tags:
+                try:
+                    expanded = _cooccurrence_expand(list(stage1_tags), n=10, min_pmi=0.5)
+                    cooccur_tags = {e['tag'] for e in expanded}
+                except Exception:
+                    pass  # Co-occurrence table may not exist yet
+
+            # Even with 0 Stage 1 results, try expanding query words via co-occurrence
+            if not stage1_tags:
+                query_words = [w.strip().lower() for w in search.split() if w.strip()]
+                try:
+                    expanded = _cooccurrence_expand(query_words, n=10, min_pmi=0.0)
+                    cooccur_tags = {e['tag'] for e in expanded}
+                except Exception:
+                    pass
+
+            # Stage 3: Search by Stage 1 tags (with BOOST_STAGE1_TAG)
+            expansion_results = []
+            for tag in stage1_tags:
+                if len(results) + len(expansion_results) >= n * 2:
+                    break
+                try:
+                    tag_results = _fts5_search(
+                        tag, n=5, type=type, tags=tags,
+                        tag_mode=tag_mode, conf=conf, since=since, until=until
+                    )
+                except RuntimeError:
+                    break
+                for tr in tag_results:
+                    if tr['id'] not in seen_ids:
+                        score = abs(float(tr.get('bm25_score', 0) or 0))
+                        boost_scores[tr['id']] = boost_scores.get(tr['id'], 0) + score * BOOST_STAGE1_TAG
+                        expansion_results.append(tr)
+                        seen_ids.add(tr['id'])
+
+            # Stage 3b: Search by co-occurrence expanded tags (with BOOST_COOCCUR)
+            for tag in cooccur_tags:
+                if len(results) + len(expansion_results) >= n * 2:
+                    break
+                try:
+                    tag_results = _fts5_search(
+                        tag, n=5, type=type, tags=tags,
+                        tag_mode=tag_mode, conf=conf, since=since, until=until
+                    )
+                except RuntimeError:
+                    break
+                for tr in tag_results:
+                    if tr['id'] not in seen_ids:
+                        score = abs(float(tr.get('bm25_score', 0) or 0))
+                        boost_scores[tr['id']] = boost_scores.get(tr['id'], 0) + score * BOOST_COOCCUR
+                        expansion_results.append(tr)
+                        seen_ids.add(tr['id'])
+
+            # Stage 4: Second-hop — extract tags from expansion results, search again
+            hop2_tags = set()
+            for r in expansion_results:
+                result_tags = r.get('tags', [])
+                if isinstance(result_tags, list):
+                    hop2_tags.update(result_tags)
+            hop2_tags -= stage1_tags
+            hop2_tags -= cooccur_tags
+
+            for tag in hop2_tags:
+                if len(results) + len(expansion_results) >= n * 2:
+                    break
+                try:
+                    tag_results = _fts5_search(
+                        tag, n=3, type=type, tags=tags,
+                        tag_mode=tag_mode, conf=conf, since=since, until=until
+                    )
+                except RuntimeError:
+                    break
+                for tr in tag_results:
+                    if tr['id'] not in seen_ids:
+                        score = abs(float(tr.get('bm25_score', 0) or 0))
+                        boost_scores[tr['id']] = boost_scores.get(tr['id'], 0) + score * BOOST_HOP2
+                        expansion_results.append(tr)
+                        seen_ids.add(tr['id'])
+
+            # Merge: combine primary + expansion, sort by boost score, take top n
+            all_results = results + expansion_results
+            all_results.sort(key=lambda r: boost_scores.get(r['id'], 0), reverse=True)
+            results = all_results[:n]
     else:
         # No search term or strict mode: use direct Turso query
         results = _retry_with_backoff(
@@ -684,12 +780,37 @@ def forget(memory_id: str) -> bool:
     Raises:
         ValueError: If partial ID matches zero or multiple memories.
 
+    v5.4.0: Added incremental co-occurrence update on forget (#383).
     v5.1.0: Added partial ID support with prefix matching (#244).
     v5.0.0: Turso-only. Removed local cache invalidation.
     """
     resolved_id = _resolve_memory_id(memory_id)
+
+    # v5.4.0: Fetch tags before deletion for co-occurrence update (#383)
+    forgotten_tags = None
+    try:
+        rows = _exec("SELECT tags FROM memories WHERE id = ? AND deleted_at IS NULL", [resolved_id])
+        if rows:
+            raw_tags = rows[0].get('tags', [])
+            if isinstance(raw_tags, str):
+                forgotten_tags = json.loads(raw_tags)
+            elif isinstance(raw_tags, list):
+                forgotten_tags = raw_tags
+    except Exception:
+        pass  # Best-effort
+
     now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     _exec("UPDATE memories SET deleted_at = ? WHERE id = ?", [now, resolved_id])
+
+    # v5.4.0: Decrement co-occurrence counts (#383)
+    if forgotten_tags and len(forgotten_tags) >= 2:
+        def _bg_cooccurrence():
+            try:
+                _update_cooccurrence_remove(forgotten_tags)
+            except Exception:
+                pass
+        threading.Thread(target=_bg_cooccurrence, daemon=True).start()
+
     return True
 
 

--- a/remembering/scripts/turso.py
+++ b/remembering/scripts/turso.py
@@ -448,6 +448,315 @@ def _fts5_search(search: str, *, n: int = 10, type: str = None,
     return _exec(sql, params)
 
 
+def _build_cooccurrence(*, prune_threshold: int = 1, top_n: int = 50) -> dict:
+    """Build the tag co-occurrence index from all active memories.
+
+    Scans all non-deleted memories, enumerates tag pairs, computes
+    co-occurrence counts and PMI (pointwise mutual information).
+
+    Args:
+        prune_threshold: Minimum co-occurrence count to keep (default 1)
+        top_n: Max associations to keep per tag (default 50)
+
+    Returns:
+        Dict with 'pairs' (total pairs stored) and 'tags' (unique tags seen)
+    """
+    _init()
+
+    # Create table if needed
+    _exec("""
+        CREATE TABLE IF NOT EXISTS tag_cooccurrence (
+            tag1 TEXT NOT NULL,
+            tag2 TEXT NOT NULL,
+            count INTEGER NOT NULL,
+            pmi REAL,
+            PRIMARY KEY (tag1, tag2)
+        )
+    """)
+
+    # Fetch all active memories with tags
+    rows = _exec(
+        "SELECT id, tags FROM memories WHERE deleted_at IS NULL AND tags != '[]'",
+        parse_json=False
+    )
+
+    # Count tag frequencies and co-occurrences
+    import math
+    tag_freq = {}  # tag -> number of memories containing it
+    pair_freq = {}  # (tag1, tag2) -> co-occurrence count
+    total_memories = len(rows)
+
+    for row in rows:
+        tags_raw = row.get('tags', '[]')
+        try:
+            tags = json.loads(tags_raw) if isinstance(tags_raw, str) else tags_raw
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(tags, list) or len(tags) < 2:
+            # Single tags still count for frequency but produce no pairs
+            if isinstance(tags, list):
+                for t in tags:
+                    tag_freq[t] = tag_freq.get(t, 0) + 1
+            continue
+
+        for t in tags:
+            tag_freq[t] = tag_freq.get(t, 0) + 1
+
+        # Enumerate all ordered pairs (tag1 < tag2 lexicographically)
+        sorted_tags = sorted(set(tags))
+        for i in range(len(sorted_tags)):
+            for j in range(i + 1, len(sorted_tags)):
+                pair = (sorted_tags[i], sorted_tags[j])
+                pair_freq[pair] = pair_freq.get(pair, 0) + 1
+
+    if total_memories == 0:
+        return {'pairs': 0, 'tags': 0}
+
+    # Compute PMI and build insert batch
+    # PMI = log2(P(a,b) / (P(a) * P(b)))
+    # where P(a) = freq(a)/N, P(b) = freq(b)/N, P(a,b) = co-occur(a,b)/N
+    inserts = []
+    for (t1, t2), count in pair_freq.items():
+        if count < prune_threshold:
+            continue
+        p_ab = count / total_memories
+        p_a = tag_freq.get(t1, 1) / total_memories
+        p_b = tag_freq.get(t2, 1) / total_memories
+        denom = p_a * p_b
+        pmi = math.log2(p_ab / denom) if denom > 0 else 0.0
+        inserts.append((t1, t2, count, pmi))
+
+    # Prune to top_n per tag (by PMI)
+    if top_n:
+        from collections import defaultdict
+        tag_pairs = defaultdict(list)
+        for t1, t2, count, pmi in inserts:
+            tag_pairs[t1].append((t1, t2, count, pmi))
+            tag_pairs[t2].append((t1, t2, count, pmi))
+
+        keep = set()
+        for tag, pairs in tag_pairs.items():
+            pairs.sort(key=lambda x: x[3], reverse=True)  # sort by PMI desc
+            for p in pairs[:top_n]:
+                keep.add((p[0], p[1]))
+
+        inserts = [(t1, t2, c, p) for t1, t2, c, p in inserts if (t1, t2) in keep]
+
+    # Clear and rebuild
+    _exec("DELETE FROM tag_cooccurrence")
+
+    # Batch insert in chunks of 50
+    for i in range(0, len(inserts), 50):
+        chunk = inserts[i:i+50]
+        stmts = []
+        for t1, t2, count, pmi in chunk:
+            stmts.append((
+                "INSERT OR REPLACE INTO tag_cooccurrence (tag1, tag2, count, pmi) VALUES (?, ?, ?, ?)",
+                [t1, t2, count, pmi]
+            ))
+        if stmts:
+            _exec_batch(stmts)
+
+    # Create index for lookups
+    try:
+        _exec("CREATE INDEX IF NOT EXISTS idx_cooccurrence_tag1 ON tag_cooccurrence(tag1)")
+        _exec("CREATE INDEX IF NOT EXISTS idx_cooccurrence_tag2 ON tag_cooccurrence(tag2)")
+    except RuntimeError:
+        pass  # Indexes may already exist
+
+    return {'pairs': len(inserts), 'tags': len(tag_freq)}
+
+
+def _update_cooccurrence_add(tags: list) -> None:
+    """Incrementally update co-occurrence index when a memory is added.
+
+    For each new tag pair, increment the count. Recompute PMI for affected pairs.
+
+    Args:
+        tags: List of tags from the newly created memory
+    """
+    if not tags or len(tags) < 2:
+        return
+
+    _init()
+
+    # Check if table exists
+    try:
+        _exec("SELECT 1 FROM tag_cooccurrence LIMIT 1")
+    except RuntimeError:
+        return  # Table doesn't exist yet; skip incremental update
+
+    import math
+
+    # Get total memory count and tag frequencies for PMI
+    total_row = _exec("SELECT COUNT(*) as cnt FROM memories WHERE deleted_at IS NULL")
+    total_memories = int(total_row[0]['cnt']) if total_row else 1
+
+    sorted_tags = sorted(set(tags))
+    stmts = []
+
+    for i in range(len(sorted_tags)):
+        for j in range(i + 1, len(sorted_tags)):
+            t1, t2 = sorted_tags[i], sorted_tags[j]
+
+            # Upsert count
+            stmts.append((
+                """INSERT INTO tag_cooccurrence (tag1, tag2, count, pmi)
+                   VALUES (?, ?, 1, 0.0)
+                   ON CONFLICT(tag1, tag2) DO UPDATE SET count = count + 1""",
+                [t1, t2]
+            ))
+
+    if stmts:
+        _exec_batch(stmts)
+
+    # Recompute PMI for affected pairs
+    _recompute_pmi_for_tags(sorted_tags, total_memories)
+
+
+def _update_cooccurrence_remove(tags: list) -> None:
+    """Incrementally update co-occurrence index when a memory is forgotten.
+
+    Decrement counts for the forgotten memory's tag pairs.
+    Remove entries where count drops to 0.
+
+    Args:
+        tags: List of tags from the forgotten memory
+    """
+    if not tags or len(tags) < 2:
+        return
+
+    _init()
+
+    try:
+        _exec("SELECT 1 FROM tag_cooccurrence LIMIT 1")
+    except RuntimeError:
+        return  # Table doesn't exist yet
+
+    import math
+
+    total_row = _exec("SELECT COUNT(*) as cnt FROM memories WHERE deleted_at IS NULL")
+    total_memories = int(total_row[0]['cnt']) if total_row else 1
+
+    sorted_tags = sorted(set(tags))
+    stmts = []
+
+    for i in range(len(sorted_tags)):
+        for j in range(i + 1, len(sorted_tags)):
+            t1, t2 = sorted_tags[i], sorted_tags[j]
+            stmts.append((
+                "UPDATE tag_cooccurrence SET count = count - 1 WHERE tag1 = ? AND tag2 = ?",
+                [t1, t2]
+            ))
+
+    if stmts:
+        _exec_batch(stmts)
+
+    # Remove zero-count entries
+    _exec("DELETE FROM tag_cooccurrence WHERE count <= 0")
+
+    # Recompute PMI for remaining affected pairs
+    _recompute_pmi_for_tags(sorted_tags, total_memories)
+
+
+def _recompute_pmi_for_tags(tags: list, total_memories: int) -> None:
+    """Recompute PMI for all co-occurrence pairs involving the given tags.
+
+    Args:
+        tags: Tags whose pairs need PMI recomputation
+        total_memories: Total number of active memories in corpus
+    """
+    import math
+
+    if total_memories <= 0:
+        return
+
+    for tag in tags:
+        # Get all pairs involving this tag
+        pairs = _exec(
+            "SELECT tag1, tag2, count FROM tag_cooccurrence WHERE tag1 = ? OR tag2 = ?",
+            [tag, tag]
+        )
+
+        stmts = []
+        for pair in pairs:
+            t1, t2 = pair['tag1'], pair['tag2']
+            count = int(pair['count'])
+
+            # Get individual tag frequencies
+            f1_row = _exec(
+                "SELECT COUNT(*) as cnt FROM memories WHERE deleted_at IS NULL AND tags LIKE ?",
+                [f'%"{t1}"%']
+            )
+            f2_row = _exec(
+                "SELECT COUNT(*) as cnt FROM memories WHERE deleted_at IS NULL AND tags LIKE ?",
+                [f'%"{t2}"%']
+            )
+            f1 = int(f1_row[0]['cnt']) if f1_row else 1
+            f2 = int(f2_row[0]['cnt']) if f2_row else 1
+
+            p_ab = count / total_memories
+            p_a = f1 / total_memories
+            p_b = f2 / total_memories
+            denom = p_a * p_b
+            pmi = math.log2(p_ab / denom) if denom > 0 and p_ab > 0 else 0.0
+
+            stmts.append((
+                "UPDATE tag_cooccurrence SET pmi = ? WHERE tag1 = ? AND tag2 = ?",
+                [pmi, t1, t2]
+            ))
+
+        if stmts:
+            _exec_batch(stmts)
+
+
+def _cooccurrence_expand(tags: list, *, n: int = 10, min_pmi: float = 0.0) -> list:
+    """Find tags that co-occur with the given tags, ranked by PMI.
+
+    Args:
+        tags: Input tags to expand from
+        n: Max number of expanded tags to return per input tag
+        min_pmi: Minimum PMI threshold (default 0.0)
+
+    Returns:
+        List of dicts with 'tag', 'pmi', 'count' for co-occurring tags,
+        deduplicated and sorted by max PMI descending.
+    """
+    if not tags:
+        return []
+
+    _init()
+
+    try:
+        _exec("SELECT 1 FROM tag_cooccurrence LIMIT 1")
+    except RuntimeError:
+        return []  # Table doesn't exist
+
+    seen = {}  # tag -> best (pmi, count)
+    input_set = set(tags)
+
+    for tag in tags:
+        rows = _exec(
+            """SELECT tag1, tag2, count, pmi FROM tag_cooccurrence
+               WHERE (tag1 = ? OR tag2 = ?) AND pmi >= ?
+               ORDER BY pmi DESC LIMIT ?""",
+            [tag, tag, min_pmi, n]
+        )
+        for row in rows:
+            # The co-occurring tag is the other one in the pair
+            other = row['tag2'] if row['tag1'] == tag else row['tag1']
+            if other in input_set:
+                continue  # Skip tags we already have
+            pmi = float(row['pmi']) if row['pmi'] else 0.0
+            count = int(row['count']) if row['count'] else 0
+            if other not in seen or pmi > seen[other][0]:
+                seen[other] = (pmi, count)
+
+    result = [{'tag': t, 'pmi': p, 'count': c} for t, (p, c) in seen.items()]
+    result.sort(key=lambda x: x['pmi'], reverse=True)
+    return result
+
+
 def _exec(sql, args=None, parse_json: bool = True):
     """Execute SQL, return list of dicts.
 


### PR DESCRIPTION
## Summary

Implements #383 — enhanced `recall()` retrieval with tag co-occurrence index, multi-stage query expansion, and boost-aware scoring.

- **Tag co-occurrence index** (`tag_cooccurrence` table): Precomputed PMI-based associations between tags, built from all active memories. Supports full rebuild (`_build_cooccurrence()`) and incremental maintenance on `remember()`/`forget()`.
- **Multi-stage expansion pipeline** in `recall()`: When FTS5 returns sparse results, expands through 4 stages using co-occurrence PMI for semantic bridging
- **Boost-aware scoring**: Results ranked by provenance-weighted scores (primary 3x > stage1 tags 2x > co-occurrence 1.5x > hop2 1x)
- **Incremental maintenance**: `remember()` and `forget()` update co-occurrence counts in background threads

## Test plan

- [ ] Run `_build_cooccurrence()` against the live corpus
- [ ] Test recall queries that currently miss semantically-related memories
- [ ] Verify incremental updates on remember/forget
- [ ] Verify boost scoring produces sensible rankings
- [ ] Performance: ensure pipeline stays under 500ms

https://claude.ai/code/session_01BGYCXUheVt298ZgbWErjZy