### PR TITLE
feat(mapping-features): v0.3 code-first overhaul with selective vision

### DIFF
--- a/mapping-features/SKILL.md
+++ b/mapping-features/SKILL.md
@@ -1,138 +1,158 @@
 ---
 name: mapping-features
-description: Generate behavioral/feature documentation for brownfield web apps. Captures screenshots, accessibility trees, and behavioral invariants via browser automation, then synthesizes into _FEATURES.md. Companion to mapping-codebases. Use when documenting app behavior, creating feature inventories, generating behavioral ground truth for agents, or before modifying UI code. Triggers on "map features", "document app behavior", "feature inventory", "what does this app do".
+description: Generate behavioral/feature documentation for web apps using code-first analysis. Reads source code and _MAP.md files to produce _FEATURES.md, with optional visual verification via browser automation. Companion to mapping-codebases. Use when documenting app behavior, creating feature inventories, generating behavioral ground truth for agents, or before modifying UI code. Triggers on "map features", "document app behavior", "feature inventory", "what does this app do".
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # Mapping Features
 
-Generate `_FEATURES.md` files documenting what a web app *does* from the outside in — screens, flows, states, behavioral invariants. Companion to `mapping-codebases` which documents code *structure*.
+Generate `_FEATURES.md` files documenting what a web app *does* — screens, flows, states, behavioral invariants. Companion to `mapping-codebases` which documents code *structure*.
+
+**v0.3.0: Code-first architecture.** The code IS the ground truth; screenshots are supplementary verification.
 
 ## Prerequisites
 
 1. **mapping-codebases** must have run first (`_MAP.md` files exist)
-2. **webctl** installed and configured (see `using-webctl` skill)
-3. **Claude API key** available (via `api-credentials` skill or `ANTHROPIC_API_KEY` env var)
-4. A running instance of the target app (local dev server or deployed URL)
-
-## Installation
-
-```bash
-pip install webctl --break-system-packages
-webctl setup
-# Apply proxy patch per using-webctl skill if in Claude.ai container
-```
+2. **Claude API key** available (via `api-credentials` skill or `ANTHROPIC_API_KEY` env var)
+3. *Optional:* **webctl** for visual verification (not required for `--code-only`)
 
 ## Usage
 
 ```bash
+# Code-only analysis (no browser needed):
 python /mnt/skills/user/mapping-features/scripts/featuremap.py \
-  --app-url https://example.com \
-  --codebase /path/to/repo \
-  --output /path/to/repo/_FEATURES.md
+  --app-url https://example.com --codebase /path/to/repo --code-only
+
+# Full pipeline (code analysis + selective visual verification):
+python /mnt/skills/user/mapping-features/scripts/featuremap.py \
+  --app-url https://example.com --codebase /path/to/repo
+
+# Incremental update:
+python /mnt/skills/user/mapping-features/scripts/featuremap.py \
+  --app-url https://example.com --codebase . --incremental
 ```
 
 ### Options
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--app-url` | required | Base URL of the running app |
-| `--codebase` | required | Path to repo root (must contain `_MAP.md` files) |
-| `--output` | `<codebase>/_FEATURES.md` | Output path for features doc |
-| `--max-pages` | `20` | Cap on pages to discover before prompting |
+| `--app-url` | required | Base URL of the web app |
+| `--codebase` | required | Path to repo root (must have `_MAP.md` files) |
+| `--output` | `<codebase>/_FEATURES.md` | Output path |
+| `--max-pages` | `100` | Cap on pages to discover |
+| `--code-only` | `false` | Skip all vision — code analysis only |
+| `--verify-only` | `false` | Only run vision on already-analyzed pages |
+| `--batch-size` | auto | Pages per batch (auto-detected from environment) |
+| `--incremental` | `false` | Only re-process changed pages |
 | `--viewport` | `1280x720` | Screenshot viewport (WxH) |
-| `--skip-describe` | `false` | Capture only, skip Claude vision step |
-| `--incremental` | `false` | Only re-capture pages with changed screenshots |
 | `--routes` | none | Comma-separated routes or path to routes file |
 | `--screenshots-dir` | `<codebase>/screenshots` | Where to store PNGs |
+| `--model` | `claude-sonnet-4-6` | Claude model for analysis/vision |
+| `--dry-run` / `-n` | `false` | Discover only, print sitemap |
 
-## Execution Phases
+## Architecture: Code-First Pipeline
 
 ### Phase 1: DISCOVER
-Reads `_MAP.md` + navigates app entry point via webctl. Crawls accessible routes by extracting nav links from accessibility snapshots. Builds a sitemap of reachable pages.
+Discovers pages from **code structure**, not browser crawling:
+- Scans for HTML files (static sites)
+- Detects framework routing conventions (Next.js, SvelteKit, etc.)
+- Parses `_MAP.md` for page references
+- Supplements with `--routes` for manual seeding
 
-For SPAs with JS-only navigation, use `--routes` to seed known paths:
-```bash
-python featuremap.py --app-url https://example.com --codebase . \
-  --routes /,/demo.html,/dashboard.html
-# Or from a file:
-python featuremap.py --app-url https://example.com --codebase . --routes routes.txt
-```
-Routes are merged with discover results (manual routes take priority).
+No browser required for discovery.
 
-### Phase 2: CAPTURE
-For each discovered page: takes a screenshot, captures the accessibility tree (interactive elements), and hashes the screenshot for staleness detection.
+### Phase 2: ANALYZE
+Reads source code for each discovered page and uses Claude API (text, not vision) to generate behavioral descriptions:
+- Finds relevant source files (HTML + referenced JS/CSS)
+- Includes `_MAP.md` excerpts for code context
+- Produces: what the user sees, interactions, invariants, code references
 
-### Phase 3: DESCRIBE
-Sends each screenshot + accessibility tree + relevant `_MAP.md` excerpts to Claude API (vision). Generates prose descriptions, interaction inventories, and behavioral invariants linked back to code.
+**Code-derived descriptions are usable standalone.** Vision is enrichment, not requirement.
+
+### Phase 3: VERIFY (optional)
+Selective visual verification for pages where it adds value:
+- Skips error pages (404, 500), gated pages, redirects
+- Captures screenshots + accessibility trees via webctl
+- Sends to Claude vision API to verify/enrich code descriptions
+- Falls back to code description if vision fails
+
+Skipped entirely with `--code-only`. Run only this phase with `--verify-only`.
 
 ### Phase 4: ASSEMBLE
-Compiles all page descriptions into `_FEATURES.md` with screenshot references, code links, and a summary section suitable for CLAUDE.md injection.
+Compiles all descriptions into `_FEATURES.md`:
+- Source badges indicate code-analyzed vs visually-verified
+- Screenshot references only for verified pages
+- Status summary with breakdown by source
+
+## Environment-Adaptive Batching
+
+The skill auto-detects the runtime environment and adjusts batch size:
+
+| Environment | Batch Size | Notes |
+|-------------|-----------|-------|
+| Claude.ai container | 4 pages | Short bash timeouts |
+| Claude Code on Web | 12 pages | Longer execution windows |
+| Local CLI | Unbatched | Full control |
+
+Override with `--batch-size N`.
+
+Progress is checkpointed after each batch via `_FEATURES_MANIFEST.json`, so work survives if a conversation ends mid-pipeline.
+
+## Incremental Mode
+
+Each run stores page hashes and descriptions in `_FEATURES_MANIFEST.json`. With `--incremental`:
+- Code analysis: skips pages with existing descriptions
+- Visual verification: skips pages with unchanged screenshots
+- Descriptions from previous runs are preserved and merged
 
 ## Auth / Gated Pages
 
-Pages requiring authentication are marked `GATED` during Phase 1. The skill generates step-by-step instructions for manual capture:
-
-```
-GATED PAGES — Manual Capture Required:
-1. Navigate to https://app.example.com/login
-2. Sign in with your credentials
-3. Navigate to /dashboard
-4. Run: webctl screenshot --path screenshots/dashboard.png
-5. Run: webctl snapshot --interactive-only > captures/dashboard-a11y.txt
-```
-
-After manual capture, re-run with `--incremental` to describe the new pages.
-
-## Staleness Detection
-
-Each run stores screenshot hashes and descriptions in `_FEATURES_MANIFEST.json`. On re-run with `--incremental`, unchanged pages reuse their stored descriptions (no API calls). Changed pages are re-captured and re-described.
+Pages requiring authentication are detected during verification (redirect detection + text heuristics) and marked `GATED`. The skill generates step-by-step manual capture instructions in `GATED_PAGES.md`.
 
 ## Output Format
 
 ```markdown
 # _FEATURES.md — App Name
-Generated: 2026-03-22T12:00:00-04:00
+Generated: 2026-03-22T12:00:00+0000
 App URL: https://example.com
 
 ## Feature Inventory
 
-### Page Name (`/route`)
-![Screenshot](screenshots/route.png)
+### Status Summary
+- **Documented:** 45 pages
+  - Code-analyzed: 40
+  - Visually verified: 5
+- **Gated (auth required):** 2 pages
 
-**What the user sees:** Prose description from Claude vision.
+### Page Title (`/route`)
+> *Derived from source code analysis*
+
+**What the user sees:** Prose description from code analysis.
 
 **Interactions:**
 - Button "X" → does Y
-- Link "Z" → navigates to /other
 
 **Invariants:**
-- Rule 1 the feature must satisfy
-- Rule 2
+- Rule 1
 
-**Code:** `src/components/Page.js` :1 | `src/utils.js` :42
+**Code:** `src/page.html` :1
+
+---
 ```
 
 ## Relationship to CLAUDE.md
 
-`_FEATURES.md` is the behavioral source of truth. Combined with `_MAP.md` (structural), these feed the behavioral sections of CLAUDE.md. Workflow:
+`_FEATURES.md` is the behavioral source of truth. Combined with `_MAP.md` (structural):
 
 1. `mapping-codebases` → `_MAP.md` (structural)
 2. `mapping-features` → `_FEATURES.md` (behavioral)
 3. Merge both into CLAUDE.md architecture/concepts sections
 
-## Process Guardrails
-
-- Do NOT bypass auth — use the human-in-the-loop pattern
-- Do NOT describe code internals — that's `_MAP.md`'s job. Describe *behavior*, linked to code
-- Do NOT hardcode app-specific logic — works for any web app with a running instance
-- If webctl fails on a page, mark it `CAPTURE_FAILED` with the error — don't skip silently
-- Store PNGs in `screenshots/` directory, not embedded as base64
-
 ## Limitations
 
-- Requires a running app instance (no static analysis of UI)
-- Claude API calls for vision cost tokens — use `--incremental` to minimize
-- Single-page apps with client-side routing may need `--routes` flag to seed known paths
-- Auth-gated pages require human intervention
+- Code analysis requires Claude API calls (tokens)
+- Visual verification requires webctl + a running app instance
+- SPAs with client-side routing may need `--routes` flag
+- Auth-gated pages require human intervention for visual verification
+- Code analysis quality depends on source code readability

--- a/mapping-features/scripts/analyze.py
+++ b/mapping-features/scripts/analyze.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+Phase 2: ANALYZE — Code-first behavioral analysis.
+
+Reads source code for each discovered page and uses Claude API to generate
+behavioral descriptions without requiring a browser or screenshots.
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from .discover import PageInfo
+
+
+# Prompt template for code-based analysis
+ANALYZE_PROMPT = """\
+You are documenting a web application's features for developer agents who cannot see the UI.
+
+I'm showing you the source code for a page at `{path}` ({url}).
+Analyze this code and produce a structured behavioral description.
+
+## Sections to produce:
+
+1. **What the user sees:** Describe what a user would see on this page — layout, content areas, \
+visual hierarchy. Infer from the HTML structure, CSS classes, and component composition.
+
+2. **Interactions:** Bullet list of interactive elements and what they do. Format:
+   - "Button/Link/Input label" → what happens when activated
+
+3. **Invariants:** Behavioral rules this page must satisfy. These are testable assertions. Think: \
+"What must always be true for this page to be correct?" Examples:
+   - "Page renders without authentication"
+   - "Navigation links are present in header"
+   - "Form validates required fields before submission"
+
+4. **Code:** Reference the source files that implement this page. Format: `path/file.ext` :linenum
+
+Keep descriptions factual and concise. Infer behavior from code structure — do not speculate \
+about features not present in the source.
+
+## Source Code
+```
+{source_code}
+```
+
+## Code Map Context
+```
+{map_excerpts}
+```
+"""
+
+
+def _find_source_files(codebase: Path, page_path: str) -> list[Path]:
+    """Find source files relevant to a page path.
+
+    For static sites: finds the HTML file directly.
+    For SPAs: looks for components matching the route name.
+
+    Args:
+        codebase: Path to codebase root.
+        page_path: URL path (e.g., '/dashboard', '/about.html').
+
+    Returns:
+        List of source file paths, ordered by relevance.
+    """
+    sources = []
+    clean_path = page_path.strip("/")
+
+    # Direct file match (static sites)
+    if clean_path:
+        candidates = [
+            codebase / clean_path,
+            codebase / f"{clean_path}.html",
+            codebase / f"{clean_path}/index.html",
+        ]
+    else:
+        candidates = [
+            codebase / "index.html",
+        ]
+
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            sources.append(candidate)
+            break  # Take the first direct match
+
+    # Look for associated JS/CSS/TS files
+    if clean_path:
+        # Extract the base name for matching
+        base_name = clean_path.rsplit("/", 1)[-1]
+        base_name = base_name.rsplit(".", 1)[0] if "." in base_name else base_name
+
+        # Search for component/module files matching the page name
+        for ext in (".js", ".ts", ".jsx", ".tsx", ".vue", ".svelte"):
+            for match in codebase.rglob(f"*{base_name}*{ext}"):
+                if match not in sources and "node_modules" not in str(match):
+                    sources.append(match)
+                    if len(sources) >= 5:  # Cap to avoid reading too many files
+                        break
+
+    # Look for referenced scripts in the HTML source
+    if sources and sources[0].suffix in (".html", ".htm"):
+        html_content = sources[0].read_text(encoding="utf-8", errors="replace")
+        script_refs = re.findall(r'<script[^>]+src=["\']([^"\']+)["\']', html_content)
+        style_refs = re.findall(r'<link[^>]+href=["\']([^"\']+\.css)["\']', html_content)
+        for ref in script_refs + style_refs:
+            if ref.startswith(("http://", "https://", "//")):
+                continue  # Skip external resources
+            ref_path = (sources[0].parent / ref).resolve()
+            if ref_path.exists() and ref_path not in sources:
+                sources.append(ref_path)
+
+    return sources[:8]  # Cap total files
+
+
+def _read_source_context(codebase: Path, page_path: str, max_chars: int = 15000) -> str:
+    """Read source files for a page and prepare a combined context string.
+
+    Args:
+        codebase: Path to codebase root.
+        page_path: URL path of the page.
+        max_chars: Maximum total characters to include.
+
+    Returns:
+        Combined source code string with file headers.
+    """
+    sources = _find_source_files(codebase, page_path)
+    if not sources:
+        return "(no source files found for this page)"
+
+    parts = []
+    total_chars = 0
+
+    for src in sources:
+        try:
+            content = src.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        rel_path = src.relative_to(codebase)
+        header = f"### {rel_path}"
+
+        # Truncate individual files if too large
+        remaining = max_chars - total_chars
+        if remaining <= 0:
+            break
+        if len(content) > remaining:
+            content = content[:remaining] + "\n... (truncated)"
+
+        parts.append(f"{header}\n{content}")
+        total_chars += len(header) + len(content)
+
+    return "\n\n".join(parts) if parts else "(no readable source files)"
+
+
+def _find_relevant_map_excerpts(codebase: Path, page_path: str) -> str:
+    """Find _MAP.md excerpts relevant to a page.
+
+    Args:
+        codebase: Path to codebase root.
+        page_path: URL path of the page.
+
+    Returns:
+        Concatenated relevant _MAP.md excerpts.
+    """
+    excerpts = []
+    map_files = list(codebase.rglob("_MAP.md"))
+
+    keywords = [
+        seg.lower()
+        for seg in page_path.strip("/").split("/")
+        if seg and len(seg) > 1
+    ]
+    # Also strip file extensions from keywords
+    keywords = [kw.rsplit(".", 1)[0] if "." in kw else kw for kw in keywords]
+
+    if not keywords:
+        keywords = ["index", "home", "app", "main"]
+
+    for map_file in map_files[:10]:
+        try:
+            content = map_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        content_lower = content.lower()
+        if any(kw in content_lower for kw in keywords):
+            lines = content.splitlines()[:200]
+            rel_path = map_file.relative_to(codebase)
+            excerpts.append(f"### {rel_path}\n" + "\n".join(lines))
+
+    if not excerpts:
+        root_map = codebase / "_MAP.md"
+        if root_map.exists():
+            try:
+                content = root_map.read_text(encoding="utf-8")
+                lines = content.splitlines()[:100]
+                excerpts.append("### _MAP.md (root)\n" + "\n".join(lines))
+            except (OSError, UnicodeDecodeError):
+                pass
+
+    return "\n\n".join(excerpts) if excerpts else "(no _MAP.md excerpts found)"
+
+
+def _get_api_key() -> str:
+    """Retrieve the Anthropic API key."""
+    try:
+        cred_path = Path("/mnt/skills/user/api-credentials/scripts")
+        if cred_path.exists():
+            sys.path.insert(0, str(cred_path))
+            from credentials import get_anthropic_api_key
+            return get_anthropic_api_key()
+    except (ImportError, ValueError):
+        pass
+
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if key:
+        return key
+
+    raise ValueError(
+        "No Anthropic API key found. Set ANTHROPIC_API_KEY or configure "
+        "the api-credentials skill."
+    )
+
+
+def _get_api_url() -> str:
+    """Build the Anthropic API messages URL."""
+    cf_account = os.environ.get("CF_ACCOUNT_ID", "").strip()
+    cf_gateway = os.environ.get("CF_GATEWAY_ID", "").strip()
+    if cf_account and cf_gateway:
+        return (
+            f"https://gateway.ai.cloudflare.com/v1/"
+            f"{cf_account}/{cf_gateway}/anthropic/v1/messages"
+        )
+    return "https://api.anthropic.com/v1/messages"
+
+
+def analyze_page(
+    page: PageInfo,
+    codebase: Path,
+    model: str = "claude-sonnet-4-6",
+) -> dict:
+    """Generate a behavioral description of a page by analyzing its source code.
+
+    Args:
+        page: PageInfo with path and URL.
+        codebase: Path to codebase root.
+        model: Claude model for text analysis.
+
+    Returns:
+        Dict with 'path', 'url', 'description', 'error', 'source': 'code'.
+    """
+    source_code = _read_source_context(codebase, page.path)
+    if source_code.startswith("(no "):
+        return {
+            "path": page.path,
+            "url": page.url,
+            "description": "",
+            "error": f"NO_SOURCE: no source files found for {page.path}",
+            "source": "code",
+        }
+
+    map_excerpts = _find_relevant_map_excerpts(codebase, page.path)
+
+    prompt = ANALYZE_PROMPT.format(
+        path=page.path,
+        url=page.url,
+        source_code=source_code,
+        map_excerpts=map_excerpts,
+    )
+
+    api_key = _get_api_key()
+    import urllib.request
+
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 2000,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt,
+            }
+        ],
+    }).encode("utf-8")
+
+    api_url = _get_api_url()
+    req = urllib.request.Request(
+        api_url,
+        data=payload,
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            result = json.loads(resp.read())
+    except Exception as e:
+        return {
+            "path": page.path,
+            "url": page.url,
+            "description": "",
+            "error": f"API call failed: {e}",
+            "source": "code",
+        }
+
+    description = ""
+    for block in result.get("content", []):
+        if block.get("type") == "text":
+            description += block["text"]
+
+    return {
+        "path": page.path,
+        "url": page.url,
+        "description": description,
+        "error": "",
+        "source": "code",
+    }
+
+
+def analyze_pages(
+    pages: list[PageInfo],
+    codebase: Path,
+    model: str = "claude-sonnet-4-6",
+) -> list[dict]:
+    """Analyze all pages via code reading.
+
+    Args:
+        pages: List of discovered pages.
+        codebase: Path to codebase root.
+        model: Claude model for text analysis.
+
+    Returns:
+        List of description dicts with 'source': 'code'.
+    """
+    descriptions = []
+    for page in pages:
+        desc = analyze_page(page, codebase, model)
+        descriptions.append(desc)
+    return descriptions

--- a/mapping-features/scripts/assemble.py
+++ b/mapping-features/scripts/assemble.py
@@ -2,8 +2,8 @@
 """
 Phase 4: ASSEMBLE — Compile _FEATURES.md from page descriptions.
 
-Combines all page descriptions, screenshots, and metadata into a single
-_FEATURES.md document with a feature inventory.
+Combines all page descriptions (code-derived and/or vision-verified),
+screenshots, and metadata into a single _FEATURES.md document.
 """
 
 from datetime import datetime, timezone
@@ -43,24 +43,43 @@ def _page_title(desc: dict, capture: PageCapture | None) -> str:
     label = ""
     if capture and capture.page.label:
         label = capture.page.label
+    elif desc.get("label"):
+        label = desc["label"]
     path = desc.get("path", "/")
     if label:
         return f"{label} (`{path}`)"
     return f"`{path}`"
 
 
+def _source_badge(source: str) -> str:
+    """Generate a source indicator badge.
+
+    Args:
+        source: Description source — 'code', 'verified', or 'failed'.
+
+    Returns:
+        Markdown badge string.
+    """
+    badges = {
+        "code": "> *Derived from source code analysis*",
+        "verified": "> *Verified via screenshot + accessibility tree*",
+        "failed": "> *Description unavailable*",
+    }
+    return badges.get(source, "")
+
+
 def assemble_features_md(
     descriptions: list[dict],
-    captures: list[PageCapture],
-    app_url: str,
+    captures: list[PageCapture] | None = None,
+    app_url: str = "",
     app_name: str = "",
     output_path: Path | None = None,
 ) -> str:
     """Assemble a _FEATURES.md document from page descriptions.
 
     Args:
-        descriptions: List of description dicts from describe phase.
-        captures: List of PageCapture for screenshot paths.
+        descriptions: List of description dicts from analyze/verify phases.
+        captures: Optional list of PageCapture for screenshot paths.
         app_url: Base URL of the app.
         app_name: Human-readable app name (defaults to URL hostname).
         output_path: Path where _FEATURES.md will be written (for relative paths).
@@ -71,14 +90,15 @@ def assemble_features_md(
     from urllib.parse import urlparse
 
     if not app_name:
-        app_name = urlparse(app_url).netloc
+        app_name = urlparse(app_url).netloc if app_url else "App"
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S%z")
 
     # Build capture lookup by path
     capture_by_path: dict[str, PageCapture] = {}
-    for c in captures:
-        capture_by_path[c.page.path] = c
+    if captures:
+        for c in captures:
+            capture_by_path[c.page.path] = c
 
     lines = [
         f"# _FEATURES.md — {app_name}",
@@ -89,21 +109,29 @@ def assemble_features_md(
         "",
     ]
 
-    # Summary of gated/failed pages
+    # Summary
     gated_pages = [d for d in descriptions if d.get("error", "").startswith("GATED")]
-    failed_pages = [d for d in descriptions if d.get("error", "").startswith("CAPTURE_FAILED")]
-    ok_pages = [d for d in descriptions if not d.get("error")]
+    failed_pages = [
+        d for d in descriptions
+        if d.get("error") and not d.get("error", "").startswith("GATED")
+    ]
+    code_pages = [d for d in descriptions if d.get("source") == "code" and not d.get("error")]
+    verified_pages = [d for d in descriptions if d.get("source") == "verified"]
+    ok_pages = [d for d in descriptions if d.get("description") and not d.get("error")]
 
-    if gated_pages or failed_pages:
-        lines.append("### Status Summary")
-        lines.append(f"- **Documented:** {len(ok_pages)} pages")
-        if gated_pages:
-            lines.append(f"- **Gated (auth required):** {len(gated_pages)} pages")
-        if failed_pages:
-            lines.append(f"- **Capture failed:** {len(failed_pages)} pages")
-        lines.append("")
+    lines.append("### Status Summary")
+    lines.append(f"- **Documented:** {len(ok_pages)} pages")
+    if code_pages:
+        lines.append(f"  - Code-analyzed: {len(code_pages)}")
+    if verified_pages:
+        lines.append(f"  - Visually verified: {len(verified_pages)}")
+    if gated_pages:
+        lines.append(f"- **Gated (auth required):** {len(gated_pages)} pages")
+    if failed_pages:
+        lines.append(f"- **Failed:** {len(failed_pages)} pages")
+    lines.append("")
 
-    # Documented pages
+    # Page descriptions
     for desc in descriptions:
         path = desc.get("path", "/")
         capture = capture_by_path.get(path)
@@ -119,13 +147,20 @@ def assemble_features_md(
             lines.append("")
             continue
 
-        # Screenshot reference
+        # Source badge
+        source = desc.get("source", "")
+        badge = _source_badge(source)
+        if badge:
+            lines.append(badge)
+            lines.append("")
+
+        # Screenshot reference (only for verified pages)
         if capture and capture.screenshot_path and output_path:
             rel_path = _relative_screenshot_path(capture.screenshot_path, output_path)
             lines.append(f"![Screenshot of {path}]({rel_path})")
             lines.append("")
 
-        # Description from Claude vision
+        # Description
         description = desc.get("description", "")
         if description:
             lines.append(description)
@@ -141,7 +176,7 @@ def assemble_features_md(
 
 def write_features_md(
     descriptions: list[dict],
-    captures: list[PageCapture],
+    captures: list[PageCapture] | None,
     app_url: str,
     output_path: Path,
     app_name: str = "",
@@ -150,7 +185,7 @@ def write_features_md(
 
     Args:
         descriptions: List of description dicts.
-        captures: List of PageCapture results.
+        captures: Optional list of PageCapture results.
         app_url: Base URL of the app.
         output_path: Where to write the file.
         app_name: Human-readable app name.

--- a/mapping-features/scripts/discover.py
+++ b/mapping-features/scripts/discover.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """
-Phase 1: DISCOVER — Route/page crawling via webctl.
+Phase 1: DISCOVER — Code-first page discovery with optional browser crawling.
 
-Navigates the app entry point, extracts links from accessibility snapshots,
-and builds a sitemap of reachable pages.
+Primary: discovers pages from codebase structure (_MAP.md, HTML files, route configs).
+Secondary: supplements with browser crawling via webctl when available.
 """
 
 import json
 import re
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
 
@@ -22,6 +23,269 @@ class PageInfo:
     gated: bool = False
     gate_reason: str = ""
 
+
+# Files to skip during code-based discovery
+SKIP_PATTERNS = {
+    "404.html", "404.htm",
+    "500.html", "500.htm",
+    "robots.txt", "sitemap.xml",
+    ".htaccess", "favicon.ico",
+}
+
+# Directories to skip
+SKIP_DIRS = {
+    "node_modules", ".git", "__pycache__", ".next", ".nuxt",
+    "dist", "build", "coverage", ".cache", "vendor",
+    "screenshots", "assets", "images", "img", "fonts",
+}
+
+
+def discover_from_code(
+    codebase: Path,
+    app_url: str,
+    max_pages: int = 100,
+) -> list[PageInfo]:
+    """Discover pages from codebase structure without browser crawling.
+
+    Finds pages by:
+    1. Scanning for HTML files (static sites)
+    2. Parsing _MAP.md for route-like patterns
+    3. Looking for common router/page directory conventions
+
+    Args:
+        codebase: Path to codebase root.
+        app_url: Base URL of the app (for constructing full URLs).
+        max_pages: Maximum pages to discover.
+
+    Returns:
+        List of PageInfo discovered from code.
+    """
+    pages: list[PageInfo] = []
+    seen_paths: set[str] = set()
+    base_url = app_url.rstrip("/")
+
+    def _normalize_path(p: str) -> str:
+        """Normalize a path for deduplication."""
+        norm = p.rstrip("/") or "/"
+        # Treat /foo/index.html as /foo/
+        if norm.endswith("/index.html") or norm.endswith("/index.htm"):
+            norm = norm.rsplit("/index.", 1)[0] + "/"
+            norm = norm.rstrip("/") or "/"
+        return norm
+
+    def _add_page(page: PageInfo) -> bool:
+        norm = _normalize_path(page.path)
+        if norm not in seen_paths:
+            pages.append(page)
+            seen_paths.add(norm)
+            return True
+        return False
+
+    # Strategy 1: Find HTML files (primary for static sites)
+    html_pages = _discover_html_files(codebase, base_url, max_pages)
+    for page in html_pages:
+        _add_page(page)
+        if len(pages) >= max_pages:
+            break
+
+    # Strategy 2: Parse route patterns from common framework conventions
+    if len(pages) < max_pages:
+        route_pages = _discover_framework_routes(codebase, base_url)
+        for page in route_pages:
+            _add_page(page)
+            if len(pages) >= max_pages:
+                break
+
+    # Strategy 3: Parse _MAP.md for page-like entries
+    if len(pages) < max_pages:
+        map_pages = _discover_from_maps(codebase, base_url)
+        for page in map_pages:
+            _add_page(page)
+            if len(pages) >= max_pages:
+                break
+
+    return pages
+
+
+def _discover_html_files(
+    codebase: Path,
+    base_url: str,
+    max_pages: int = 100,
+) -> list[PageInfo]:
+    """Find HTML files in the codebase and treat them as pages.
+
+    Args:
+        codebase: Path to codebase root.
+        base_url: Base URL for constructing full URLs.
+        max_pages: Maximum pages to return.
+
+    Returns:
+        List of PageInfo for HTML files.
+    """
+    pages = []
+
+    for html_file in sorted(codebase.rglob("*.html")):
+        # Skip files in excluded directories
+        parts = html_file.relative_to(codebase).parts
+        if any(part in SKIP_DIRS for part in parts):
+            continue
+
+        # Skip known non-page files
+        if html_file.name in SKIP_PATTERNS:
+            continue
+
+        rel_path = html_file.relative_to(codebase)
+        url_path = "/" + str(rel_path)
+
+        # Simplify index.html → parent directory
+        if html_file.name == "index.html":
+            url_path = "/" + str(rel_path.parent)
+            if url_path == "/.":
+                url_path = "/"
+            elif not url_path.endswith("/"):
+                url_path += "/"
+
+        # Extract title from HTML for label
+        label = _extract_html_title(html_file)
+
+        full_url = base_url + url_path
+        pages.append(PageInfo(url=full_url, path=url_path, label=label))
+
+        if len(pages) >= max_pages:
+            break
+
+    # Also check .htm files
+    for htm_file in sorted(codebase.rglob("*.htm")):
+        parts = htm_file.relative_to(codebase).parts
+        if any(part in SKIP_DIRS for part in parts):
+            continue
+        if htm_file.name in SKIP_PATTERNS:
+            continue
+
+        rel_path = htm_file.relative_to(codebase)
+        url_path = "/" + str(rel_path)
+        label = _extract_html_title(htm_file)
+        full_url = base_url + url_path
+        pages.append(PageInfo(url=full_url, path=url_path, label=label))
+
+        if len(pages) >= max_pages:
+            break
+
+    return pages
+
+
+def _extract_html_title(html_file: Path) -> str:
+    """Extract the <title> content from an HTML file.
+
+    Args:
+        html_file: Path to HTML file.
+
+    Returns:
+        Title string, or empty string if not found.
+    """
+    try:
+        content = html_file.read_text(encoding="utf-8", errors="replace")[:5000]
+        match = re.search(r"<title[^>]*>([^<]+)</title>", content, re.IGNORECASE)
+        if match:
+            title = match.group(1).strip()
+            # Clean up common suffixes like " | Site Name" or " - Site Name"
+            return title
+    except OSError:
+        pass
+    return ""
+
+
+def _discover_framework_routes(codebase: Path, base_url: str) -> list[PageInfo]:
+    """Discover routes from common framework conventions.
+
+    Checks for:
+    - Next.js/Nuxt pages/ directories
+    - SvelteKit routes/ directories
+    - React Router / Vue Router config files
+
+    Args:
+        codebase: Path to codebase root.
+        base_url: Base URL for constructing full URLs.
+
+    Returns:
+        List of PageInfo from framework routing conventions.
+    """
+    pages = []
+
+    # Next.js: pages/ or app/ directories
+    for pages_dir_name in ("pages", "app", "src/pages", "src/app"):
+        pages_dir = codebase / pages_dir_name
+        if pages_dir.is_dir():
+            for f in sorted(pages_dir.rglob("*")):
+                if not f.is_file():
+                    continue
+                if f.suffix not in (".js", ".jsx", ".ts", ".tsx", ".vue", ".svelte"):
+                    continue
+                if f.name.startswith("_") or f.name.startswith("["):
+                    continue  # Skip _app, _document, [slug] etc.
+
+                rel = f.relative_to(pages_dir)
+                route = "/" + str(rel.with_suffix(""))
+                if route.endswith("/index"):
+                    route = route[:-6] or "/"
+
+                full_url = base_url + route
+                pages.append(PageInfo(url=full_url, path=route, label=f.stem))
+
+    # SvelteKit: src/routes/
+    routes_dir = codebase / "src" / "routes"
+    if routes_dir.is_dir():
+        for f in sorted(routes_dir.rglob("+page.svelte")):
+            rel = f.relative_to(routes_dir).parent
+            route = "/" + str(rel)
+            if route == "/.":
+                route = "/"
+            full_url = base_url + route
+            pages.append(PageInfo(url=full_url, path=route, label=str(rel)))
+
+    return pages
+
+
+def _discover_from_maps(codebase: Path, base_url: str) -> list[PageInfo]:
+    """Parse _MAP.md files for page-like entries.
+
+    Looks for HTML file references and route patterns in code maps.
+
+    Args:
+        codebase: Path to codebase root.
+        base_url: Base URL for constructing full URLs.
+
+    Returns:
+        List of PageInfo from _MAP.md analysis.
+    """
+    pages = []
+    seen = set()
+
+    root_map = codebase / "_MAP.md"
+    if not root_map.exists():
+        return pages
+
+    try:
+        content = root_map.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return pages
+
+    # Look for HTML file references in _MAP.md
+    html_refs = re.findall(r'\b([\w/.-]+\.html?)\b', content)
+    for ref in html_refs:
+        if ref in SKIP_PATTERNS:
+            continue
+        path = "/" + ref
+        norm = path.rstrip("/") or "/"
+        if norm not in seen:
+            full_url = base_url + path
+            pages.append(PageInfo(url=full_url, path=path, label=""))
+            seen.add(norm)
+
+    return pages
+
+
+# --- Browser-based discovery (original, now secondary) ---
 
 def run_webctl(*args: str, quiet: bool = True) -> str:
     """Run a webctl command and return stdout.
@@ -56,13 +320,10 @@ def extract_links_from_snapshot(snapshot_text: str, base_url: str) -> list[dict]
         List of dicts with 'url', 'label' keys.
     """
     links = []
-    # Match lines like: link "Home" [ref=5] url="/"
-    # or: link "About" url="/about"
     link_pattern = re.compile(
         r'link\s+"([^"]*)".*url="([^"]*)"',
         re.IGNORECASE
     )
-    # Also match href patterns in raw snapshot
     href_pattern = re.compile(r'href="([^"]*)"')
 
     for line in snapshot_text.splitlines():
@@ -118,6 +379,9 @@ def detect_gated_page(snapshot_text: str) -> tuple[bool, str]:
 def discover_pages(app_url: str, max_pages: int = 20) -> list[PageInfo]:
     """Crawl the app starting from app_url and discover accessible pages.
 
+    This is the browser-based discovery method. Used as a supplement to
+    code-first discovery, or when webctl is available.
+
     Args:
         app_url: Base URL of the running app.
         max_pages: Maximum number of pages to discover.
@@ -160,7 +424,7 @@ def discover_pages(app_url: str, max_pages: int = 20) -> list[PageInfo]:
             ))
             continue
 
-        # Check for redirect-as-gating: if final URL differs from intended
+        # Check for redirect-as-gating
         is_gated = False
         gate_reason = ""
         try:
@@ -179,7 +443,7 @@ def discover_pages(app_url: str, max_pages: int = 20) -> list[PageInfo]:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             snapshot = ""
 
-        # Check text-based gating heuristics (if not already gated by redirect)
+        # Check text-based gating heuristics
         if not is_gated:
             is_gated, gate_reason = detect_gated_page(snapshot)
 
@@ -205,13 +469,56 @@ def discover_pages(app_url: str, max_pages: int = 20) -> list[PageInfo]:
                 link_normalized = f"{link_parsed.scheme}://{link_parsed.netloc}{link_parsed.path.rstrip('/')}"
                 if link_normalized not in visited:
                     to_visit.append(link_url)
-                    # Update label if we find one for an existing page
                     if link.get("label"):
                         for p in pages:
                             if p.path == link_parsed.path and not p.label:
                                 p.label = link["label"]
 
     return pages
+
+
+def is_webctl_available() -> bool:
+    """Check if webctl is installed and can be started.
+
+    Returns:
+        True if webctl is available.
+    """
+    try:
+        result = subprocess.run(
+            ["which", "webctl"],
+            capture_output=True, text=True, timeout=5
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def should_skip_verify(page: PageInfo) -> bool:
+    """Determine if a page should be skipped during visual verification.
+
+    Skips pages that are unlikely to benefit from screenshot verification:
+    - Error pages (404, 500)
+    - Pure redirect pages
+    - Very small utility pages
+
+    Args:
+        page: PageInfo to evaluate.
+
+    Returns:
+        True if this page should be skipped for visual verification.
+    """
+    skip_names = {"404", "500", "error", "redirect"}
+    path_parts = page.path.strip("/").lower().split("/")
+
+    for part in path_parts:
+        base = part.rsplit(".", 1)[0] if "." in part else part
+        if base in skip_names:
+            return True
+
+    if page.gated:
+        return True
+
+    return False
 
 
 def pages_to_dict(pages: list[PageInfo]) -> list[dict]:

--- a/mapping-features/scripts/environment.py
+++ b/mapping-features/scripts/environment.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Environment detection and adaptive batch sizing.
+
+Detects whether running in Claude.ai container, Claude Code on the Web (CCotW),
+or local CLI, and adjusts batch size accordingly.
+"""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Environment:
+    """Detected runtime environment."""
+    name: str          # "claude-ai", "ccotw", "local"
+    batch_size: int    # Pages per batch for analysis/verify
+    interactive: bool  # Whether to checkpoint interactively
+
+
+def detect_environment() -> Environment:
+    """Detect the current runtime environment and return appropriate settings.
+
+    Returns:
+        Environment with auto-detected batch size and interactivity.
+    """
+    # Claude.ai container: has /mnt/skills/ and short bash timeouts
+    if os.path.exists("/mnt/skills/") and os.path.exists("/mnt/user-data/"):
+        return Environment(name="claude-ai", batch_size=4, interactive=True)
+
+    # Claude Code on the Web: has /mnt/skills/ but longer execution windows
+    if os.path.exists("/mnt/skills/"):
+        return Environment(name="ccotw", batch_size=12, interactive=False)
+
+    # Local CLI
+    return Environment(name="local", batch_size=0, interactive=False)
+
+
+def get_batch_size(override: int | None, env: Environment | None = None) -> int:
+    """Get the effective batch size.
+
+    Args:
+        override: User-specified --batch-size value, or None for auto.
+        env: Pre-detected environment, or None to auto-detect.
+
+    Returns:
+        Batch size (0 means unbatched / process all at once).
+    """
+    if override is not None and override > 0:
+        return override
+    if env is None:
+        env = detect_environment()
+    return env.batch_size
+
+
+def batched(items: list, size: int) -> list[list]:
+    """Split a list into batches.
+
+    Args:
+        items: Items to batch.
+        size: Batch size. 0 or negative means single batch (all items).
+
+    Returns:
+        List of batches (sublists).
+    """
+    if size <= 0:
+        return [items] if items else []
+    return [items[i:i + size] for i in range(0, len(items), size)]

--- a/mapping-features/scripts/featuremap.py
+++ b/mapping-features/scripts/featuremap.py
@@ -2,25 +2,37 @@
 """
 mapping-features main entry point.
 
-Orchestrates all four phases: discover → capture → describe → assemble.
-Produces a _FEATURES.md file documenting the behavioral features of a web app.
+Orchestrates the code-first feature mapping pipeline:
+  Phase 1: DISCOVER — find pages from code structure
+  Phase 2: ANALYZE  — generate behavioral descriptions from source code
+  Phase 3: VERIFY   — selective visual verification via browser (optional)
+  Phase 4: ASSEMBLE — compile _FEATURES.md
 """
 
 import argparse
 import json
 import sys
 from pathlib import Path
+from urllib.parse import urljoin
 
 # Allow running as script or via package import
 if __name__ == "__main__":
     sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from scripts.discover import discover_pages, pages_to_dict, PageInfo
-from scripts.capture import capture_all_pages, PageCapture
-from scripts.describe import describe_all_pages
+from scripts.discover import (
+    discover_from_code, discover_pages, pages_to_dict, PageInfo,
+    is_webctl_available, should_skip_verify,
+)
+from scripts.analyze import analyze_page, analyze_pages
+from scripts.capture import PageCapture
+from scripts.verify import select_pages_for_verification, verify_pages
 from scripts.assemble import write_features_md
-from scripts.staleness import load_manifest, save_manifest, filter_changed_pages
+from scripts.staleness import (
+    load_manifest, save_manifest, save_code_manifest,
+    filter_changed_pages, filter_unanalyzed_pages,
+)
 from scripts.auth_instructions import generate_auth_instructions
+from scripts.environment import detect_environment, get_batch_size, batched
 
 
 def parse_args() -> argparse.Namespace:
@@ -30,10 +42,20 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
+  # Code-only analysis (no browser needed):
+  %(prog)s --app-url https://example.com --codebase /path/to/repo --code-only
+
+  # Full pipeline with selective verification:
   %(prog)s --app-url https://example.com --codebase /path/to/repo
-  %(prog)s --app-url http://localhost:3000 --codebase . --max-pages 10
+
+  # Incremental update (skip unchanged pages):
   %(prog)s --app-url https://example.com --codebase . --incremental
-  %(prog)s --app-url https://example.com --codebase . --skip-describe
+
+  # Verify specific pages only:
+  %(prog)s --app-url https://example.com --codebase . --verify-only
+
+  # Custom batch size:
+  %(prog)s --app-url https://example.com --codebase . --batch-size 5
 """,
     )
     parser.add_argument(
@@ -49,20 +71,32 @@ Examples:
         help="Output path for _FEATURES.md (default: <codebase>/_FEATURES.md)",
     )
     parser.add_argument(
-        "--max-pages", type=int, default=20,
-        help="Maximum number of pages to discover (default: 20)",
+        "--max-pages", type=int, default=100,
+        help="Maximum number of pages to discover (default: 100)",
     )
     parser.add_argument(
         "--viewport", default="1280x720",
         help="Screenshot viewport as WxH (default: 1280x720)",
     )
     parser.add_argument(
+        "--code-only", action="store_true",
+        help="Skip all vision — produce features from code analysis alone",
+    )
+    parser.add_argument(
+        "--verify-only", action="store_true",
+        help="Only run visual verification on already-analyzed pages",
+    )
+    parser.add_argument(
         "--skip-describe", action="store_true",
-        help="Capture screenshots only, skip Claude vision description",
+        help="(Legacy) Capture screenshots only, skip description. Use --code-only instead.",
     )
     parser.add_argument(
         "--incremental", action="store_true",
-        help="Only re-capture and re-describe pages with changed screenshots",
+        help="Only re-process pages that have changed since last run",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=None,
+        help="Pages per batch (auto-detected from environment if not set)",
     )
     parser.add_argument(
         "--screenshots-dir", type=Path, default=None,
@@ -70,20 +104,51 @@ Examples:
     )
     parser.add_argument(
         "--model", default="claude-sonnet-4-6",
-        help="Claude model for vision descriptions (default: claude-sonnet-4-6)",
+        help="Claude model for analysis/vision (default: claude-sonnet-4-6)",
     )
     parser.add_argument(
         "--routes",
         help=(
-            "Comma-separated list of routes (e.g. /,/demo.html,/dashboard.html) "
-            "or path to a file with one route per line. Skips or supplements discover crawl."
+            "Comma-separated routes (e.g., /,/about.html) or path to a "
+            "routes file. Supplements code-based discovery."
         ),
     )
     parser.add_argument(
         "--dry-run", "-n", action="store_true",
-        help="Discover pages only, print sitemap without capturing",
+        help="Discover pages only, print sitemap without analyzing",
     )
     return parser.parse_args()
+
+
+def _parse_routes(routes_arg: str | None, app_url: str) -> list[PageInfo]:
+    """Parse --routes argument into PageInfo list.
+
+    Args:
+        routes_arg: Raw --routes value (comma-separated or file path).
+        app_url: Base URL for constructing full URLs.
+
+    Returns:
+        List of PageInfo from manual routes.
+    """
+    if not routes_arg:
+        return []
+
+    routes_path = Path(routes_arg)
+    if routes_path.is_file():
+        route_strings = [
+            line.strip() for line in routes_path.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+    else:
+        route_strings = [r.strip() for r in routes_arg.split(",") if r.strip()]
+
+    pages = []
+    for route in route_strings:
+        url = urljoin(app_url.rstrip("/") + "/", route.lstrip("/") or "/")
+        path = route if route.startswith("/") else "/" + route
+        pages.append(PageInfo(url=url, path=path))
+
+    return pages
 
 
 def main() -> int:
@@ -104,137 +169,240 @@ def main() -> int:
         )
         return 1
 
+    # Detect environment for batch sizing
+    env = detect_environment()
+    batch_size = get_batch_size(args.batch_size, env)
+    print(f"Environment: {env.name} | Batch size: {batch_size or 'unbatched'}")
+
+    # ================================================================
     # Phase 1: DISCOVER
-    # Parse --routes if provided
-    manual_routes: list[str] = []
-    if args.routes:
-        routes_path = Path(args.routes)
-        if routes_path.is_file():
-            manual_routes = [
-                line.strip() for line in routes_path.read_text().splitlines()
-                if line.strip() and not line.strip().startswith("#")
-            ]
-        else:
-            manual_routes = [r.strip() for r in args.routes.split(",") if r.strip()]
+    # ================================================================
+    print(f"\nPhase 1: Discovering pages from code structure...")
 
+    # Code-first discovery
+    pages = discover_from_code(codebase, args.app_url, max_pages=args.max_pages)
+    print(f"  Found {len(pages)} pages from code")
+
+    # Supplement with manual routes
+    manual_routes = _parse_routes(args.routes, args.app_url)
     if manual_routes:
-        # Build PageInfo from manual routes
-        from urllib.parse import urljoin
-        route_pages = []
-        for route in manual_routes:
-            url = urljoin(args.app_url.rstrip("/") + "/", route.lstrip("/") or "/")
-            route_pages.append(PageInfo(url=url, path=route if route.startswith("/") else "/" + route))
-        if args.max_pages > 0:
-            # Also run discover to find additional pages
-            print(f"Phase 1: Discovering pages at {args.app_url} (seeded with {len(route_pages)} routes)...")
-            discovered = discover_pages(args.app_url, max_pages=args.max_pages)
-            # Merge: manual routes first, then discovered (deduplicated by path)
-            seen_paths = {p.path.rstrip("/") or "/" for p in route_pages}
-            for dp in discovered:
-                norm = dp.path.rstrip("/") or "/"
-                if norm not in seen_paths:
-                    route_pages.append(dp)
-                    seen_paths.add(norm)
-        pages = route_pages
-        print(f"  Total pages: {len(pages)} ({len(manual_routes)} from --routes)")
-    else:
-        print(f"Phase 1: Discovering pages at {args.app_url}...")
-        pages = discover_pages(args.app_url, max_pages=args.max_pages)
-        print(f"  Found {len(pages)} pages")
+        seen_paths = {p.path.rstrip("/") or "/" for p in pages}
+        added = 0
+        for rp in manual_routes:
+            norm = rp.path.rstrip("/") or "/"
+            if norm not in seen_paths:
+                pages.append(rp)
+                seen_paths.add(norm)
+                added += 1
+        if added:
+            print(f"  Added {added} pages from --routes")
 
+    # Print discovered pages
     for p in pages:
-        status = "GATED" if p.gated else "OK"
         label = f" ({p.label})" if p.label else ""
-        print(f"  [{status}] {p.path}{label}")
+        print(f"    {p.path}{label}")
 
     if args.dry_run:
-        print("\nDry run — sitemap above. No captures taken.")
+        print("\nDry run — sitemap above. No analysis performed.")
         print(json.dumps(pages_to_dict(pages), indent=2))
         return 0
 
-    # Phase 2: CAPTURE
-    print(f"\nPhase 2: Capturing screenshots to {screenshots_dir}...")
-    captures = capture_all_pages(pages, screenshots_dir, args.viewport)
+    if not pages:
+        print("No pages discovered. Nothing to do.", file=sys.stderr)
+        return 1
 
-    ok_count = sum(1 for c in captures if not c.capture_error)
-    err_count = sum(1 for c in captures if c.capture_error)
-    print(f"  Captured: {ok_count} | Errors: {err_count}")
+    # ================================================================
+    # Phase 2: ANALYZE (code-first)
+    # ================================================================
+    old_manifest = load_manifest(codebase) if args.incremental else {}
+    all_descriptions: list[dict] = []
 
-    # Staleness filtering for incremental mode
-    old_manifest = {}
-    if args.incremental:
-        old_manifest = load_manifest(codebase)
-        changed, unchanged = filter_changed_pages(captures, old_manifest)
-        print(f"  Incremental: {len(changed)} changed, {len(unchanged)} unchanged")
-        captures_to_describe = changed
-    else:
-        captures_to_describe = captures
-
-    # Save manifest with current hashes (descriptions added after describe phase)
-    # Initial save for hash tracking; will be updated with descriptions later
-    save_manifest(codebase, captures, args.app_url)
-
-    # Generate auth instructions for gated pages
-    auth_text = generate_auth_instructions(captures, screenshots_dir)
-    if auth_text:
-        auth_path = codebase / "GATED_PAGES.md"
-        auth_path.write_text(auth_text, encoding="utf-8")
-        print(f"\n  Auth instructions written to {auth_path}")
-
-    if args.skip_describe:
-        print("\nSkipping Phase 3 (describe). Screenshots captured only.")
-        # Still assemble a skeleton _FEATURES.md
-        descriptions = [
-            {"path": c.page.path, "url": c.page.url, "description": "", "error": c.capture_error}
-            for c in captures
-        ]
-        write_features_md(descriptions, captures, args.app_url, output_path)
-        print(f"Skeleton _FEATURES.md written to {output_path}")
-        return 0
-
-    # Phase 3: DESCRIBE
-    print(f"\nPhase 3: Describing {len(captures_to_describe)} pages via Claude vision...")
-    descriptions = describe_all_pages(captures_to_describe, codebase, model=args.model)
-
-    # Merge unchanged descriptions from previous run if incremental
-    if args.incremental and old_manifest:
-        old_pages = old_manifest.get("pages", {})
-        for c in unchanged:
-            old_entry = old_pages.get(c.page.path, {})
-            prev_desc = old_entry.get("description", "")
-            if prev_desc:
-                descriptions.append({
-                    "path": c.page.path,
-                    "url": c.page.url,
-                    "description": prev_desc,
+    if args.verify_only:
+        # Skip analysis, load existing descriptions from manifest
+        print("\nPhase 2: Skipped (--verify-only)")
+        old_pages = old_manifest.get("pages", {}) if old_manifest else {}
+        for p in pages:
+            entry = old_pages.get(p.path, {})
+            if entry.get("description"):
+                all_descriptions.append({
+                    "path": p.path,
+                    "url": p.url,
+                    "description": entry["description"],
                     "error": "",
+                    "source": entry.get("source", "code"),
                 })
             else:
-                # Legacy manifest without descriptions — must re-describe
-                descriptions.append({
-                    "path": c.page.path,
-                    "url": c.page.url,
-                    "description": "*(unchanged — previous description not available, re-run without --incremental)*",
-                    "error": "",
+                all_descriptions.append({
+                    "path": p.path,
+                    "url": p.url,
+                    "description": "",
+                    "error": "NO_PRIOR: no existing description found",
+                    "source": "code",
                 })
+    else:
+        # Determine which pages need analysis
+        if args.incremental and old_manifest:
+            to_analyze, already_done = filter_unanalyzed_pages(pages, old_manifest)
+            print(f"\nPhase 2: Analyzing {len(to_analyze)} pages "
+                  f"({len(already_done)} unchanged, skipped)")
+            # Carry forward existing descriptions
+            old_pages = old_manifest.get("pages", {})
+            for p in already_done:
+                entry = old_pages.get(p.path, {})
+                all_descriptions.append({
+                    "path": p.path,
+                    "url": p.url,
+                    "description": entry.get("description", ""),
+                    "error": "",
+                    "source": entry.get("source", "code"),
+                })
+        else:
+            to_analyze = pages
+            print(f"\nPhase 2: Analyzing {len(to_analyze)} pages via code reading...")
 
-    desc_ok = sum(1 for d in descriptions if d.get("description") and not d.get("error"))
-    desc_err = sum(1 for d in descriptions if d.get("error"))
-    print(f"  Described: {desc_ok} | Errors: {desc_err}")
+        # Process in batches
+        batches = batched(to_analyze, batch_size)
+        for i, batch in enumerate(batches):
+            if len(batches) > 1:
+                print(f"  Batch {i + 1}/{len(batches)}: {len(batch)} pages...")
 
-    # Update manifest with descriptions for future incremental runs
-    save_manifest(codebase, captures, args.app_url, descriptions=descriptions)
+            batch_descs = analyze_pages(batch, codebase, model=args.model)
+            all_descriptions.extend(batch_descs)
 
+            # Checkpoint: save progress after each batch
+            save_code_manifest(codebase, args.app_url, all_descriptions)
+
+            ok = sum(1 for d in batch_descs if d.get("description") and not d.get("error"))
+            err = sum(1 for d in batch_descs if d.get("error"))
+            print(f"    Analyzed: {ok} | Errors: {err}")
+
+        total_ok = sum(1 for d in all_descriptions if d.get("description") and not d.get("error"))
+        total_err = sum(1 for d in all_descriptions if d.get("error"))
+        print(f"  Total: {total_ok} analyzed, {total_err} errors")
+
+    # ================================================================
+    # Phase 3: VERIFY (selective vision — optional)
+    # ================================================================
+    all_captures: list[PageCapture] = []
+
+    if args.code_only or args.skip_describe:
+        print("\nPhase 3: Skipped (code-only mode)")
+    else:
+        # Check if webctl is available
+        if not is_webctl_available():
+            print("\nPhase 3: Skipped (webctl not available)")
+            print("  Install webctl for visual verification. "
+                  "Code-derived descriptions will be used.")
+        else:
+            # Select pages for verification
+            verify_candidates = select_pages_for_verification(pages, all_descriptions)
+
+            if args.incremental and old_manifest:
+                # In incremental mode, only verify pages with changed screenshots
+                # First capture all candidates to check hashes
+                from scripts.capture import capture_all_pages
+                temp_captures = capture_all_pages(
+                    verify_candidates, screenshots_dir, args.viewport
+                )
+                changed, unchanged = filter_changed_pages(temp_captures, old_manifest)
+                verify_candidates_filtered = [c.page for c in changed]
+                all_captures.extend(temp_captures)
+
+                if unchanged:
+                    # Carry forward unchanged verified descriptions
+                    old_pages = old_manifest.get("pages", {})
+                    for c in unchanged:
+                        entry = old_pages.get(c.page.path, {})
+                        if entry.get("description") and entry.get("source") == "verified":
+                            # Update the description to the verified version
+                            for idx, d in enumerate(all_descriptions):
+                                if d["path"] == c.page.path:
+                                    all_descriptions[idx] = {
+                                        "path": c.page.path,
+                                        "url": c.page.url,
+                                        "description": entry["description"],
+                                        "error": "",
+                                        "source": "verified",
+                                    }
+                                    break
+
+                print(f"\nPhase 3: Verifying {len(verify_candidates_filtered)} pages "
+                      f"({len(unchanged)} unchanged)")
+                verify_pages_list = verify_candidates_filtered
+            else:
+                print(f"\nPhase 3: Verifying {len(verify_candidates)} pages via vision...")
+                verify_pages_list = verify_candidates
+
+            if verify_pages_list:
+                # Build code descriptions lookup for merging
+                batches = batched(verify_pages_list, batch_size)
+                for i, batch in enumerate(batches):
+                    if len(batches) > 1:
+                        print(f"  Batch {i + 1}/{len(batches)}: {len(batch)} pages...")
+
+                    batch_captures, batch_verified = verify_pages(
+                        batch, all_descriptions, screenshots_dir,
+                        codebase, args.viewport, args.model
+                    )
+                    all_captures.extend(batch_captures)
+
+                    # Merge verified descriptions into all_descriptions
+                    for vd in batch_verified:
+                        # Replace existing description for this path
+                        found = False
+                        for idx, d in enumerate(all_descriptions):
+                            if d["path"] == vd["path"]:
+                                all_descriptions[idx] = vd
+                                found = True
+                                break
+                        if not found:
+                            all_descriptions.append(vd)
+
+                    ok = sum(1 for d in batch_verified
+                             if d.get("description") and not d.get("error"))
+                    print(f"    Verified: {ok}")
+
+            # Generate auth instructions for gated pages
+            gated_captures = [c for c in all_captures if c.page.gated]
+            if gated_captures:
+                auth_text = generate_auth_instructions(all_captures, screenshots_dir)
+                if auth_text:
+                    auth_path = codebase / "GATED_PAGES.md"
+                    auth_path.write_text(auth_text, encoding="utf-8")
+                    print(f"  Auth instructions: {auth_path}")
+
+    # ================================================================
     # Phase 4: ASSEMBLE
+    # ================================================================
     print(f"\nPhase 4: Assembling _FEATURES.md...")
-    write_features_md(descriptions, captures, args.app_url, output_path)
+
+    # Sort descriptions: documented first, then errors
+    all_descriptions.sort(key=lambda d: (bool(d.get("error")), d.get("path", "")))
+
+    write_features_md(
+        all_descriptions,
+        all_captures if all_captures else None,
+        args.app_url,
+        output_path,
+    )
     print(f"  Written to {output_path}")
 
+    # Save final manifest
+    if all_captures:
+        save_manifest(codebase, all_captures, args.app_url, descriptions=all_descriptions)
+    else:
+        save_code_manifest(codebase, args.app_url, all_descriptions)
+
     # Summary
-    gated = [c for c in captures if c.page.gated]
-    print(f"\nDone. {desc_ok} pages documented, {len(gated)} gated, {desc_err} errors.")
-    if gated:
-        print(f"See {codebase / 'GATED_PAGES.md'} for manual capture instructions.")
+    ok_count = sum(1 for d in all_descriptions if d.get("description") and not d.get("error"))
+    code_count = sum(1 for d in all_descriptions if d.get("source") == "code" and not d.get("error"))
+    verified_count = sum(1 for d in all_descriptions if d.get("source") == "verified")
+    err_count = sum(1 for d in all_descriptions if d.get("error"))
+    gated_count = sum(1 for d in all_descriptions if d.get("error", "").startswith("GATED"))
+
+    print(f"\nDone. {ok_count} pages documented "
+          f"({code_count} code-analyzed, {verified_count} verified), "
+          f"{gated_count} gated, {err_count} errors.")
 
     return 0
 

--- a/mapping-features/scripts/staleness.py
+++ b/mapping-features/scripts/staleness.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """
-Staleness detection via screenshot hash comparison.
+Staleness detection and manifest management.
 
-Manages _FEATURES_MANIFEST.json which stores screenshot hashes for each page.
-On re-run, unchanged pages can skip the expensive describe phase.
+Manages _FEATURES_MANIFEST.json which stores page hashes, descriptions,
+and source tracking (code vs verified) for incremental updates.
 """
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -21,7 +22,7 @@ def load_manifest(codebase: Path) -> dict:
         codebase: Path to codebase root.
 
     Returns:
-        Dict mapping page paths to their last-known screenshot hashes and metadata.
+        Dict with manifest data, or empty dict if none exists.
     """
     manifest_path = codebase / MANIFEST_FILENAME
     if not manifest_path.exists():
@@ -39,13 +40,13 @@ def save_manifest(
     app_url: str,
     descriptions: list[dict] | None = None,
 ) -> Path:
-    """Save the features manifest with current screenshot hashes and descriptions.
+    """Save the features manifest with current state.
 
     Args:
         codebase: Path to codebase root.
         captures: List of PageCapture with current hashes.
         app_url: Base URL of the app.
-        descriptions: Optional list of description dicts to persist alongside hashes.
+        descriptions: Optional list of description dicts to persist.
 
     Returns:
         Path to the written manifest file.
@@ -53,20 +54,24 @@ def save_manifest(
     from datetime import datetime, timezone
 
     # Build description lookup
-    desc_by_path: dict[str, str] = {}
+    desc_by_path: dict[str, dict] = {}
     if descriptions:
         for d in descriptions:
             text = d.get("description", "")
             if text and not text.startswith("*(unchanged"):
-                desc_by_path[d["path"]] = text
+                desc_by_path[d["path"]] = {
+                    "description": text,
+                    "source": d.get("source", "code"),
+                }
 
-    # Preserve descriptions from old manifest for pages not re-described
+    # Preserve data from old manifest for pages not re-described
     old_manifest = load_manifest(codebase)
     old_pages = old_manifest.get("pages", {})
 
     manifest: dict = {
         "app_url": app_url,
         "updated": datetime.now(timezone.utc).isoformat(),
+        "version": "0.3.0",
         "pages": {},
     }
 
@@ -77,11 +82,12 @@ def save_manifest(
                 "screenshot": c.screenshot_path,
                 "url": c.page.url,
             }
-            # Store description: prefer fresh, fall back to old manifest
             if c.page.path in desc_by_path:
-                entry["description"] = desc_by_path[c.page.path]
+                entry["description"] = desc_by_path[c.page.path]["description"]
+                entry["source"] = desc_by_path[c.page.path]["source"]
             elif c.page.path in old_pages and "description" in old_pages[c.page.path]:
                 entry["description"] = old_pages[c.page.path]["description"]
+                entry["source"] = old_pages[c.page.path].get("source", "code")
             manifest["pages"][c.page.path] = entry
         elif c.page.gated:
             manifest["pages"][c.page.path] = {
@@ -89,6 +95,71 @@ def save_manifest(
                 "gated": True,
                 "gate_reason": c.page.gate_reason,
             }
+
+    # Also store code-only descriptions (pages with no capture)
+    if descriptions:
+        for d in descriptions:
+            path = d["path"]
+            if path not in manifest["pages"] and d.get("description"):
+                manifest["pages"][path] = {
+                    "hash": "",
+                    "url": d.get("url", ""),
+                    "description": d["description"],
+                    "source": d.get("source", "code"),
+                }
+
+    manifest_path = codebase / MANIFEST_FILENAME
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+
+    return manifest_path
+
+
+def save_code_manifest(
+    codebase: Path,
+    app_url: str,
+    descriptions: list[dict],
+) -> Path:
+    """Save a manifest for code-only analysis (no captures).
+
+    Args:
+        codebase: Path to codebase root.
+        app_url: Base URL of the app.
+        descriptions: Code-derived description dicts.
+
+    Returns:
+        Path to the written manifest file.
+    """
+    from datetime import datetime, timezone
+
+    old_manifest = load_manifest(codebase)
+    old_pages = old_manifest.get("pages", {})
+
+    manifest: dict = {
+        "app_url": app_url,
+        "updated": datetime.now(timezone.utc).isoformat(),
+        "version": "0.3.0",
+        "pages": {},
+    }
+
+    for d in descriptions:
+        path = d["path"]
+        entry: dict = {
+            "hash": _hash_description(d.get("description", "")),
+            "url": d.get("url", ""),
+            "source": d.get("source", "code"),
+        }
+
+        if d.get("description") and not d.get("error"):
+            entry["description"] = d["description"]
+        elif path in old_pages and "description" in old_pages[path]:
+            entry["description"] = old_pages[path]["description"]
+            entry["source"] = old_pages[path].get("source", "code")
+
+        if d.get("error"):
+            entry["error"] = d["error"]
+
+        manifest["pages"][path] = entry
 
     manifest_path = codebase / MANIFEST_FILENAME
     with open(manifest_path, "w", encoding="utf-8") as f:
@@ -128,3 +199,42 @@ def filter_changed_pages(
             changed.append(c)
 
     return changed, unchanged
+
+
+def filter_unanalyzed_pages(
+    pages: list,
+    old_manifest: dict,
+) -> tuple[list, list]:
+    """Split pages into analyzed and unanalyzed based on manifest.
+
+    Args:
+        pages: List of PageInfo.
+        old_manifest: Previously saved manifest dict.
+
+    Returns:
+        Tuple of (unanalyzed, already_analyzed) page lists.
+    """
+    old_pages = old_manifest.get("pages", {})
+    unanalyzed = []
+    analyzed = []
+
+    for p in pages:
+        old_entry = old_pages.get(p.path, {})
+        if old_entry.get("description") and not old_entry.get("error"):
+            analyzed.append(p)
+        else:
+            unanalyzed.append(p)
+
+    return unanalyzed, analyzed
+
+
+def _hash_description(text: str) -> str:
+    """Hash a description string for staleness detection.
+
+    Args:
+        text: Description text.
+
+    Returns:
+        SHA-256 hex digest.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest() if text else ""

--- a/mapping-features/scripts/verify.py
+++ b/mapping-features/scripts/verify.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Phase 3: VERIFY — Selective visual verification of code-derived descriptions.
+
+Orchestrates capture + describe for pages where visual verification adds value.
+Uses screenshots + a11y trees to enrich code-derived behavioral descriptions.
+"""
+
+from pathlib import Path
+
+from .capture import capture_page, PageCapture
+from .describe import describe_page
+from .discover import PageInfo, should_skip_verify
+
+
+VERIFY_ENRICHMENT_SUFFIX = """
+
+---
+*Verified via screenshot + accessibility tree analysis.*
+"""
+
+
+def select_pages_for_verification(
+    pages: list[PageInfo],
+    code_descriptions: list[dict],
+) -> list[PageInfo]:
+    """Select which pages should undergo visual verification.
+
+    Filters out pages that:
+    - Are error/utility pages (404, 500, redirect)
+    - Are auth-gated
+    - Had no source files (nothing to verify against)
+
+    Args:
+        pages: All discovered pages.
+        code_descriptions: Code-derived descriptions from analyze phase.
+
+    Returns:
+        Filtered list of pages suitable for visual verification.
+    """
+    # Build lookup of pages with successful code analysis
+    analyzed_paths = {
+        d["path"] for d in code_descriptions
+        if d.get("description") and not d.get("error")
+    }
+
+    selected = []
+    for page in pages:
+        if should_skip_verify(page):
+            continue
+        # Verify pages that were successfully analyzed (have code descriptions to enrich)
+        # Also verify pages that FAILED code analysis (vision might succeed where code didn't)
+        selected.append(page)
+
+    return selected
+
+
+def verify_page(
+    page: PageInfo,
+    code_description: dict | None,
+    screenshots_dir: Path,
+    codebase: Path,
+    viewport: str = "1280x720",
+    model: str = "claude-sonnet-4-6",
+) -> tuple[PageCapture, dict]:
+    """Capture and verify a single page via vision.
+
+    Args:
+        page: PageInfo to verify.
+        code_description: Existing code-derived description, or None.
+        screenshots_dir: Directory for screenshot PNGs.
+        codebase: Path to codebase root.
+        viewport: Screenshot viewport dimensions.
+        model: Claude model for vision.
+
+    Returns:
+        Tuple of (PageCapture, enriched_description_dict).
+    """
+    # Capture screenshot + a11y tree
+    capture = capture_page(page, screenshots_dir, viewport)
+
+    if capture.capture_error:
+        # Vision capture failed — fall back to code description
+        if code_description and code_description.get("description"):
+            return capture, {
+                **code_description,
+                "source": "code",
+            }
+        return capture, {
+            "path": page.path,
+            "url": page.url,
+            "description": "",
+            "error": capture.capture_error,
+            "source": "failed",
+        }
+
+    # Run vision description
+    vision_desc = describe_page(capture, codebase, model)
+
+    if vision_desc.get("error"):
+        # Vision API failed — fall back to code description
+        if code_description and code_description.get("description"):
+            return capture, {
+                **code_description,
+                "source": "code",
+            }
+        return capture, {
+            **vision_desc,
+            "source": "failed",
+        }
+
+    # Merge: vision description enriches/replaces code description
+    if code_description and code_description.get("description"):
+        # Both available — use vision as primary (it has visual context),
+        # append code analysis insights
+        merged_desc = vision_desc["description"] + VERIFY_ENRICHMENT_SUFFIX
+        return capture, {
+            "path": page.path,
+            "url": page.url,
+            "description": merged_desc,
+            "error": "",
+            "source": "verified",
+        }
+
+    # Only vision available
+    return capture, {
+        **vision_desc,
+        "source": "verified",
+    }
+
+
+def verify_pages(
+    pages: list[PageInfo],
+    code_descriptions: list[dict],
+    screenshots_dir: Path,
+    codebase: Path,
+    viewport: str = "1280x720",
+    model: str = "claude-sonnet-4-6",
+) -> tuple[list[PageCapture], list[dict]]:
+    """Verify multiple pages via vision, merging with code descriptions.
+
+    Args:
+        pages: Pages to verify.
+        code_descriptions: Code-derived descriptions (for merging).
+        screenshots_dir: Directory for screenshot PNGs.
+        codebase: Path to codebase root.
+        viewport: Screenshot viewport dimensions.
+        model: Claude model for vision.
+
+    Returns:
+        Tuple of (all_captures, merged_descriptions).
+    """
+    screenshots_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build code description lookup by path
+    code_desc_by_path: dict[str, dict] = {}
+    for d in code_descriptions:
+        code_desc_by_path[d["path"]] = d
+
+    all_captures = []
+    verified_descriptions = []
+
+    for page in pages:
+        code_desc = code_desc_by_path.get(page.path)
+        capture, desc = verify_page(
+            page, code_desc, screenshots_dir, codebase, viewport, model
+        )
+        all_captures.append(capture)
+        verified_descriptions.append(desc)
+
+    return all_captures, verified_descriptions


### PR DESCRIPTION
## Summary

Implements #442. Reverses the mapping-features architecture from vision-first to code-first.

- **Phase 1 DISCOVER**: Finds pages from codebase structure (_MAP.md, HTML files, framework routes) — no browser needed
- **Phase 2 ANALYZE** (new): Reads source code and generates behavioral descriptions via Claude API text analysis
- **Phase 3 VERIFY** (refactored): Selective visual verification only for pages where screenshots add value; graceful fallback
- **Phase 4 ASSEMBLE** (updated): Mixed description sources with source badges, status breakdown

New flags: `--code-only`, `--verify-only`, `--batch-size N`

New modules: `analyze.py`, `verify.py`, `environment.py`

Environment-adaptive batching (Claude.ai: 4 pages/batch, CCotW: 12, local: unbatched) with checkpoint after each batch.

## Test plan

- [x] All Python files pass AST syntax check
- [x] Import chain works (environment → discover → analyze → verify → assemble → featuremap)
- [x] Code discovery finds HTML files, extracts titles, deduplicates index.html vs /
- [x] Source file finder locates HTML + referenced JS/CSS
- [x] Assemble produces correct _FEATURES.md with source badges and status summary
- [x] CLI `--help` shows all new flags
- [x] Skips 404.html, gated pages, node_modules during discovery
- [ ] End-to-end with `--code-only` on a real static site (needs API key)
- [ ] End-to-end with visual verification (needs webctl + running app)

https://claude.ai/code/session_015y76JJR4WbvHiPxz57jibf