### PR TITLE
Add missing READMEs for searching-codebases, featuring, tree-sitting

### DIFF
--- a/featuring/README.md
+++ b/featuring/README.md
@@ -1,0 +1,22 @@
+# featuring
+
+Generate hierarchical `_FEATURES.md` files that describe what a codebase **does** from a user/consumer perspective, anchored to source symbols via tree-sitting.
+
+## Features
+
+- **Top-down feature documentation** — organized by capability, not by file or directory structure
+- **Hierarchical decomposition** — complex capability areas get their own sub-feature files with progressive disclosure
+- **Multi-pass synthesis** — orientation scan, detailed extraction, then overview rewrite (written last, not first)
+- **Symbol anchoring** — every feature references key symbols via `file#symbol` notation
+- **Drift detection** — `check.py` validates all symbol references against the live codebase, catching renames, deletions, and uncovered new APIs
+- **CI-ready** — check script returns exit codes suitable for GitHub Actions or pre-commit hooks
+
+## Dependency
+
+Requires the **tree-sitting** skill for AST-based code scanning.
+
+## Relationship to Other Skills
+
+- **tree-sitting** provides the structural inventory (what symbols exist)
+- **featuring** adds the semantic layer (why they exist, what they accomplish together)
+- **generating-lattice** offers stricter bidirectional traceability when needed

--- a/searching-codebases/README.md
+++ b/searching-codebases/README.md
@@ -1,0 +1,18 @@
+# searching-codebases
+
+Find code in any codebase by regex pattern or natural language concept. Auto-routes between n-gram indexed regex search (2-20x faster than ripgrep) and TF-IDF semantic search. Expands results to full functions via tree-sitting AST data.
+
+## Features
+
+- **Dual search modes** — regex (pattern/identifier) and semantic (natural language concepts), auto-routed per query
+- **N-gram indexed regex** — sparse inverted index narrows candidate files by 90-99% before ripgrep verification
+- **TF-IDF semantic search** — cosine similarity ranking over code chunks (functions, classes)
+- **AST context expansion** — optional tree-sitting integration returns complete function/class bodies instead of line fragments
+- **Flexible sources** — accepts GitHub URLs, local directories, uploaded files/archives, or project knowledge
+- **Mixed queries** — multiple queries with different modes in a single invocation; indexes built once per mode
+
+## Dependencies
+
+- **ripgrep** — required for regex verification
+- **tree-sitting** — optional, enables `--expand` for structural context
+- **scikit-learn** — required for semantic mode (auto-installs)

--- a/tree-sitting/README.md
+++ b/tree-sitting/README.md
@@ -1,0 +1,19 @@
+# tree-sitting
+
+AST-powered code navigation using tree-sitter. Parses all source files in a codebase into in-memory syntax trees, then provides fast query tools for symbol search, file/directory overview, source retrieval, and reference finding.
+
+## Features
+
+- **Fast scanning** — parses ~250 files in ~700ms, then all queries are sub-millisecond from cache
+- **Symbol search** — find by exact name, substring, or glob pattern across the entire codebase
+- **Directory and file overview** — structural summaries with symbol counts, signatures, and doc comments
+- **Source retrieval** — fetch implementation of any symbol, preferring definitions over declarations
+- **Reference finding** — locate all textual references to a symbol via fast grep against cached source
+- **26 languages** — Python, JavaScript, TypeScript, Go, Rust, Ruby, Java, C, C++, C#, Swift, Kotlin, and more
+- **Three-tier extraction** — custom extractors (richest), community tags.scm queries, and generic heuristic fallback
+- **Dual deployment** — direct Python calls in Claude.ai, or long-lived MCP server in Claude Code
+
+## Dependencies
+
+- **tree-sitter-language-pack** — grammar bundles for all supported languages
+- **fastmcp** — required only for MCP server mode (Claude Code)


### PR DESCRIPTION
Three skills released today are showing "No README found" on the skill-releases page.

Adds README.md for:
- **searching-codebases** v2.0.0
- **featuring** v0.2.0
- **tree-sitting** v0.2.0

READMEs are excluded from release zips so no new versions needed.