### PR TITLE
fix(image-to-svg): mode→pipeline map, stroke params, bezier curves, group styling (#494)

### DIFF
--- a/image-to-svg/scripts/lines.py
+++ b/image-to-svg/scripts/lines.py
@@ -222,6 +222,179 @@ def merge_collinear(segments, angle_tol=0.12, dist_tol=6.0, gap_tol=15.0):
     return merged
 
 
+def merge_segments_to_curves(lines, merge_distance=10, merge_angle=30):
+    """Merge nearby collinear line segments into bezier curves.
+
+    Clusters extracted line segments by endpoint proximity and angular
+    continuity, then fits smooth bezier curves to each chain.
+
+    Args:
+        lines: list of dicts with {x1, y1, x2, y2, color, stroke_width}
+        merge_distance: max endpoint distance for chaining (in SVG units)
+        merge_angle: max angular deviation in degrees for chaining
+
+    Returns:
+        list of dicts — either:
+          {"path_d": str, "color": hex, "stroke_width": float}  (merged curves)
+          {"x1", "y1", "x2", "y2", "color", "stroke_width"}    (isolated segments)
+    """
+    if not lines:
+        return []
+
+    angle_tol_rad = merge_angle * np.pi / 180
+
+    def seg_angle(seg):
+        return np.arctan2(seg["y2"] - seg["y1"], seg["x2"] - seg["x1"]) % np.pi
+
+    def endpoint_dist(seg_a, seg_b):
+        """Min distance between any pair of endpoints."""
+        pts_a = [(seg_a["x1"], seg_a["y1"]), (seg_a["x2"], seg_a["y2"])]
+        pts_b = [(seg_b["x1"], seg_b["y1"]), (seg_b["x2"], seg_b["y2"])]
+        return min(
+            np.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2)
+            for a in pts_a for b in pts_b
+        )
+
+    # Build chains via greedy nearest-neighbor with angle + distance constraints
+    used = [False] * len(lines)
+    chains = []
+
+    for i in range(len(lines)):
+        if used[i]:
+            continue
+        chain = [i]
+        used[i] = True
+
+        # Extend chain in both directions
+        changed = True
+        while changed:
+            changed = False
+            head = chain[0]
+            tail = chain[-1]
+
+            best_head = (-1, float("inf"))
+            best_tail = (-1, float("inf"))
+
+            for j in range(len(lines)):
+                if used[j]:
+                    continue
+
+                # Angle check against the neighbor in the chain
+                da_head = abs(seg_angle(lines[head]) - seg_angle(lines[j]))
+                da_head = min(da_head, np.pi - da_head)
+                da_tail = abs(seg_angle(lines[tail]) - seg_angle(lines[j]))
+                da_tail = min(da_tail, np.pi - da_tail)
+
+                d_head = endpoint_dist(lines[head], lines[j])
+                d_tail = endpoint_dist(lines[tail], lines[j])
+
+                if da_head <= angle_tol_rad and d_head <= merge_distance:
+                    if d_head < best_head[1]:
+                        best_head = (j, d_head)
+                if da_tail <= angle_tol_rad and d_tail <= merge_distance:
+                    if d_tail < best_tail[1]:
+                        best_tail = (j, d_tail)
+
+            if best_tail[0] >= 0:
+                chain.append(best_tail[0])
+                used[best_tail[0]] = True
+                changed = True
+            if best_head[0] >= 0 and best_head[0] != best_tail[0]:
+                chain.insert(0, best_head[0])
+                used[best_head[0]] = True
+                changed = True
+
+        chains.append(chain)
+
+    # Convert chains to output
+    result = []
+    for chain in chains:
+        if len(chain) == 1:
+            # Isolated segment — pass through unchanged
+            result.append(dict(lines[chain[0]]))
+            continue
+
+        # Order chain endpoints into a polyline
+        # Use median color and stroke width from chain members
+        chain_segs = [lines[idx] for idx in chain]
+        colors = [s["color"] for s in chain_segs]
+        widths = [s["stroke_width"] for s in chain_segs]
+        # Most common color
+        from collections import Counter
+        color = Counter(colors).most_common(1)[0][0]
+        stroke_width = round(float(np.median(widths)), 1)
+
+        # Build ordered point sequence by walking closest endpoints
+        ordered_pts = [(chain_segs[0]["x1"], chain_segs[0]["y1"]),
+                       (chain_segs[0]["x2"], chain_segs[0]["y2"])]
+        remaining = list(range(1, len(chain_segs)))
+
+        while remaining:
+            last_pt = ordered_pts[-1]
+            best_idx = -1
+            best_dist = float("inf")
+            best_flip = False
+
+            for ri in remaining:
+                seg = chain_segs[ri]
+                d1 = np.sqrt((last_pt[0] - seg["x1"]) ** 2 + (last_pt[1] - seg["y1"]) ** 2)
+                d2 = np.sqrt((last_pt[0] - seg["x2"]) ** 2 + (last_pt[1] - seg["y2"]) ** 2)
+                if d1 < best_dist:
+                    best_dist, best_idx, best_flip = d1, ri, False
+                if d2 < best_dist:
+                    best_dist, best_idx, best_flip = d2, ri, True
+
+            seg = chain_segs[best_idx]
+            if best_flip:
+                ordered_pts.append((seg["x2"], seg["y2"]))
+                ordered_pts.append((seg["x1"], seg["y1"]))
+            else:
+                ordered_pts.append((seg["x1"], seg["y1"]))
+                ordered_pts.append((seg["x2"], seg["y2"]))
+            remaining.remove(best_idx)
+
+        # Deduplicate consecutive near-identical points
+        deduped = [ordered_pts[0]]
+        for pt in ordered_pts[1:]:
+            if np.sqrt((pt[0] - deduped[-1][0]) ** 2 + (pt[1] - deduped[-1][1]) ** 2) > 0.5:
+                deduped.append(pt)
+
+        # Fit bezier curve
+        if len(deduped) == 2:
+            # Two points — just a line, emit as segment
+            result.append({
+                "x1": deduped[0][0], "y1": deduped[0][1],
+                "x2": deduped[1][0], "y2": deduped[1][1],
+                "color": color, "stroke_width": stroke_width,
+            })
+        elif len(deduped) == 3:
+            # Quadratic bezier through 3 points
+            p0, p1, p2 = deduped
+            path_d = (f"M {p0[0]:.1f},{p0[1]:.1f} "
+                      f"Q {p1[0]:.1f},{p1[1]:.1f} "
+                      f"{p2[0]:.1f},{p2[1]:.1f}")
+            result.append({"path_d": path_d, "color": color, "stroke_width": stroke_width})
+        else:
+            # 4+ points — chain of quadratic beziers through midpoints
+            parts = [f"M {deduped[0][0]:.1f},{deduped[0][1]:.1f}"]
+            for k in range(1, len(deduped) - 1):
+                # Control point is the actual point, endpoint is midpoint to next
+                cx, cy = deduped[k]
+                if k < len(deduped) - 2:
+                    ex = (deduped[k][0] + deduped[k + 1][0]) / 2
+                    ey = (deduped[k][1] + deduped[k + 1][1]) / 2
+                else:
+                    ex, ey = deduped[-1]
+                parts.append(f"Q {cx:.1f},{cy:.1f} {ex:.1f},{ey:.1f}")
+            path_d = " ".join(parts)
+            result.append({"path_d": path_d, "color": color, "stroke_width": stroke_width})
+
+    n_curves = sum(1 for r in result if "path_d" in r)
+    n_lines = sum(1 for r in result if "x1" in r)
+    print(f"  merge_to_curves: {n_curves} curves + {n_lines} lines from {len(lines)} segments")
+    return result
+
+
 def measure_stroke_width(mask, x1, y1, x2, y2, n_samples=5):
     """Measure stroke width perpendicular to a line segment.
 
@@ -355,14 +528,34 @@ def suppress_line_regions(img_rgb, thin_mask):
     return result
 
 
-def lines_to_svg_elements(lines):
-    """Convert extracted lines to SVG <line> element strings."""
+def lines_to_svg_elements(lines, opacity=1.0):
+    """Convert extracted lines/curves to SVG element strings.
+
+    Handles two item formats:
+      - {"path_d": str, "color": hex, "stroke_width": float} → <path> element
+      - {"x1", "y1", "x2", "y2", "color", "stroke_width"} → <line> element
+
+    Args:
+        lines: list of line/curve dicts
+        opacity: per-element stroke-opacity (0.0–1.0). Only emitted if < 1.0.
+
+    Returns:
+        list of SVG element strings
+    """
+    opacity_attr = f' stroke-opacity="{opacity}"' if opacity < 1.0 else ''
     elements = []
     for ln in lines:
-        elements.append(
-            f'    <line x1="{ln["x1"]}" y1="{ln["y1"]}" '
-            f'x2="{ln["x2"]}" y2="{ln["y2"]}" '
-            f'stroke="{ln["color"]}" stroke-width="{ln["stroke_width"]}" '
-            f'stroke-linecap="round"/>'
-        )
+        if "path_d" in ln:
+            elements.append(
+                f'    <path d="{ln["path_d"]}" '
+                f'stroke="{ln["color"]}" stroke-width="{ln["stroke_width"]}" '
+                f'stroke-linecap="round" fill="none"{opacity_attr}/>'
+            )
+        else:
+            elements.append(
+                f'    <line x1="{ln["x1"]}" y1="{ln["y1"]}" '
+                f'x2="{ln["x2"]}" y2="{ln["y2"]}" '
+                f'stroke="{ln["color"]}" stroke-width="{ln["stroke_width"]}" '
+                f'stroke-linecap="round"{opacity_attr}/>'
+            )
     return elements

--- a/image-to-svg/scripts/pipeline.py
+++ b/image-to-svg/scripts/pipeline.py
@@ -5,7 +5,15 @@ Usage:
     svg, flow = image_to_svg("photo.jpg", mode="painting")
 
     # Compositional pipeline for line art / graphic inputs:
-    svg, flow = image_to_svg("kandinsky.jpg", mode="graphic", pipeline="compositional")
+    svg, flow = image_to_svg("kandinsky.jpg", mode="graphic")
+
+    # Mode implies pipeline: graphic→compositional, all others→fill.
+    # Override with pipeline="compositional" or pipeline="fill".
+
+    # Stroke params (compositional only):
+    svg, flow = image_to_svg("sketch.jpg", mode="graphic",
+                             stroke_width_cap=6, stroke_opacity=0.8,
+                             stroke_merge=True, stroke_blur=0.5)
 """
 import cv2
 import numpy as np
@@ -44,6 +52,14 @@ PALETTES = {
     "ocean":    ["#0c2340", "#1e6091", "#48c9b0", "#e8f4f8"],
 }
 
+# --- Mode → pipeline routing (replaces CV heuristic classify_input) ---
+MODE_PIPELINE = {
+    "graphic":      "compositional",
+    "illustration": "fill",
+    "painting":     "fill",
+    "photo":        "fill",
+}
+
 # --- Pipeline config (module-level, set by configure()) ---
 _cfg = {}
 
@@ -55,7 +71,10 @@ def _hex_luminance(hex_color):
     return 0.299 * r + 0.587 * g + 0.114 * b
 
 
-def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_color=None, smooth=None, bg_clusters=None, pipeline="auto", **overrides):
+def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_color=None, smooth=None, bg_clusters=None, pipeline="auto",
+              stroke_width_cap=4.5, stroke_width_scale=0.65, stroke_opacity=1.0,
+              stroke_merge=None, stroke_merge_distance=10, stroke_merge_angle=30,
+              stroke_blur=0, stroke_dasharray=None, **overrides):
     """Set pipeline config. Called internally by image_to_svg().
 
     Any key in MODES presets can be overridden: K, dark_lum,
@@ -79,9 +98,18 @@ def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_col
              - 0: disable background detection (no background rect fill)
              - list of ints: force specific cluster indices as background
     pipeline: Pipeline selection for handling line art.
-             - "auto" (default): classify input and choose automatically
+             - "auto" (default): mode implies pipeline via MODE_PIPELINE
              - "fill": force fill-only pipeline (current behavior)
              - "compositional": force two-pass line+fill pipeline
+    stroke_width_cap: Maximum SVG stroke width for extracted lines (default 4.5).
+    stroke_width_scale: Multiply measured width by this (default 0.65).
+    stroke_opacity: Per-element stroke opacity 0.0–1.0 (default 1.0).
+    stroke_merge: Enable bezier curve fitting for extracted strokes.
+                  Default: True for compositional pipeline, False otherwise.
+    stroke_merge_distance: Max endpoint distance for chaining (default 10).
+    stroke_merge_angle: Max angular deviation in degrees (default 30).
+    stroke_blur: Gaussian blur stdDeviation applied to stroke group (default 0).
+    stroke_dasharray: SVG stroke-dasharray for sketchy effect (default None).
     """
     if mode not in MODES:
         raise ValueError(f"Unknown mode '{mode}'. Choose from: {list(MODES.keys())}")
@@ -96,6 +124,14 @@ def configure(source_path, mode="painting", svg_width=1000, palette=None, bg_col
         "source_path": str(source_path), "svg_width": svg_width,
         "palette": palette, "bg_color": bg_color, "smooth": smooth,
         "bg_clusters_override": bg_clusters, "pipeline": pipeline,
+        "stroke_width_cap": stroke_width_cap,
+        "stroke_width_scale": stroke_width_scale,
+        "stroke_opacity": stroke_opacity,
+        "stroke_merge": stroke_merge,
+        "stroke_merge_distance": stroke_merge_distance,
+        "stroke_merge_angle": stroke_merge_angle,
+        "stroke_blur": stroke_blur,
+        "stroke_dasharray": stroke_dasharray,
         **MODES[mode], **overrides,
     })
 
@@ -523,16 +559,21 @@ def _assemble_pure(shapes, svg_w, svg_h, bg_hex, palette=None, bg_color=None):
 # --- Compositional assembly (fills + strokes) ---
 
 def _assemble_compositional(shapes, stroke_lines, svg_w, svg_h, bg_hex,
-                            palette=None, bg_color=None):
+                            palette=None, bg_color=None,
+                            stroke_opacity=1.0, stroke_blur=0,
+                            stroke_dasharray=None):
     """Assemble layered SVG with fill shapes behind line strokes.
 
     Args:
         shapes: List of {"path": str, "color": hex, "area": float}
-        stroke_lines: List of {"x1", "y1", "x2", "y2", "color", "stroke_width"}
+        stroke_lines: List of line/curve dicts (from extract_lines or merge_segments_to_curves)
         svg_w, svg_h: ViewBox dimensions
         bg_hex: Detected background color
         palette: Optional palette for fill remapping
         bg_color: Optional background color override
+        stroke_opacity: Opacity for the entire strokes group (0.0–1.0, default 1.0)
+        stroke_blur: Gaussian blur stdDeviation for strokes group (default 0)
+        stroke_dasharray: SVG stroke-dasharray value for sketchy effect (default None)
 
     Returns:
         SVG string with <g id="fills"> and <g id="strokes"> layers
@@ -558,16 +599,32 @@ def _assemble_compositional(shapes, stroke_lines, svg_w, svg_h, bg_hex,
 
     out = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}">',
-        f'  <rect width="{svg_w}" height="{svg_h}" fill="{bg_hex}"/>',
-        '  <g id="fills">',
     ]
+
+    # Defs for stroke filter (if blur requested)
+    if stroke_blur > 0:
+        out.append(f'  <defs><filter id="sf"><feGaussianBlur stdDeviation="{stroke_blur}"/></filter></defs>')
+
+    out.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="{bg_hex}"/>')
+    out.append('  <g id="fills">')
     for s in shapes:
         c = color_map.get(s["color"], s["color"]) if palette else s["color"]
         out.append(f'    <path d="{s["path"]}" fill="{c}" stroke="{c}" stroke-width="4" stroke-linejoin="round"/>')
     out.append('  </g>')
 
     if stroke_lines:
-        out.append('  <g id="strokes">')
+        # Build group attributes
+        g_attrs = ['id="strokes"']
+        if stroke_opacity < 1.0:
+            g_attrs.append(f'opacity="{stroke_opacity}"')
+        if stroke_blur > 0:
+            g_attrs.append('filter="url(#sf)"')
+        if stroke_dasharray:
+            g_attrs.append(f'stroke-dasharray="{stroke_dasharray}"')
+
+        out.append(f'  <g {" ".join(g_attrs)}>')
+        # Per-element opacity is NOT used when group-level opacity is set
+        # (avoid double-application). Use per-element only if group opacity is 1.0.
         out.extend(lines_to_svg_elements(stroke_lines))
         out.append('  </g>')
 
@@ -576,18 +633,24 @@ def _assemble_compositional(shapes, stroke_lines, svg_w, svg_h, bg_hex,
 
 
 def _run_compositional(source_path, mode, svg_width, palette, bg_color,
-                       smooth, bg_clusters, **overrides):
+                       smooth, bg_clusters,
+                       stroke_width_cap=4.5, stroke_width_scale=0.65,
+                       stroke_opacity=1.0,
+                       stroke_merge=True, stroke_merge_distance=10,
+                       stroke_merge_angle=30,
+                       stroke_blur=0, stroke_dasharray=None,
+                       **overrides):
     """Run the two-pass compositional pipeline.
 
-    Pass 1: Extract lines from the original image -> SVG <line> strokes
-    Pass 2: Suppress lines, run fill pipeline on cleaned image -> SVG <path> fills
+    Pass 1: Extract lines from the original image -> SVG strokes
+    Pass 2: Suppress lines, run fill pipeline on cleaned image -> SVG fills
     Compose both layers into a single SVG.
 
     Returns:
-        (svg_string, flow, classification) tuple
+        (svg_string, flow) tuple
     """
     import tempfile, os
-    from lines import classify_input, extract_lines, suppress_line_regions
+    from lines import extract_lines, suppress_line_regions, merge_segments_to_curves
 
     # Load original image
     img = cv2.imread(str(source_path))
@@ -600,12 +663,22 @@ def _run_compositional(source_path, mode, svg_width, palette, bg_color,
     scale_x = svg_width / w
     scale_y = svg_h / h
 
-    # Pass 1: Line extraction
+    # Pass 1: Line extraction with configurable stroke params
     print("  compositional pass 1: line extraction")
     stroke_lines, thin_mask = extract_lines(
         rgb, scale_x=scale_x, scale_y=scale_y,
         min_line_length=max(20, int(min(h, w) * 0.02)),
+        stroke_width_cap=stroke_width_cap,
+        stroke_width_scale=stroke_width_scale,
     )
+
+    # Bezier curve fitting (merge nearby segments into smooth curves)
+    if stroke_merge and stroke_lines:
+        stroke_lines = merge_segments_to_curves(
+            stroke_lines,
+            merge_distance=stroke_merge_distance,
+            merge_angle=stroke_merge_angle,
+        )
 
     # Pass 2: Suppress lines, run fill pipeline on cleaned image
     print("  compositional pass 2: fill extraction on line-suppressed image")
@@ -636,6 +709,9 @@ def _run_compositional(source_path, mode, svg_width, palette, bg_color,
         contour_result["svg_w"], contour_result["svg_h"],
         bg_result["bg_hex"],
         palette=palette, bg_color=bg_color,
+        stroke_opacity=stroke_opacity,
+        stroke_blur=stroke_blur,
+        stroke_dasharray=stroke_dasharray,
     )
 
     n_fills = len(contour_result["shapes"])
@@ -649,6 +725,9 @@ def _run_compositional(source_path, mode, svg_width, palette, bg_color,
 
 def image_to_svg(source_path, mode="painting", svg_width=1000, palette=None,
                  bg_color=None, smooth=None, bg_clusters=None, pipeline="auto",
+                 stroke_width_cap=4.5, stroke_width_scale=0.65, stroke_opacity=1.0,
+                 stroke_merge=None, stroke_merge_distance=10, stroke_merge_angle=30,
+                 stroke_blur=0, stroke_dasharray=None,
                  **overrides):
     """Convert a raster image to SVG.
 
@@ -664,33 +743,46 @@ def image_to_svg(source_path, mode="painting", svg_width=1000, palette=None,
         bg_clusters: Override background detection.
                      None=auto-detect, 0=disable, [list]=force cluster indices.
         pipeline: Pipeline selection.
-                  "auto" — classify input, use compositional for graphic art (default)
-                  "fill" — fill-only pipeline (previous default behavior)
+                  "auto" — mode implies pipeline via MODE_PIPELINE (default)
+                  "fill" — fill-only pipeline
                   "compositional" — two-pass line+fill pipeline for line art
+        stroke_width_cap: Maximum SVG stroke width for extracted lines (default 4.5).
+        stroke_width_scale: Multiply measured width by this (default 0.65).
+        stroke_opacity: Stroke group opacity 0.0–1.0 (default 1.0).
+        stroke_merge: Enable bezier curve fitting for extracted strokes.
+                      Default: True for compositional pipeline.
+        stroke_merge_distance: Max endpoint distance for chaining (default 10).
+        stroke_merge_angle: Max angular deviation in degrees (default 30).
+        stroke_blur: Gaussian blur stdDeviation for stroke group (default 0).
+        stroke_dasharray: SVG stroke-dasharray for sketchy effect (default None).
         **overrides: Override any mode preset (K, dark_lum, compactness_min,
                      edge_density_min, isolation_filter, min_area)
 
     Returns:
         (svg_string, flow) — the SVG content and the Flow object for inspection
     """
-    # Determine effective pipeline
+    # Determine effective pipeline — mode implies pipeline, no CV classifier
     effective_pipeline = pipeline
     if pipeline == "auto":
-        from lines import classify_input as _classify
-        img = cv2.imread(str(source_path))
-        if img is None:
-            raise FileNotFoundError(f"Cannot read: {source_path}")
-        rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        classification = _classify(rgb)
-        effective_pipeline = "compositional" if classification["is_graphic"] else "fill"
-        print(f"  classify: {'graphic' if classification['is_graphic'] else 'photographic'} "
-              f"(edge={classification['edge_density']}, bimodal={classification['bimodality']}, "
-              f"lines={classification['n_lines']})")
+        effective_pipeline = MODE_PIPELINE[mode]
+        print(f"  pipeline: {mode} → {effective_pipeline}")
+
+    # Resolve stroke_merge default
+    effective_merge = stroke_merge if stroke_merge is not None else (effective_pipeline == "compositional")
 
     if effective_pipeline == "compositional":
         svg, flow = _run_compositional(
             source_path, mode=mode, svg_width=svg_width, palette=palette,
-            bg_color=bg_color, smooth=smooth, bg_clusters=bg_clusters, **overrides,
+            bg_color=bg_color, smooth=smooth, bg_clusters=bg_clusters,
+            stroke_width_cap=stroke_width_cap,
+            stroke_width_scale=stroke_width_scale,
+            stroke_opacity=stroke_opacity,
+            stroke_merge=effective_merge,
+            stroke_merge_distance=stroke_merge_distance,
+            stroke_merge_angle=stroke_merge_angle,
+            stroke_blur=stroke_blur,
+            stroke_dasharray=stroke_dasharray,
+            **overrides,
         )
         return svg, flow
 


### PR DESCRIPTION
Closes #494

## Changes

### Fix 1: Mode implies pipeline (no more `classify_input` auto-routing)

- Added `MODE_PIPELINE` map: `graphic→compositional`, all others→`fill`
- `pipeline="auto"` now uses this map instead of calling `classify_input()`
- `classify_input()` stays in lines.py untouched — just no longer called from the pipeline
- Explicit `pipeline="compositional"` override still works for any mode

### Fix 2: Exposed stroke params on API

New params on `image_to_svg()` and `configure()`:
- `stroke_width_cap` (default 4.5)
- `stroke_width_scale` (default 0.65)
- `stroke_opacity` (default 1.0)

Threaded through `_run_compositional` → `extract_lines` (width params) and `_assemble_compositional` → `lines_to_svg_elements` (opacity).

### Fix 3: Bezier curve fitting for extracted strokes

New `merge_segments_to_curves()` in lines.py:
- Clusters nearby segments by endpoint proximity + angular continuity
- Fits quadratic bezier chains through ordered point sequences
- Isolated segments pass through as `<line>` elements
- Merged chains become `<path d="M... Q...">` with `fill="none"`

New params: `stroke_merge` (default True for compositional), `stroke_merge_distance`, `stroke_merge_angle`.

`lines_to_svg_elements()` updated to handle both `{path_d}` and `{x1,y1,x2,y2}` dicts.

### Fix 4: Group-level stroke styling

`_assemble_compositional` now applies styling to `<g id="strokes">`:
- `stroke_opacity` → `opacity="..."` on group
- `stroke_blur` → `<filter>` with `feGaussianBlur`, applied via `filter="url(#sf)"`
- `stroke_dasharray` → `stroke-dasharray="..."` on group

Zero per-element cost for group attrs.

## Invariants verified

- `mode="painting"` → fill pipeline (no Hough lines) ✓
- `mode="graphic"` → compositional pipeline ✓
- `pipeline="compositional"` works regardless of mode ✓
- `stroke_opacity=0.5` produces `stroke-opacity="0.5"` ✓
- Default `mode="graphic"` renders identically (defaults unchanged) ✓
- Merged strokes are `<path>` with `fill="none"` ✓
- Isolated segments stay as `<line>` ✓
- `stroke_merge=False` produces identical output to current ✓
- Group filter/opacity on `<g>` level, not per-element ✓

## svg-portrait-mode assessment

Portrait mode imports `configure`, `preprocess`, `quantize`, `detect_background`, `edge_map` from pipeline — none of the changed functions. It has its own zone-aware contour extraction and never touches `classify_input`, `extract_lines`, `_run_compositional`, or `_assemble_compositional`. **No changes needed.**