### PR TITLE
ci: Force Node.js 24 for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/perch.yml
+++ b/.github/workflows/perch.yml
@@ -34,6 +34,9 @@ permissions:
   contents: read
   discussions: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   perch:
     runs-on: ubuntu-latest

--- a/.github/workflows/registry-generate.yml
+++ b/.github/workflows/registry-generate.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -20,12 +20,15 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-skill:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for changelog generation
 

--- a/.github/workflows/skill-upload.yml
+++ b/.github/workflows/skill-upload.yml
@@ -10,12 +10,15 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   upload-skill:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2  # Fetch current commit and parent to enable diff
 


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to all 4 workflows (perch, registry-generate, skill-release, skill-upload)
- Bump `actions/checkout@v3` → `v4` in skill-release and skill-upload (were lagging behind perch and registry-generate)

Opts into Node.js 24 ahead of the June 2, 2026 forced migration deadline. Suppresses the deprecation warnings from actions/checkout@v4, actions/setup-python@v5, and actions/upload-artifact@v4.

## Test plan
- [ ] Trigger a workflow_dispatch on perch and verify no Node.js 20 deprecation warnings
- [ ] Verify skill-release and skill-upload still work with checkout@v4

https://claude.ai/code/session_01LYopq2aGsZ1hb3DxH6fdPF