### PR TITLE
fix: align marketplace.json with official Claude Code plugin spec

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,322 +1,346 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "oaustegard-claude-skills",
+  "description": "Community skills for Claude Code and Claude.ai",
   "owner": {
     "name": "Oskar Austegard"
-  },
-  "metadata": {
-    "description": "Community skills for Claude Code and Claude.ai",
-    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "accessing-github-repos",
       "description": "GitHub repository access in containerized environments using REST API and credential detection. Use when git clone fails, or when accessing private repos/writing files via API.",
-      "source": "./",
+      "source": "./accessing-github-repos",
       "strict": false,
       "skills": [
-        "./accessing-github-repos"
+        "./"
       ],
       "version": "2.0.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/accessing-github-repos",
       "license": "MIT"
     },
     {
       "name": "api-credentials",
       "description": "Securely manages API credentials for multiple providers (Anthropic Claude, Google Gemini, GitHub). Use when skills need to access stored API keys for external service invocations.",
-      "source": "./",
+      "source": "./api-credentials",
       "strict": false,
       "skills": [
-        "./api-credentials"
+        "./"
       ],
       "version": "0.0.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/api-credentials",
       "license": "MIT"
     },
     {
       "name": "asking-questions",
       "description": "Guidance for asking clarifying questions when user requests are ambiguous, have multiple valid approaches, or require critical decisions. Use when implementation choices exist that could significantly affect outcomes.",
-      "source": "./",
+      "source": "./asking-questions",
       "strict": false,
       "skills": [
-        "./asking-questions"
+        "./"
       ],
       "version": "1.0.7",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/asking-questions",
       "license": "MIT"
     },
     {
       "name": "browsing-bluesky",
       "description": "Browse Bluesky content via API and firehose - search posts, fetch user activity, sample trending topics, read feeds and lists, analyze and categorize accounts. Supports authenticated access for personalized feeds. Use for Bluesky research, user monitoring, trend analysis, feed reading, firehose sampling, account categorization.",
-      "source": "./",
+      "source": "./browsing-bluesky",
       "strict": false,
       "skills": [
-        "./browsing-bluesky"
+        "./"
       ],
       "version": "0.5.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/browsing-bluesky",
       "license": "MIT"
     },
     {
       "name": "building-github-index",
       "description": "Generate progressive disclosure indexes for GitHub repositories to use as Claude project knowledge. Use when setting up projects referencing external documentation, creating searchable indexes of technical blogs or knowledge bases, combining multiple repos into one index, or when user mentions \"index\", \"github repo\", \"project knowledge\", or \"documentation reference\".",
-      "source": "./",
+      "source": "./building-github-index",
       "strict": false,
       "skills": [
-        "./building-github-index"
+        "./"
       ],
       "version": "2.0.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/building-github-index",
       "license": "MIT"
     },
     {
       "name": "building-github-index",
       "description": "Generate progressive disclosure indexes for GitHub repositories to use as Claude project knowledge. Use when setting up projects referencing external documentation, creating searchable indexes of technical blogs or knowledge bases, combining multiple repos into one index, or when user mentions \"index\", \"github repo\", \"project knowledge\", or \"documentation reference\".",
-      "source": "./",
+      "source": "./building-github-index-v2",
       "strict": false,
       "skills": [
-        "./building-github-index-v2"
+        "./"
       ],
       "version": "2.0.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/building-github-index-v2",
       "license": "MIT"
     },
     {
       "name": "categorizing-bsky-accounts",
       "description": "Analyze and categorize Bluesky accounts by topic using keyword extraction. Use when users mention Bluesky account analysis, following/follower lists, topic discovery, account curation, or network analysis.",
-      "source": "./",
+      "source": "./categorizing-bsky-accounts",
       "strict": false,
       "skills": [
-        "./categorizing-bsky-accounts"
+        "./"
       ],
       "version": "0.2.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/categorizing-bsky-accounts",
       "license": "MIT"
     },
     {
       "name": "charting-vega-lite",
       "description": "Create interactive data visualizations using Vega-Lite declarative JSON grammar. Supports 20+ chart types (bar, line, scatter, histogram, boxplot, grouped/stacked variations, etc.) via templates and programmatic builders. Use when users upload data for charting, request specific chart types, or mention visualizations. Produces portable JSON specs with inline data islands that work in Claude artifacts and can be adapted for production.",
-      "source": "./",
+      "source": "./charting-vega-lite",
       "strict": false,
       "skills": [
-        "./charting-vega-lite"
+        "./"
       ],
       "version": "0.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/charting-vega-lite",
       "license": "MIT"
     },
     {
       "name": "check-tools",
       "description": "Validates development tool installations across Python, Node.js, Java, Go, Rust, C/C++, Git, and system utilities. Use when verifying environments or troubleshooting dependencies.",
-      "source": "./",
+      "source": "./check-tools",
       "strict": false,
       "skills": [
-        "./check-tools"
+        "./"
       ],
       "version": "1.1.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/check-tools",
       "license": "MIT"
     },
     {
       "name": "cloning-project",
       "description": "Exports project instructions and knowledge files from the current Claude project. Use when users want to clone, copy, backup, or export a project's configuration and files.",
-      "source": "./",
+      "source": "./cloning-project",
       "strict": false,
       "skills": [
-        "./cloning-project"
+        "./"
       ],
       "version": "1.0.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/cloning-project",
       "license": "MIT"
     },
     {
       "name": "configuring",
       "description": "Universal environment variable loader for AI agent environments. Loads secrets and config from Claude.ai, Claude Code, OpenAI Codex, Jules, and standard .env files.",
-      "source": "./",
+      "source": "./configuring",
       "strict": false,
       "skills": [
-        "./configuring"
+        "./"
       ],
       "version": "2.0.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/configuring",
       "license": "MIT"
     },
     {
       "name": "controlling-spotify",
       "description": "Control Spotify playback and manage playlists via MCP server. Use when user requests playing music, controlling Spotify, creating playlists, searching songs, or managing their Spotify library.",
-      "source": "./",
+      "source": "./controlling-spotify",
       "strict": false,
       "skills": [
-        "./controlling-spotify"
+        "./"
       ],
       "version": "0.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/controlling-spotify",
       "license": "MIT"
     },
     {
       "name": "convening-experts",
       "description": "Convenes expert panels for problem-solving. Use when user mentions panel, experts, multiple perspectives, MECE, DMAIC, RAPID, Six Sigma, root cause analysis, strategic decisions, or process improvement.",
-      "source": "./",
+      "source": "./convening-experts",
       "strict": false,
       "skills": [
-        "./convening-experts"
+        "./"
       ],
       "version": "1.0.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/convening-experts",
       "license": "MIT"
     },
     {
       "name": "crafting-instructions",
       "description": "Generate optimized instructions for Claude (Project instructions, Skills, or standalone prompts). Use when users request creating project setups, writing effective prompts, building Skills, or need guidance on instruction types for Claude.ai.",
-      "source": "./",
+      "source": "./crafting-instructions",
       "strict": false,
       "skills": [
-        "./crafting-instructions"
+        "./"
       ],
       "version": "0.3.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/crafting-instructions",
       "license": "MIT"
     },
     {
       "name": "creating-bookmarklets",
       "description": "Creates browser-executable JavaScript bookmarklets with strict formatting requirements. Use when users mention bookmarklets, browser utilities, dragging code to bookmarks bar, or need JavaScript that runs when clicked in the browser toolbar.",
-      "source": "./",
+      "source": "./creating-bookmarklets",
       "strict": false,
       "skills": [
-        "./creating-bookmarklets"
+        "./"
       ],
       "version": "1.0.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/creating-bookmarklets",
       "license": "MIT"
     },
     {
       "name": "creating-mcp-servers",
       "description": "Creates production-ready MCP servers using FastMCP v2. Use when building MCP servers, optimizing tool descriptions for context efficiency, implementing progressive disclosure for multiple capabilities, or packaging servers for distribution.",
-      "source": "./",
+      "source": "./creating-mcp-servers",
       "strict": false,
       "skills": [
-        "./creating-mcp-servers"
+        "./"
       ],
       "version": "1.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/creating-mcp-servers",
       "license": "MIT"
     },
     {
       "name": "creating-skill",
       "description": "Creates Skills for Claude. Use when users request creating/updating skills, need skill structure guidance, or mention extending Claude's capabilities through custom skills.",
-      "source": "./",
+      "source": "./creating-skill",
       "strict": false,
       "skills": [
-        "./creating-skill"
+        "./"
       ],
       "version": "2.1.2",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/creating-skill",
       "license": "MIT"
     },
     {
       "name": "developing-preact",
       "description": "Specialized Preact development skill for standards-based web applications with native-first architecture and minimal dependency footprint. Use when building Preact projects, particularly those involving data visualization, interactive applications, single-page apps with HTM syntax, Web Components integration, CSV/JSON data parsing, WebGL shader visualizations, or zero-build solutions with vendored ESM imports.",
-      "source": "./",
+      "source": "./developing-preact",
       "strict": false,
       "skills": [
-        "./developing-preact"
+        "./"
       ],
       "version": "1.2.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/developing-preact",
       "license": "MIT"
     },
     {
       "name": "down-skilling",
       "description": "Distill Opus-level reasoning into optimized instructions for Haiku 4.5 (and Sonnet). Generates explicit, procedural prompts with n-shot examples that maximize smaller model performance on a given task. Use when user says \"down-skill\", \"distill for Haiku\", \"optimize for Haiku\", \"make this work on Haiku\", \"generate Haiku instructions\", or needs to delegate a task to a smaller model with high reliability.",
-      "source": "./",
+      "source": "./down-skilling",
       "strict": false,
       "skills": [
-        "./down-skilling"
+        "./"
       ],
       "version": "1.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/down-skilling",
       "license": "MIT"
     },
     {
       "name": "exploring-codebases",
       "description": "Semantic search for codebases. Locates matches with ripgrep and expands them into full AST nodes (functions/classes) using tree-sitter or pre-generated _MAP.md files. Returns complete, syntactically valid code blocks rather than fragmented lines. Use when looking for specific implementations, examples, or references where full context is needed.",
-      "source": "./",
+      "source": "./exploring-codebases",
       "strict": false,
       "skills": [
-        "./exploring-codebases"
+        "./"
       ],
       "version": "0.3.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/exploring-codebases",
       "license": "MIT"
     },
     {
       "name": "exploring-data",
       "description": "Exploratory data analysis using ydata-profiling. Use when users upload .csv/.xlsx/.json/.parquet files or request \"explore data\", \"analyze dataset\", \"EDA\", \"profile data\". Generates interactive HTML or JSON reports with statistics, visualizations, correlations, and quality alerts.",
-      "source": "./",
+      "source": "./exploring-data",
       "strict": false,
       "skills": [
-        "./exploring-data"
+        "./"
       ],
       "version": "0.0.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/exploring-data",
       "license": "MIT"
     },
     {
       "name": "extracting-keywords",
       "description": "Extract keywords from documents using YAKE algorithm with support for 34 languages (Arabic to Chinese). Use when users request keyword extraction, key terms, topic identification, content summarization, or document analysis. Includes domain-specific stopwords for AI/ML and life sciences. Optional deeper extraction mode (n=2+n=3 combined) for comprehensive coverage.",
-      "source": "./",
+      "source": "./extracting-keywords",
       "strict": false,
       "skills": [
-        "./extracting-keywords"
+        "./"
       ],
       "version": "0.2.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/extracting-keywords",
       "license": "MIT"
     },
     {
       "name": "fetching-blocked-urls",
       "description": "Retrieve clean markdown from URLs when web_fetch fails. Converts pages via Jina AI reader service with automatic retry. Use when web_fetch or curl returns 403, blocked, paywall, timeout, JavaScript-rendering errors, or empty content or user explicitly suggests using jina.",
-      "source": "./",
+      "source": "./fetching-blocked-urls",
       "strict": false,
       "skills": [
-        "./fetching-blocked-urls"
+        "./"
       ],
       "version": "0.1.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/fetching-blocked-urls",
       "license": "MIT"
     },
     {
       "name": "forecasting-reverso",
       "description": "Zero-shot univariate time series forecasting using the Reverso foundation model (NumPy/Numba CPU-only inference). Activate when users provide time series data and request forecasts, predictions, or extrapolations. Supports Reverso Small (550K params). Triggers on \"forecast\", \"predict\", \"time series\", \"Reverso\", or when tabular data with a temporal dimension needs future-value estimation.",
-      "source": "./",
+      "source": "./forecasting-reverso",
       "strict": false,
       "skills": [
-        "./forecasting-reverso"
+        "./"
       ],
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/forecasting-reverso",
       "license": "MIT"
     },
     {
       "name": "generating-patches",
       "description": "Generates git patch files from codebase modifications for local application. Use when user mentions patch, diff, export changes, bring changes back, apply locally, or after editing uploaded codebases.",
-      "source": "./",
+      "source": "./generating-patches",
       "strict": false,
       "skills": [
-        "./generating-patches"
+        "./"
       ],
       "version": "0.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/generating-patches",
       "license": "MIT"
     },
     {
       "name": "githubbing",
       "description": "GitHub CLI (gh) installation and authenticated operations in Claude.ai containers. Use when user needs to create issues, PRs, view repos, or perform GitHub operations beyond raw API calls.",
-      "source": "./",
+      "source": "./githubbing",
       "strict": false,
       "skills": [
-        "./githubbing"
+        "./"
       ],
       "version": "1.1.2",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/githubbing",
       "license": "MIT",
       "keywords": [
         "configuring"
@@ -325,168 +349,182 @@
     {
       "name": "hello-demo",
       "description": "Delivers a static Hello World HTML demo page with bookmarklet. Use when user requests the hello demo, hello world demo, or demo page.",
-      "source": "./",
+      "source": "./hello-demo",
       "strict": false,
       "skills": [
-        "./hello-demo"
+        "./"
       ],
       "version": "1.0.4",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/hello-demo",
       "license": "MIT"
     },
     {
       "name": "inspecting-skills",
       "description": "Discovers and indexes Python code in skills, enabling cross-skill imports. Use when importing functions from other skills or analyzing skill codebases.",
-      "source": "./",
+      "source": "./inspecting-skills",
       "strict": false,
       "skills": [
-        "./inspecting-skills"
+        "./"
       ],
       "version": "1.0.2",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/inspecting-skills",
       "license": "MIT"
     },
     {
       "name": "installing-skills",
       "description": "Install skills from github.com/oaustegard/claude-skills into /mnt/skills/user. Use when user mentions \"install skills\", \"load skills\", \"add skills\", \"update skills\", \"refresh skills\", or references a skill not currently installed.",
-      "source": "./",
+      "source": "./installing-skills",
       "strict": false,
       "skills": [
-        "./installing-skills"
+        "./"
       ],
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/installing-skills",
       "license": "MIT"
     },
     {
       "name": "invoking-gemini",
       "description": "Invokes Google Gemini models for structured outputs, multi-modal tasks, and Google-specific features. Use when users request Gemini, structured JSON output, Google API integration, or cost-effective parallel processing.",
-      "source": "./",
+      "source": "./invoking-gemini",
       "strict": false,
       "skills": [
-        "./invoking-gemini"
+        "./"
       ],
       "version": "0.4.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/invoking-gemini",
       "license": "MIT"
     },
     {
       "name": "invoking-github",
       "description": "Enables GitHub repository operations (read/write/commit/PR) for Claude.ai chat environments. Use when users request GitHub commits, repository updates, DEVLOG persistence, or cross-session state management via GitHub branches. Not needed in Claude Code (has native git access).",
-      "source": "./",
+      "source": "./invoking-github",
       "strict": false,
       "skills": [
-        "./invoking-github"
+        "./"
       ],
       "version": "0.0.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/invoking-github",
       "license": "MIT"
     },
     {
       "name": "iterating",
       "description": "Multi-conversation methodology for iterative stateful work with context accumulation. Use when users request work that spans multiple sessions (research, debugging, refactoring, feature development), need to build on past progress, explicitly mention iterative work, work logs, project knowledge, or cross-conversation learning.",
-      "source": "./",
+      "source": "./iterating",
       "strict": false,
       "skills": [
-        "./iterating"
+        "./"
       ],
       "version": "1.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/iterating",
       "license": "MIT"
     },
     {
       "name": "making-waffles",
       "description": "Generates WAFFLES Declarations for social media posts — preemptive lists of what a post does NOT say. Use when users mention WAFFLES, ask for clarifications on their post, want to prevent misinterpretation, or request disclaimers for controversial/nuanced takes.",
-      "source": "./",
+      "source": "./making-waffles",
       "strict": false,
       "skills": [
-        "./making-waffles"
+        "./"
       ],
       "version": "0.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/making-waffles",
       "license": "MIT"
     },
     {
       "name": "mapping-codebases",
       "description": "Generate navigable code maps for unfamiliar codebases. Extracts exports/imports via AST (tree-sitter) to create _MAP.md files per directory showing classes, functions, methods with signatures and line numbers. Use when exploring repositories, understanding project structure, analyzing unfamiliar code, or before modifications. Triggers on \"map this codebase\", \"explore repo\", \"understand structure\", \"what does this project contain\", or when starting work on an unfamiliar repository.",
-      "source": "./",
+      "source": "./mapping-codebases",
       "strict": false,
       "skills": [
-        "./mapping-codebases"
+        "./"
       ],
       "version": "0.7.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/mapping-codebases",
       "license": "MIT"
     },
     {
       "name": "orchestrating-agents",
       "description": "Orchestrates parallel API instances, delegated sub-tasks, and multi-agent workflows with streaming and tool-enabled delegation patterns. Use for parallel analysis, multi-perspective reviews, or complex task decomposition.",
-      "source": "./",
+      "source": "./orchestrating-agents",
       "strict": false,
       "skills": [
-        "./orchestrating-agents"
+        "./"
       ],
       "version": "0.3.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/orchestrating-agents",
       "license": "MIT"
     },
     {
       "name": "orchestrating-skills",
       "description": "Skill-aware orchestration with context routing. Decomposes complex tasks into skill-typed subtasks, extracts targeted context subsets, executes subagents in parallel, and synthesizes results. Self-answers trivial lookups inline. No SDK dependency — uses raw HTTP via httpx. Use when tasks require multiple analytical perspectives, when context is large and subtasks only need portions, or when orchestrating-agents spawns too many redundant subagents.",
-      "source": "./",
+      "source": "./orchestrating-skills",
       "strict": false,
       "skills": [
-        "./orchestrating-skills"
+        "./"
       ],
       "version": "0.3.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/orchestrating-skills",
       "license": "MIT"
     },
     {
       "name": "remembering",
       "description": "Advanced memory operations reference. Basic patterns (profile loading, simple recall/remember) are in project instructions. Consult this skill for background writes, memory versioning, complex queries, edge cases, session scoping, retention management, type-safe results, proactive memory hints, GitHub access detection, autonomous curation, episodic scoring, and decision traces.",
-      "source": "./",
+      "source": "./remembering",
       "strict": false,
       "skills": [
-        "./remembering"
+        "./"
       ],
       "version": "5.4.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/remembering",
       "license": "MIT"
     },
     {
       "name": "reviewing-ai-papers",
       "description": "Analyze AI/ML technical content (papers, articles, blog posts) and extract actionable insights filtered through enterprise AI engineering lens. Use when user provides URL/document for AI/ML content analysis, asks to \"review this paper\", or mentions technical content in domains like RAG, embeddings, fine-tuning, prompt engineering, LLM deployment.",
-      "source": "./",
+      "source": "./reviewing-ai-papers",
       "strict": false,
       "skills": [
-        "./reviewing-ai-papers"
+        "./"
       ],
       "version": "0.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/reviewing-ai-papers",
       "license": "MIT"
     },
     {
       "name": "sorting-groceries",
       "description": "Sort grocery lists by aisle order using store aisle sign photos. Build aisle maps from uploaded images, match items to aisles, and output optimized shopping routes. Use when users upload aisle sign photos, request grocery list sorting, want shopping trip optimization, need store layout mapping, or mention grocery list organization.",
-      "source": "./",
+      "source": "./sorting-groceries",
       "strict": false,
       "skills": [
-        "./sorting-groceries"
+        "./"
       ],
       "version": "0.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/sorting-groceries",
       "license": "MIT"
     },
     {
       "name": "tiling-tree",
       "description": "Exhaustive problem space exploration using the MIT Synthetic Neurobiology \"tiling tree\" method. Partitions a problem into MECE (Mutually Exclusive, Collectively Exhaustive) subsets recursively via parallel subagents, then evaluates leaf ideas against specified criteria. Use when users say \"tiling tree\", \"tile the solution space\", \"exhaustively explore approaches to\", \"what are all the ways to\", or request a MECE breakdown of a problem. Requires orchestrating-agents skill.",
-      "source": "./",
+      "source": "./tiling-tree",
       "strict": false,
       "skills": [
-        "./tiling-tree"
+        "./"
       ],
       "version": "1.0.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/tiling-tree",
       "license": "MIT",
       "keywords": [
         "orchestrating-agents"
@@ -495,37 +533,40 @@
     {
       "name": "updating-knowledge",
       "description": "Systematic research methodology for building comprehensive, current knowledge on any topic. Requires web_search tool. Use when questions require thorough investigation, recent developments post-cutoff, synthesis across multiple sources, or when Claude's knowledge may be outdated or incomplete. Triggered by \"Research\", \"Investigate\", \"What's current on\", \"Latest info on\", complex queries needing validation, or technical topics with recent changes.",
-      "source": "./",
+      "source": "./updating-knowledge",
       "strict": false,
       "skills": [
-        "./updating-knowledge"
+        "./"
       ],
       "version": "1.0.3",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/updating-knowledge",
       "license": "MIT"
     },
     {
       "name": "using-webctl",
       "description": "Browser automation via webctl CLI in Claude.ai containers with authenticated proxy support. Use when users mention webctl, browser automation, Playwright browsing, web scraping, or headless Chrome in container environments.",
-      "source": "./",
+      "source": "./using-webctl",
       "strict": false,
       "skills": [
-        "./using-webctl"
+        "./"
       ],
       "version": "0.0.1",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/using-webctl",
       "license": "MIT"
     },
     {
       "name": "versioning-skills",
       "description": "REQUIRED for all skill development. Automatically version control every skill file modification for rollback/comparison. Use after init_skill.sh, after every str_replace/create_file, and before packaging.",
-      "source": "./",
+      "source": "./versioning-skills",
       "strict": false,
       "skills": [
-        "./versioning-skills"
+        "./"
       ],
       "version": "1.1.0",
       "repository": "https://github.com/oaustegard/claude-skills",
+      "homepage": "https://github.com/oaustegard/claude-skills/tree/main/versioning-skills",
       "license": "MIT"
     }
   ]

--- a/registry/_MAP.md
+++ b/registry/_MAP.md
@@ -11,8 +11,8 @@
 - **discover_skill_dirs** (f) `(root: Path)` :28
 - **normalize_list** (f) `(value)` :43
 - **build_entry** (f) `(skill_dir: Path)` :54
-- **generate** (f) `(root: Path)` :88
-- **main** (f) `()` :104
+- **generate** (f) `(root: Path)` :89
+- **main** (f) `()` :105
 
 ### schema.py
 > Imports: `dataclasses, typing`

--- a/registry/generate.py
+++ b/registry/generate.py
@@ -75,10 +75,11 @@ def build_entry(skill_dir: Path) -> PluginEntry | None:
     return PluginEntry(
         name=name,
         description=description,
-        source="./",
+        source=f"./{skill_dir.name}",
         strict=False,
-        skills=[f"./{skill_dir.name}"],
+        skills=["./"],
         version=version,
+        homepage=f"https://github.com/{REPO}/tree/main/{skill_dir.name}",
         repository=f"https://github.com/{REPO}",
         license="MIT",
         keywords=keywords if keywords else [],

--- a/registry/schema.py
+++ b/registry/schema.py
@@ -15,7 +15,9 @@ class PluginEntry:
     version: Optional[str] = None
     author: Optional[dict] = None
     repository: Optional[str] = None
+    homepage: Optional[str] = None
     license: Optional[str] = None
+    category: Optional[str] = None
     keywords: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
@@ -32,8 +34,12 @@ class PluginEntry:
             d["author"] = self.author
         if self.repository:
             d["repository"] = self.repository
+        if self.homepage:
+            d["homepage"] = self.homepage
         if self.license:
             d["license"] = self.license
+        if self.category:
+            d["category"] = self.category
         if self.keywords:
             d["keywords"] = self.keywords
         return d
@@ -42,20 +48,19 @@ class PluginEntry:
 @dataclass
 class Marketplace:
     """Top-level marketplace manifest."""
+    schema: str = "https://anthropic.com/claude-code/marketplace.schema.json"
     name: str = "oaustegard-claude-skills"
+    description: str = "Community skills for Claude Code and Claude.ai"
     owner: dict = field(default_factory=lambda: {
         "name": "Oskar Austegard",
-    })
-    metadata: dict = field(default_factory=lambda: {
-        "description": "Community skills for Claude Code and Claude.ai",
-        "version": "1.0.0",
     })
     plugins: list[PluginEntry] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
+            "$schema": self.schema,
             "name": self.name,
+            "description": self.description,
             "owner": self.owner,
-            "metadata": self.metadata,
             "plugins": [p.to_dict() for p in self.plugins],
         }


### PR DESCRIPTION
- Add $schema pointing to Anthropic's marketplace schema
- Change source from "./" to "./skill-name" per-plugin (each plugin points to its skill directory, not the repo root)
- skills: ["./"] means the source directory itself contains SKILL.md
- Use strict: false so marketplace controls component definitions
- Add homepage per plugin pointing to GitHub tree
- Move description to root level (drop metadata wrapper)
- Matches pattern used by anthropics/claude-plugins-official

https://claude.ai/code/session_01HEVNzGF6Zofb6m7YfeNEVw