### PR TITLE
chore: add version 0.3.0, move provenance to README

### DIFF
--- a/reasoning-semiformally/README.md
+++ b/reasoning-semiformally/README.md
@@ -1,0 +1,18 @@
+# Semi-Formal Code Reasoning
+
+Structured certificate templates for code analysis, based on Ugare & Chandra (2026).
+
+## Provenance
+
+- Paper: Ugare & Chandra, "Agentic Code Reasoning with Semi-Formal Certificates" (arXiv:2603.01896, March 2026)
+- Replication: Django name-shadowing (0%→100% fault localization), 3 real bugs (+11pp aggregate)
+- CVE validation: CVE-2026-29000 (pac4j-jwt, 383 lines). Haiku: +20pp with template. Sonnet: -20pp with template.
+- Finding: Template value is model-capability-dependent. Scaffolding helps weaker models; it becomes overhead for stronger ones.
+
+## Structure
+
+| File | Audience | Purpose |
+|------|----------|---------|
+| `SKILL.md` | All models | Thin router: skip conditions + model-tier routing |
+| `sonnet.md` | Sonnet/Opus | 3 compact verification checkpoints |
+| `haiku.md` | Haiku | Full procedural templates with worked examples |

--- a/reasoning-semiformally/SKILL.md
+++ b/reasoning-semiformally/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: reasoning-semiformally
+version: 0.3.0
 description: Apply semi-formal certificate reasoning to code analysis — patch verification, fault localization, patch equivalence. Use when reviewing patches, hunting bugs across scopes, comparing fixes, or when code reasoning requires tracing execution across files/modules. Triggers on code review, bug localization, patch comparison, name shadowing, scope analysis, regression checking.
 ---
 
 # Semi-Formal Code Reasoning
 
-Structured certificate templates that force mandatory checkpoints before conclusions. Based on Ugare & Chandra (2026), validated in replication experiments.
+Structured certificate templates that force mandatory checkpoints before conclusions.
 
 ## Skip Conditions
 
@@ -33,10 +34,3 @@ For complex tasks, apply templates sequentially:
 3. **Patch equivalence** to compare alternative fixes
 
 Each output feeds the next as premises.
-
-## Provenance
-
-- Paper: Ugare & Chandra, "Agentic Code Reasoning with Semi-Formal Certificates" (arXiv:2603.01896, March 2026)
-- Replication: Django name-shadowing (0%→100% fault localization), 3 real bugs (+11pp aggregate)
-- CVE validation: CVE-2026-29000 (pac4j-jwt, 383 lines). Haiku: +20pp with template. Sonnet: -20pp with template.
-- Finding: Template value is model-capability-dependent. Scaffolding helps weaker models; it becomes overhead for stronger ones.


### PR DESCRIPTION
Follow-up to #524 (replaces #525 which had merge conflicts).

- Remove provenance section from SKILL.md (operational-only)
- Add README.md with provenance and file structure table
- Add version: 0.3.0 to SKILL.md frontmatter