### PR TITLE
feat(mapping-features): --routes, incremental descriptions, redirect gating, proxy API

### DIFF
--- a/mapping-features/SKILL.md
+++ b/mapping-features/SKILL.md
@@ -2,7 +2,7 @@
 name: mapping-features
 description: Generate behavioral/feature documentation for brownfield web apps. Captures screenshots, accessibility trees, and behavioral invariants via browser automation, then synthesizes into _FEATURES.md. Companion to mapping-codebases. Use when documenting app behavior, creating feature inventories, generating behavioral ground truth for agents, or before modifying UI code. Triggers on "map features", "document app behavior", "feature inventory", "what does this app do".
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # Mapping Features
@@ -44,12 +44,22 @@ python /mnt/skills/user/mapping-features/scripts/featuremap.py \
 | `--viewport` | `1280x720` | Screenshot viewport (WxH) |
 | `--skip-describe` | `false` | Capture only, skip Claude vision step |
 | `--incremental` | `false` | Only re-capture pages with changed screenshots |
+| `--routes` | none | Comma-separated routes or path to routes file |
 | `--screenshots-dir` | `<codebase>/screenshots` | Where to store PNGs |
 
 ## Execution Phases
 
 ### Phase 1: DISCOVER
 Reads `_MAP.md` + navigates app entry point via webctl. Crawls accessible routes by extracting nav links from accessibility snapshots. Builds a sitemap of reachable pages.
+
+For SPAs with JS-only navigation, use `--routes` to seed known paths:
+```bash
+python featuremap.py --app-url https://example.com --codebase . \
+  --routes /,/demo.html,/dashboard.html
+# Or from a file:
+python featuremap.py --app-url https://example.com --codebase . --routes routes.txt
+```
+Routes are merged with discover results (manual routes take priority).
 
 ### Phase 2: CAPTURE
 For each discovered page: takes a screenshot, captures the accessibility tree (interactive elements), and hashes the screenshot for staleness detection.
@@ -77,7 +87,7 @@ After manual capture, re-run with `--incremental` to describe the new pages.
 
 ## Staleness Detection
 
-Each run stores screenshot hashes in `_FEATURES_MANIFEST.json`. On re-run with `--incremental`, unchanged pages skip re-description. Changed pages are re-captured and re-described.
+Each run stores screenshot hashes and descriptions in `_FEATURES_MANIFEST.json`. On re-run with `--incremental`, unchanged pages reuse their stored descriptions (no API calls). Changed pages are re-captured and re-described.
 
 ## Output Format
 
@@ -124,5 +134,5 @@ App URL: https://example.com
 
 - Requires a running app instance (no static analysis of UI)
 - Claude API calls for vision cost tokens — use `--incremental` to minimize
-- Single-page apps with client-side routing may need manual route hints
+- Single-page apps with client-side routing may need `--routes` flag to seed known paths
 - Auth-gated pages require human intervention

--- a/mapping-features/scripts/describe.py
+++ b/mapping-features/scripts/describe.py
@@ -151,6 +151,22 @@ def _get_api_key() -> str:
     )
 
 
+def _get_api_url() -> str:
+    """Build the Anthropic API messages URL, routing through CF gateway if available.
+
+    Returns:
+        Full URL for the messages endpoint.
+    """
+    cf_account = os.environ.get("CF_ACCOUNT_ID", "").strip()
+    cf_gateway = os.environ.get("CF_GATEWAY_ID", "").strip()
+    if cf_account and cf_gateway:
+        return (
+            f"https://gateway.ai.cloudflare.com/v1/"
+            f"{cf_account}/{cf_gateway}/anthropic/v1/messages"
+        )
+    return "https://api.anthropic.com/v1/messages"
+
+
 def describe_page(
     capture: PageCapture,
     codebase: Path,
@@ -220,8 +236,10 @@ def describe_page(
         ],
     }).encode("utf-8")
 
+    api_url = _get_api_url()
+
     req = urllib.request.Request(
-        "https://api.anthropic.com/v1/messages",
+        api_url,
         data=payload,
         headers={
             "x-api-key": api_key,

--- a/mapping-features/scripts/discover.py
+++ b/mapping-features/scripts/discover.py
@@ -160,14 +160,28 @@ def discover_pages(app_url: str, max_pages: int = 20) -> list[PageInfo]:
             ))
             continue
 
+        # Check for redirect-as-gating: if final URL differs from intended
+        is_gated = False
+        gate_reason = ""
+        try:
+            current_url = run_webctl("evaluate", "window.location.href")
+            current_path = urlparse(current_url).path.rstrip("/") or "/"
+            intended_path = (parsed.path or "/").rstrip("/") or "/"
+            if current_path != intended_path:
+                is_gated = True
+                gate_reason = f"redirected to {current_url}"
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            pass
+
         # Capture accessibility snapshot
         try:
             snapshot = run_webctl("snapshot", "--interactive-only", "--limit", "50")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             snapshot = ""
 
-        # Check if gated
-        is_gated, gate_reason = detect_gated_page(snapshot)
+        # Check text-based gating heuristics (if not already gated by redirect)
+        if not is_gated:
+            is_gated, gate_reason = detect_gated_page(snapshot)
 
         page = PageInfo(
             url=url,

--- a/mapping-features/scripts/featuremap.py
+++ b/mapping-features/scripts/featuremap.py
@@ -15,7 +15,7 @@ from pathlib import Path
 if __name__ == "__main__":
     sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from scripts.discover import discover_pages, pages_to_dict
+from scripts.discover import discover_pages, pages_to_dict, PageInfo
 from scripts.capture import capture_all_pages, PageCapture
 from scripts.describe import describe_all_pages
 from scripts.assemble import write_features_md
@@ -73,6 +73,13 @@ Examples:
         help="Claude model for vision descriptions (default: claude-sonnet-4-6)",
     )
     parser.add_argument(
+        "--routes",
+        help=(
+            "Comma-separated list of routes (e.g. /,/demo.html,/dashboard.html) "
+            "or path to a file with one route per line. Skips or supplements discover crawl."
+        ),
+    )
+    parser.add_argument(
         "--dry-run", "-n", action="store_true",
         help="Discover pages only, print sitemap without capturing",
     )
@@ -98,9 +105,42 @@ def main() -> int:
         return 1
 
     # Phase 1: DISCOVER
-    print(f"Phase 1: Discovering pages at {args.app_url}...")
-    pages = discover_pages(args.app_url, max_pages=args.max_pages)
-    print(f"  Found {len(pages)} pages")
+    # Parse --routes if provided
+    manual_routes: list[str] = []
+    if args.routes:
+        routes_path = Path(args.routes)
+        if routes_path.is_file():
+            manual_routes = [
+                line.strip() for line in routes_path.read_text().splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ]
+        else:
+            manual_routes = [r.strip() for r in args.routes.split(",") if r.strip()]
+
+    if manual_routes:
+        # Build PageInfo from manual routes
+        from urllib.parse import urljoin
+        route_pages = []
+        for route in manual_routes:
+            url = urljoin(args.app_url.rstrip("/") + "/", route.lstrip("/") or "/")
+            route_pages.append(PageInfo(url=url, path=route if route.startswith("/") else "/" + route))
+        if args.max_pages > 0:
+            # Also run discover to find additional pages
+            print(f"Phase 1: Discovering pages at {args.app_url} (seeded with {len(route_pages)} routes)...")
+            discovered = discover_pages(args.app_url, max_pages=args.max_pages)
+            # Merge: manual routes first, then discovered (deduplicated by path)
+            seen_paths = {p.path.rstrip("/") or "/" for p in route_pages}
+            for dp in discovered:
+                norm = dp.path.rstrip("/") or "/"
+                if norm not in seen_paths:
+                    route_pages.append(dp)
+                    seen_paths.add(norm)
+        pages = route_pages
+        print(f"  Total pages: {len(pages)} ({len(manual_routes)} from --routes)")
+    else:
+        print(f"Phase 1: Discovering pages at {args.app_url}...")
+        pages = discover_pages(args.app_url, max_pages=args.max_pages)
+        print(f"  Found {len(pages)} pages")
 
     for p in pages:
         status = "GATED" if p.gated else "OK"
@@ -130,7 +170,8 @@ def main() -> int:
     else:
         captures_to_describe = captures
 
-    # Save manifest with current hashes
+    # Save manifest with current hashes (descriptions added after describe phase)
+    # Initial save for hash tracking; will be updated with descriptions later
     save_manifest(codebase, captures, args.app_url)
 
     # Generate auth instructions for gated pages
@@ -157,18 +198,32 @@ def main() -> int:
 
     # Merge unchanged descriptions from previous run if incremental
     if args.incremental and old_manifest:
-        # For unchanged pages, create placeholder descriptions
+        old_pages = old_manifest.get("pages", {})
         for c in unchanged:
-            descriptions.append({
-                "path": c.page.path,
-                "url": c.page.url,
-                "description": "*(unchanged — using previous description)*",
-                "error": "",
-            })
+            old_entry = old_pages.get(c.page.path, {})
+            prev_desc = old_entry.get("description", "")
+            if prev_desc:
+                descriptions.append({
+                    "path": c.page.path,
+                    "url": c.page.url,
+                    "description": prev_desc,
+                    "error": "",
+                })
+            else:
+                # Legacy manifest without descriptions — must re-describe
+                descriptions.append({
+                    "path": c.page.path,
+                    "url": c.page.url,
+                    "description": "*(unchanged — previous description not available, re-run without --incremental)*",
+                    "error": "",
+                })
 
     desc_ok = sum(1 for d in descriptions if d.get("description") and not d.get("error"))
     desc_err = sum(1 for d in descriptions if d.get("error"))
     print(f"  Described: {desc_ok} | Errors: {desc_err}")
+
+    # Update manifest with descriptions for future incremental runs
+    save_manifest(codebase, captures, args.app_url, descriptions=descriptions)
 
     # Phase 4: ASSEMBLE
     print(f"\nPhase 4: Assembling _FEATURES.md...")

--- a/mapping-features/scripts/staleness.py
+++ b/mapping-features/scripts/staleness.py
@@ -33,18 +33,36 @@ def load_manifest(codebase: Path) -> dict:
         return {}
 
 
-def save_manifest(codebase: Path, captures: list[PageCapture], app_url: str) -> Path:
-    """Save the features manifest with current screenshot hashes.
+def save_manifest(
+    codebase: Path,
+    captures: list[PageCapture],
+    app_url: str,
+    descriptions: list[dict] | None = None,
+) -> Path:
+    """Save the features manifest with current screenshot hashes and descriptions.
 
     Args:
         codebase: Path to codebase root.
         captures: List of PageCapture with current hashes.
         app_url: Base URL of the app.
+        descriptions: Optional list of description dicts to persist alongside hashes.
 
     Returns:
         Path to the written manifest file.
     """
     from datetime import datetime, timezone
+
+    # Build description lookup
+    desc_by_path: dict[str, str] = {}
+    if descriptions:
+        for d in descriptions:
+            text = d.get("description", "")
+            if text and not text.startswith("*(unchanged"):
+                desc_by_path[d["path"]] = text
+
+    # Preserve descriptions from old manifest for pages not re-described
+    old_manifest = load_manifest(codebase)
+    old_pages = old_manifest.get("pages", {})
 
     manifest: dict = {
         "app_url": app_url,
@@ -54,11 +72,17 @@ def save_manifest(codebase: Path, captures: list[PageCapture], app_url: str) -> 
 
     for c in captures:
         if c.screenshot_hash:
-            manifest["pages"][c.page.path] = {
+            entry: dict = {
                 "hash": c.screenshot_hash,
                 "screenshot": c.screenshot_path,
                 "url": c.page.url,
             }
+            # Store description: prefer fresh, fall back to old manifest
+            if c.page.path in desc_by_path:
+                entry["description"] = desc_by_path[c.page.path]
+            elif c.page.path in old_pages and "description" in old_pages[c.page.path]:
+                entry["description"] = old_pages[c.page.path]["description"]
+            manifest["pages"][c.page.path] = entry
         elif c.page.gated:
             manifest["pages"][c.page.path] = {
                 "hash": "",


### PR DESCRIPTION
## Summary

- **#437**: Add `--routes` CLI flag accepting comma-separated paths or a routes file. Manual routes are merged with discover results (deduped by path). Enables SPA support where JS navigation is invisible to the crawler.
- **#438**: Store description text in `_FEATURES_MANIFEST.json` alongside hashes. Incremental mode now preserves actual descriptions for unchanged pages instead of showing placeholder text. Legacy manifests (no description field) fall back gracefully.
- **#439**: After navigation, compare final URL to intended URL. If redirected to a different path (common auth pattern), mark page as GATED. Trailing slashes are normalized to avoid false positives.
- **#440**: Check for `CF_ACCOUNT_ID` / `CF_GATEWAY_ID` env vars and route API calls through Cloudflare gateway proxy when available. Falls back to direct `api.anthropic.com`.

Closes #437, closes #438, closes #439, closes #440

## Test plan

- [ ] Verify `--routes /,/demo.html` creates PageInfo entries and merges with discover
- [ ] Verify `--routes routes.txt` reads routes from file (one per line, comments ignored)
- [ ] Verify incremental mode preserves descriptions from manifest
- [ ] Verify redirect detection marks pages as GATED when final URL differs
- [ ] Verify trailing slash normalization prevents false gating
- [ ] Verify CF gateway URL construction when env vars are set
- [ ] Verify fallback to direct API URL when env vars absent

https://claude.ai/code/session_01TFMjnJ2m2hvvyC5ks8qhY3