### PR TITLE
feat: surface due reminders in boot() output (#425)

### DIFF
--- a/remembering/scripts/_MAP.md
+++ b/remembering/scripts/_MAP.md
@@ -22,23 +22,23 @@
 - **profile** (f) `()` :382
 - **ops** (f) `(include_reference: bool = False)` :387
 - **boot** (f) `(mode: str = None)` :461
-- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :823
-- **journal_recent** (f) `(n: int = 10)` :840
-- **journal_prune** (f) `(keep: int = 40)` :856
-- **therapy_scope** (f) `()` :870
-- **therapy_session_count** (f) `()` :885
-- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :894
+- **journal** (f) `(topics: list = None, user_stated: str = None, my_intent: str = None)` :867
+- **journal_recent** (f) `(n: int = 10)` :884
+- **journal_prune** (f) `(keep: int = 40)` :900
+- **therapy_scope** (f) `()` :914
+- **therapy_session_count** (f) `()` :929
+- **decisions_recent** (f) `(n: int = 10, conf: float = 0.7)` :938
 - **therapy_reflect** (f) `(*, n_sample: int = 20, similarity_threshold: int = 3,
-                     dry_run: bool = True)` :907
-- **group_by_type** (f) `(memories: list)` :1037
-- **group_by_tag** (f) `(memories: list)` :1053
-- **muninn_export** (f) `()` :1073
-- **session_save** (f) `(summary: str = None, context: dict = None)` :1090
-- **session_resume** (f) `(session_id: str = None)` :1140
-- **sessions** (f) `(n: int = 10, *, include_counts: bool = False)` :1212
-- **handoff_pending** (f) `()` :1277
-- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :1292
-- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :1324
+                     dry_run: bool = True)` :951
+- **group_by_type** (f) `(memories: list)` :1081
+- **group_by_tag** (f) `(memories: list)` :1097
+- **muninn_export** (f) `()` :1117
+- **session_save** (f) `(summary: str = None, context: dict = None)` :1134
+- **session_resume** (f) `(session_id: str = None)` :1184
+- **sessions** (f) `(n: int = 10, *, include_counts: bool = False)` :1256
+- **handoff_pending** (f) `()` :1321
+- **handoff_complete** (f) `(handoff_id: str, completion_notes: str, version: str = None)` :1336
+- **muninn_import** (f) `(data: dict, *, merge: bool = False)` :1368
 
 ### bootstrap.py
 > Imports: `sys, os, scripts`

--- a/remembering/scripts/boot.py
+++ b/remembering/scripts/boot.py
@@ -523,6 +523,9 @@ def boot(mode: str = None) -> str:
     # Surface recent flight logs (#415)
     recent_flights = _load_recent_flights()
 
+    # Surface due reminders (#425)
+    due_reminders = _load_due_reminders()
+
     # Filter ops by boot_load flag (progressive disclosure)
     # Reference-only entries (boot_load=0) excluded from boot output but accessible via config_get()
     # Note: Turso returns boot_load as string ('0' or '1')
@@ -533,7 +536,7 @@ def boot(mode: str = None) -> str:
     ops_by_topic, uncategorized = group_ops_by_topic(core_ops)
 
     # Format output with markdown headings
-    return _format_boot_output(profile_data, ops_by_topic, uncategorized, reference_ops, installed_utils, github_access, pending_tasks, recent_flights)
+    return _format_boot_output(profile_data, ops_by_topic, uncategorized, reference_ops, installed_utils, github_access, pending_tasks, recent_flights, due_reminders)
 
 
 def _boot_perch(profile_data: list, ops_data: list) -> str:
@@ -646,6 +649,32 @@ def _load_recent_flights(n: int = 5) -> list:
         return []
 
 
+def _load_due_reminders() -> list:
+    """Load reminders that are due for boot display (#425).
+
+    Queries active reminders and filters to those where valid_from <= now.
+    Does NOT mark reminders as delivered — that happens in-conversation
+    via muninn_utils.remind.deliver().
+
+    Returns list of dicts with 'summary', 'valid_from', 'id'.
+    Safe to call — returns empty list on any error.
+    """
+    try:
+        reminders = recall(tags=["reminder", "active"], n=50, tag_mode="all")
+        if not reminders:
+            return []
+
+        now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        due = []
+        for r in reminders:
+            valid_from = r.get('valid_from', '')
+            if valid_from and valid_from <= now_iso:
+                due.append(r)
+        return due
+    except Exception:
+        return []
+
+
 def _time_anchor() -> str:
     """Generate current time context for boot output.
 
@@ -704,12 +733,14 @@ def _format_boot_output(profile_data: list, ops_by_topic: dict,
                         uncategorized: list, reference_ops: list,
                         installed_utils: dict, github_access: dict = None,
                         pending_tasks: list = None,
-                        recent_flights: list = None) -> str:
+                        recent_flights: list = None,
+                        due_reminders: list = None) -> str:
     """Format boot output with organized sections.
 
     v3.6.0: Entries within each topic are pre-sorted by priority (descending)
     by group_ops_by_topic(), so critical entries appear first.
     v5.6.0: Added recent_flights for flight log awareness (#415).
+    v5.7.0: Added due_reminders for reminder surfacing at boot (#425).
 
     Args:
         profile_data: List of profile config entries
@@ -719,6 +750,7 @@ def _format_boot_output(profile_data: list, ops_by_topic: dict,
         installed_utils: Dict of {name: {"path": path, "use_when": str|None}} from install_utilities()
         github_access: Dict from detect_github_access() with GitHub capabilities
         recent_flights: List of recent flight log discussions from GitHub (#415)
+        due_reminders: List of due reminder memories from _load_due_reminders() (#425)
 
     Returns:
         Formatted boot output string with markdown headings
@@ -816,6 +848,18 @@ def _format_boot_output(profile_data: list, ops_by_topic: dict,
             number = f.get("number", "?")
             title = f.get("title", "Untitled")
             output.append(f"- #{number} ({date}, {status}): {title}")
+
+    # Due reminders section (#425: reminder surfacing at boot)
+    if due_reminders:
+        output.append("\n🔔 REMINDERS:")
+        for r in due_reminders:
+            text = r.get('summary', '')
+            # Strip "REMINDER: " prefix for cleaner display
+            if text.upper().startswith('REMINDER: '):
+                text = text[len('REMINDER: '):]
+            due_time = r.get('valid_from', 'unknown')
+            short_id = r.get('id', '')[:8]
+            output.append(f"  - {text} (due: {due_time}, id: {short_id})")
 
     return '\n'.join(output)
 


### PR DESCRIPTION
## Summary

- Adds `_load_due_reminders()` to query active reminders where `valid_from <= now`
- Appends a `🔔 REMINDERS:` section to boot output with text, due time, and short ID
- Strips `REMINDER: ` prefix from summary for cleaner display
- Wrapped in try/except — never breaks boot over reminder failure
- Does NOT mark reminders as delivered (that's Muninn's job in-conversation)

## Test plan

- [ ] Verify boot() output includes reminders section when due reminders exist
- [ ] Verify no reminders section when none are due
- [ ] Verify future reminders (valid_from > now) are excluded
- [ ] Verify boot doesn't break if recall fails

Closes #425

https://claude.ai/code/session_01HPino3KvTCre1oEWQ1tM55