### PR TITLE
feat(image-to-svg): portrait pop-art guidance + bg_clusters override

### DIFF
--- a/_MAP.md
+++ b/_MAP.md
@@ -1,5 +1,5 @@
 # claude-skills/
-*Files: 1 | Subdirectories: 54*
+*Files: 1 | Subdirectories: 57*
 
 ## Subdirectories
 
@@ -45,12 +45,15 @@
 - [mapping-webapp/](./mapping-webapp/_MAP.md)
 - [orchestrating-agents/](./orchestrating-agents/_MAP.md)
 - [orchestrating-skills/](./orchestrating-skills/_MAP.md)
+- [processing-images/](./processing-images/_MAP.md)
+- [processing-video/](./processing-video/_MAP.md)
 - [registry/](./registry/_MAP.md)
 - [remembering/](./remembering/_MAP.md)
 - [reviewing-ai-papers/](./reviewing-ai-papers/_MAP.md)
 - [sampling-bluesky-zeitgeist/](./sampling-bluesky-zeitgeist/_MAP.md)
 - [scripts/](./scripts/_MAP.md)
 - [searching-codebases/](./searching-codebases/_MAP.md)
+- [seeing-images/](./seeing-images/_MAP.md)
 - [sorting-groceries/](./sorting-groceries/_MAP.md)
 - [templates/](./templates/_MAP.md)
 - [tiling-tree/](./tiling-tree/_MAP.md)

--- a/image-to-svg/SKILL.md
+++ b/image-to-svg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-to-svg
-version: 1.6.0
+version: 1.7.0
 description: Convert raster images (photos, paintings, illustrations) into SVG vector reproductions. Use when the user uploads an image and asks to reproduce, vectorize, trace, or convert it to SVG. Also use when asked to decompose an image into shapes, create an SVG version of a picture, or faithfully reproduce artwork as vector graphics. Do NOT use for creating original SVG illustrations from text descriptions — only for converting existing raster images.
 ---
  
@@ -71,6 +71,46 @@ svg, flow = image_to_svg("photo.jpg", mode="graphic", K=4, palette="ocean", bg_c
 **Built-in presets**: `bw`, `mono3`, `mono4`, `pop`, `pop2`, `neon`, `warhol4`, `warhol6`, `warhol8`, `sunset`, `ocean`
 
 **How it works**: Unique shape colors are sorted by luminance. Palette entries are mapped proportionally — `palette[0]` replaces the darkest cluster, `palette[-1]` replaces the lightest. Background defaults to the lightest palette entry unless `bg_color` is set. Palette length doesn't need to match K exactly; colors are binned proportionally.
+
+**Portraits**: Use K=16-24 even with bold palettes. Facial features (glasses, beard, brow) need tonal range that low K eliminates. A good rule of thumb: palette length ≈ K/3 for clean luminance binning. At K=8 with a 4-color palette, a face becomes an undifferentiated blob.
+
+**Contrast preprocessing warning**: External contrast boosting (contrast-stretch, sigmoidal-contrast) can confuse background detection. The pipeline's edge-contact heuristic assumes untouched luminance distributions — aggressive tone-mapping pushes subject tones into background-adjacent bins, causing misclassification (e.g., dark jacket regions classified as background and mapped to the lightest palette color). If you see subject regions tearing to the background color, try without preprocessing first. The pipeline's own bilateral blur + optional kuwahara/oilpaint handles tonal separation.
+
+### Background Detection Override (`bg_clusters`)
+
+Control which clusters are treated as background:
+
+```python
+# Auto-detect (default) — edge-contact heuristic
+svg, flow = image_to_svg("photo.jpg", mode="illustration", K=20, palette="warhol6")
+
+# Disable — no clusters removed, no background rect color override
+svg, flow = image_to_svg("photo.jpg", mode="illustration", K=20, palette="warhol6", bg_clusters=0)
+
+# Force specific cluster indices (from quantize step's sorted_clusters output)
+svg, flow = image_to_svg("photo.jpg", mode="illustration", K=20, palette="warhol6", bg_clusters=[2, 5])
+```
+
+Use `bg_clusters=0` when palette remapping already controls all colors explicitly and background detection is getting in the way. Use `bg_clusters=[list]` when you know which clusters are background but the heuristic misidentifies them.
+
+### Portrait Pop-Art Recipe (Warhol Style)
+
+```python
+# Key: enough K for facial features, palette length ~K/3, modest smoothing
+# Do NOT apply contrast preprocessing — it breaks background detection.
+results = image_to_svg_batch("portrait.jpg", [
+    {"name": "hot",   "mode": "illustration", "K": 20, "smooth": "kuwahara:6",
+     "palette": ["#000", "#D4145A", "#FF6B9D", "#FF85C0", "#FFD700", "#FFEF82", "#FFF8DC"]},
+    {"name": "cool",  "mode": "illustration", "K": 20, "smooth": "kuwahara:6",
+     "palette": ["#0D0035", "#4A00E0", "#7B68EE", "#00D4FF", "#7FFFD4", "#B0FFE0", "#E0FFFF"]},
+    {"name": "earth", "mode": "illustration", "K": 20, "smooth": "kuwahara:6",
+     "palette": ["#1a0a00", "#8B4513", "#CD853F", "#DEB887", "#F5DEB3", "#FAEBD7", "#FFF8DC"]},
+    {"name": "neon",  "mode": "illustration", "K": 20, "smooth": "kuwahara:6",
+     "palette": ["#0d0d0d", "#ff00ff", "#00ff00", "#ffff00", "#00ffff", "#ff69b4", "#f5f5f5"]},
+], svg_width=700)
+```
+
+Why this works: K=20 preserves enough tonal clusters for facial structure (glasses, beard, brow ridge). 7-color palettes give ~K/3 luminance bins — enough variation to separate features without muddying. `kuwahara:6` smooths texture without dissolving edges (`:12` erases glasses). Raw source → pipeline smoothing only; no external contrast manipulation.
 
 ## ImageMagick Preprocessing (smooth)
 
@@ -156,6 +196,8 @@ for name, svg in results.items():
 ```
 
 Variants sharing the same K run the pipeline (preprocess → quantize → edge_map → extract_contours) **once**, then fan out at assembly for palette remapping. This guarantees structural identity across palette variants (same shapes, same paths) and saves ~20-60s per shared K group.
+
+**Verification still applies in batch mode.** The turnkey feel of batch processing makes it easy to skip the side-by-side comparison — don't. Render at least one variant per K group and verify before delivering. Background detection failures and palette mapping issues are invisible without rendering.
 
 ## Verification Protocol
 

--- a/image-to-svg/_MAP.md
+++ b/image-to-svg/_MAP.md
@@ -1,0 +1,7 @@
+# image-to-svg/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+

--- a/image-to-svg/scripts/pipeline.py
+++ b/image-to-svg/scripts/pipeline.py
@@ -52,7 +52,7 @@ def _hex_luminance(hex_color):
     return 0.299 * r + 0.587 * g + 0.114 * b
 
 
-def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_color=None, smooth=None, **overrides):
+def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_color=None, smooth=None, bg_clusters=None, **overrides):
     """Set pipeline config. Called internally by image_to_svg().
 
     Any key in MODES presets can be overridden: K, dark_lum,
@@ -71,6 +71,10 @@ def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_col
              - "oilpaint" or "oilpaint:N": IM -paint N (default N=8)
              - "kuwahara" or "kuwahara:N": IM -kuwahara N (default N=5)
              Runs before the bilateral filter, so both are complementary.
+    bg_clusters: Override background detection.
+             - None (default): auto-detect via edge-contact heuristic
+             - 0: disable background detection (no background rect fill)
+             - list of ints: force specific cluster indices as background
     """
     if mode not in MODES:
         raise ValueError(f"Unknown mode '{mode}'. Choose from: {list(MODES.keys())}")
@@ -82,6 +86,7 @@ def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_col
     _cfg.update({
         "source_path": str(source_path), "svg_width": svg_width,
         "palette": palette, "bg_color": bg_color, "smooth": smooth,
+        "bg_clusters_override": bg_clusters,
         **MODES[mode], **overrides,
     })
 
@@ -251,6 +256,28 @@ def detect_background(quantize):
     sorted_clusters = quantize["sorted_clusters"]
     h, w = quantize["h"], quantize["w"]
 
+    override = _cfg.get("bg_clusters_override")
+
+    # bg_clusters=0 → skip detection entirely
+    if override == 0:
+        print("  detect_background: disabled (bg_clusters=0)")
+        return {"bg_clusters": set(), "bg_hex": "#000000"}
+
+    # bg_clusters=[list] → force specific cluster IDs
+    if isinstance(override, (list, tuple)):
+        bg_clusters = set(override)
+        # Compute weighted average color for forced clusters
+        bg_total = sum(cnt for cid, cnt in sorted_clusters if cid in bg_clusters)
+        bg_color = np.zeros(3, dtype=np.float64)
+        for cid, cnt in sorted_clusters:
+            if cid in bg_clusters:
+                bg_color += centers[cid].astype(np.float64) * cnt
+        bg_color = (bg_color / bg_total).astype(np.uint8) if bg_total > 0 else np.array([0, 0, 0], dtype=np.uint8)
+        bg_hex = f"#{bg_color[0]:02x}{bg_color[1]:02x}{bg_color[2]:02x}"
+        print(f"  detect_background: forced {len(bg_clusters)} clusters, {bg_hex}")
+        return {"bg_clusters": bg_clusters, "bg_hex": bg_hex}
+
+    # Default: auto-detect via edge-contact heuristic
     bg_clusters = set()
     for cid, cnt in sorted_clusters:
         pct = cnt / len(full_labels) * 100
@@ -486,7 +513,7 @@ def _assemble_pure(shapes, svg_w, svg_h, bg_hex, palette=None, bg_color=None):
 
 # --- Public API ---
 
-def image_to_svg(source_path, mode="painting", svg_width=1000, palette=None, bg_color=None, smooth=None, **overrides):
+def image_to_svg(source_path, mode="painting", svg_width=1000, palette=None, bg_color=None, smooth=None, bg_clusters=None, **overrides):
     """Convert a raster image to SVG.
 
     Args:
@@ -498,13 +525,15 @@ def image_to_svg(source_path, mode="painting", svg_width=1000, palette=None, bg_
         bg_color: Override background color (hex). With palette, defaults to lightest entry.
         smooth: ImageMagick preprocessing ("oilpaint", "oilpaint:N", "kuwahara", "kuwahara:N").
                 Reduces shape count/SVG size 20-30%. Requires ImageMagick on PATH.
+        bg_clusters: Override background detection.
+                     None=auto-detect, 0=disable, [list]=force cluster indices.
         **overrides: Override any mode preset (K, dark_lum, compactness_min,
                      edge_density_min, isolation_filter, min_area)
 
     Returns:
         (svg_string, flow) — the SVG content and the Flow object for inspection
     """
-    configure(source_path, mode=mode, svg_width=svg_width, palette=palette, bg_color=bg_color, smooth=smooth, **overrides)
+    configure(source_path, mode=mode, svg_width=svg_width, palette=palette, bg_color=bg_color, smooth=smooth, bg_clusters=bg_clusters, **overrides)
     flow = Flow(assemble_svg)
     flow.run()
     result = flow.value(assemble_svg)
@@ -524,6 +553,7 @@ def image_to_svg_batch(source_path, variants, svg_width=1000):
             - mode (str): "graphic", "illustration", "painting", "photo"
             - palette (optional): Hex list or preset name
             - bg_color (optional): Background override
+            - bg_clusters (optional): Override bg detection (None/0/[list])
             - K, dark_lum, etc. (optional): Override mode defaults
         svg_width: SVG viewBox width (shared across all variants)
 
@@ -548,9 +578,10 @@ def image_to_svg_batch(source_path, variants, svg_width=1000):
         mode = v.get("mode", "painting")
         if mode not in MODES:
             raise ValueError(f"Unknown mode '{mode}' in variant '{name}'")
-        cfg = {**MODES[mode], **{k: v[k] for k in v if k not in ("name", "mode", "palette", "bg_color", "smooth")}}
+        cfg = {**MODES[mode], **{k: v[k] for k in v if k not in ("name", "mode", "palette", "bg_color", "bg_clusters", "smooth")}}
         cfg["palette"] = v.get("palette")
         cfg["bg_color"] = v.get("bg_color")
+        cfg["bg_clusters"] = v.get("bg_clusters")
         cfg["smooth"] = v.get("smooth")
         cfg["name"] = name
         resolved.append(cfg)
@@ -572,9 +603,13 @@ def image_to_svg_batch(source_path, variants, svg_width=1000):
         use_isolation = any(v.get("isolation_filter", True) for v in group_variants)
         min_area = min(v["min_area"] for v in group_variants)
 
+        # Resolve bg_clusters for this K group: use first non-None override, else None (auto)
+        group_bg_clusters = next((v.get("bg_clusters") for v in group_variants if v.get("bg_clusters") is not None), None)
+
         # Configure for this K group
         configure(source_path, svg_width=svg_width,
                   smooth=group_variants[0].get("smooth"),
+                  bg_clusters=group_bg_clusters,
                   K=K, dark_lum=group_variants[0]["dark_lum"],
                   compactness_min=loosest_compact,
                   edge_density_min=loosest_edge,

--- a/seeing-images/_MAP.md
+++ b/seeing-images/_MAP.md
@@ -1,0 +1,7 @@
+# seeing-images/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [scripts/](./scripts/_MAP.md)
+


### PR DESCRIPTION
## Summary

Closes #481. Addresses all four issues from the Warhol portrait session:

- **`bg_clusters` parameter**: New override for background detection in `image_to_svg()` and `image_to_svg_batch()`. `None` = auto-detect (default), `0` = disable detection entirely, `[list]` = force specific cluster indices as background. This would have saved 3-4 iterations in the original session.
- **Portrait K/palette guidance**: Documents that portraits need K=16-24 even with bold palettes, with palette length ≈ K/3 for clean luminance binning.
- **Contrast preprocessing warning**: Documents the interaction between external contrast boosting and the edge-contact background detection heuristic — the most expensive trap from the session (5 iterations).
- **Batch verification reminder**: Adds a nudge in the Batch API section since the turnkey feel makes it easy to skip the non-negotiable side-by-side check.
- **Portrait pop-art recipe**: Complete Warhol-style recipe block with the settings that actually worked (K=20, kuwahara:6, 7-color palettes).

Bumps version to 1.7.0.

## Test plan

- [ ] Verify `bg_clusters=0` disables detection (returns empty set, no cluster removal)
- [ ] Verify `bg_clusters=[2, 5]` forces those clusters as background
- [ ] Verify `bg_clusters=None` (default) preserves existing auto-detect behavior
- [ ] Verify batch API passes `bg_clusters` through correctly
- [ ] Run portrait pop-art recipe from SKILL.md against a test image

https://claude.ai/code/session_01GaP6ZTSEoYbf33svKZBncq