### PR TITLE
Perch rate limit resilience: caching, SQL caps, wall-clock guard

### DIFF
--- a/.perch/perch.py
+++ b/.perch/perch.py
@@ -187,17 +187,44 @@ def run_loop(client: anthropic.Anthropic, model: str, system_prompt: str,
         turn += 1
 
         try:
+            # Enable prompt caching: system prompt and tools are identical
+            # across turns. Cached read tokens don't count toward ITPM limits.
+            cached_system = [{
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral"},
+            }]
+
+            # Mark last non-server tool with cache_control so the entire
+            # tool block is cached after the first turn.
+            cached_tools = tools
+            if tools:
+                cached_tools = [t.copy() for t in tools]
+                for t in reversed(cached_tools):
+                    if t.get("type") != "web_search_20250305":
+                        t["cache_control"] = {"type": "ephemeral"}
+                        break
+
             response = client.messages.create(
                 model=model,
                 max_tokens=4096,
-                system=system_prompt,
-                tools=tools,
+                system=cached_system,
+                tools=cached_tools,
                 messages=messages,
             )
         except anthropic.APIError as e:
             if e.status_code == 429 and retries < MAX_API_RETRIES:
-                wait = min(15 * (2 ** retries), 60)
-                log(f"Rate limited on turn {turn}, waiting {wait}s (retry {retries+1}/{MAX_API_RETRIES})", always=True)
+                # Prefer server-provided retry-after over fixed backoff
+                retry_after = None
+                if hasattr(e, "response") and e.response is not None:
+                    retry_after = e.response.headers.get("retry-after")
+                if retry_after:
+                    wait = min(float(retry_after), 120)
+                else:
+                    wait = min(15 * (2 ** retries), 60)
+                log(f"Rate limited on turn {turn}, waiting {wait:.0f}s "
+                    f"(retry {retries+1}/{MAX_API_RETRIES})",
+                    always=True)
                 time.sleep(wait)
                 retries += 1
                 turn -= 1  # don't count this as a turn
@@ -213,6 +240,12 @@ def run_loop(client: anthropic.Anthropic, model: str, system_prompt: str,
         total_input_tokens += response.usage.input_tokens
         total_output_tokens += response.usage.output_tokens
         web_search_requests += getattr(response.usage, "web_search_requests", 0) or 0
+
+        # Log cache performance
+        cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+        cache_create = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+        if cache_read or cache_create:
+            log(f"CACHE: read={cache_read}, create={cache_create}, uncached={response.usage.input_tokens}")
 
         # Process response content
         assistant_content = response.content
@@ -376,6 +409,9 @@ def run_perch(task: str, model: str, max_turns: int) -> dict:
     return record
 
 
+WALL_CLOCK_LIMIT = 25 * 60  # leave 5 min buffer before 30-min GHA timeout
+
+
 def _run_all(client, model, boot_output, max_turns, started_at) -> dict:
     """Run all three tasks sequentially: sleep → zeitgeist → fly.
 
@@ -391,6 +427,14 @@ def _run_all(client, model, boot_output, max_turns, started_at) -> dict:
     subtask_summaries = []
 
     for subtask in ALL_SEQUENCE:
+        # Wall-clock guard: skip subtask if insufficient time remains
+        elapsed = time.monotonic() - _start_time
+        remaining = WALL_CLOCK_LIMIT - elapsed
+        if remaining < 120:  # need at least 2 min
+            log(f"ALL [{subtask}]: SKIPPED -- only {remaining:.0f}s remaining", always=True)
+            all_errors.append(f"{subtask} skipped: insufficient time ({remaining:.0f}s)")
+            continue
+
         budget = min(max_turns, ALL_BUDGETS[subtask])
         tools = get_tool_definitions(subtask)
         system_prompt = boot_output + "\n\n" + load_prompt(f"tasks/{subtask}")

--- a/.perch/tools/memory.py
+++ b/.perch/tools/memory.py
@@ -273,15 +273,22 @@ def execute_consolidate(input: dict) -> str:
     return "\n".join(lines)
 
 
+MAX_SQL_CHARS = 10_000  # ~2.5K tokens — prevents context explosion
+
+
 def execute_sql_query(input: dict) -> str:
     """Execute raw SQL and return results."""
     rows = _exec(input["sql"], args=input.get("args"))
     if not rows:
         return "Query returned no results."
-    # Truncate large result sets
-    if len(rows) > 50:
-        return f"{len(rows)} rows returned (showing first 50):\n\n" + _format_rows(rows[:50])
-    return f"{len(rows)} row(s):\n\n" + _format_rows(rows)
+    truncated = len(rows) > 50
+    display_rows = rows[:50] if truncated else rows
+    result = _format_rows(display_rows)
+    if len(result) > MAX_SQL_CHARS:
+        result = result[:MAX_SQL_CHARS] + f"\n\n[... truncated at {MAX_SQL_CHARS} chars, {len(rows)} total rows]"
+        truncated = True
+    prefix = f"{len(rows)} rows (showing partial):" if truncated else f"{len(rows)} row(s):"
+    return f"{prefix}\n\n{result}"
 
 
 def _format_rows(rows: list) -> str:

--- a/_MAP.md
+++ b/_MAP.md
@@ -74,10 +74,10 @@
 - Claude Code on the Web Development `h2` :60
 - Test Before PR `h2` :93
 - Environment-Specific Tips `h2` :106
-- Code Maps `h2` :153
-- Skill Development Workflow `h2` :209
-- PR Reviews and Code Testing `h2` :320
-- Remembering Skill and Handoff Process `h2` :461
+- Code Maps `h2` :165
+- Skill Development Workflow `h2` :221
+- PR Reviews and Code Testing `h2` :332
+- Remembering Skill and Handoff Process `h2` :473
 
 ### README.md
 - claude-skills `h1` :1


### PR DESCRIPTION
## Summary

- **Prompt caching**: System prompt and tool definitions marked with `cache_control: ephemeral` so cached read tokens don't count against ITPM limits (~60-80% reduction after turn 1). Cache performance logged per response.
- **SQL output cap**: `sql_query` results capped at 10K chars (~2.5K tokens) to prevent context explosion. The 339K-char result from run #23 would now be 10K.
- **Wall-clock guard**: `_run_all` checks elapsed time before each subtask and skips if <2min remains, preventing wasted starts like the doomed zeitgeist in run #23.
- **retry-after header**: 429 responses now use the server-provided `retry-after` value (capped at 120s) instead of fixed 15/30/60s backoff, saving 30-60s per retry cycle.

## Test plan

- [x] Both files pass AST parse check
- [x] SQL character cap tested with small, large, and boundary inputs
- [ ] Verify prompt caching via CACHE log lines in next perch run
- [ ] Confirm wall-clock guard triggers correctly when time is low
- [ ] Monitor retry-after behavior on next 429 response

Closes #388

https://claude.ai/code/session_01LAcZsoVEV1MJR95Pdy5pFF