### PR TITLE
feat(boot): add task parameter for perch task prompts (#528)

### DIFF
--- a/remembering/scripts/boot.py
+++ b/remembering/scripts/boot.py
@@ -458,15 +458,22 @@ PERCH_OPS_KEYS = frozenset({
     'remembering-api', 'memory-types', 'storage-discipline',
 })
 
+# Valid task names for boot(task=...) in perch mode (#528)
+PERCH_VALID_TASKS = frozenset({'fly', 'zeitgeist', 'dispatch', 'sleep'})
+
 
 # @lat: [[memory#Boot Sequence]]
-def boot(mode: str = None) -> str:
+def boot(mode: str = None, task: str = None) -> str:
     """Boot sequence: load profile + ops from Turso.
 
     Args:
         mode: Optional boot mode. "perch" emits a slim ~10K-char output
               suitable for API callers with tight token budgets (#353).
               None (default) emits full boot output.
+        task: Optional task name for perch mode. When set with mode="perch",
+              appends task-specific instructions to the boot output (#528).
+              Valid values: "fly", "zeitgeist", "dispatch", "sleep".
+              Ignored when mode is not "perch".
 
     Returns formatted string with complete profile and ops values.
 
@@ -480,6 +487,7 @@ def boot(mode: str = None) -> str:
 
     v5.0.0: Removed local cache. All reads go to Turso directly.
     v5.4.0: Added mode="perch" for slim API boot (#353).
+    v5.8.0: Added task= for unified perch task prompts (#528).
     """
     # Refresh OPS_TOPICS from config (v3.6.0: dynamic loading)
     global OPS_TOPICS, _OPS_KEY_TO_TOPIC
@@ -509,7 +517,7 @@ def boot(mode: str = None) -> str:
             return f"ERROR: Unable to load config (remote failed: {e}, no defaults available)"
 
     if mode == "perch":
-        return _boot_perch(profile_data, ops_data)
+        return _boot_perch(profile_data, ops_data, task=task)
 
     # -- Full boot (default) --
 
@@ -545,20 +553,31 @@ def boot(mode: str = None) -> str:
     return _format_boot_output(profile_data, ops_by_topic, uncategorized, reference_ops, installed_utils, github_access, pending_tasks, recent_flights, due_reminders)
 
 
-def _boot_perch(profile_data: list, ops_data: list) -> str:
-    """Slim boot for perch/API context (#353).
+def _boot_perch(profile_data: list, ops_data: list, *, task: str = None) -> str:
+    """Slim boot for perch/API context (#353, #528).
 
     Emits ~10K chars by keeping only identity core + essential memory ops.
     Drops: recall-triggers, utility listings, voice/tensions profile,
     reference entries, GitHub detection, incomplete tasks.
 
+    When task is specified, appends task-specific instructions from the
+    tasks/ directory within the remembering skill (#528).
+
     Args:
         profile_data: List of profile config entries
         ops_data: List of all ops config entries
+        task: Optional task name ("fly", "zeitgeist", "dispatch", "sleep").
+              If specified, task instructions are appended to boot output.
 
     Returns:
-        Compact boot output string
+        Compact boot output string, optionally with task instructions appended
     """
+    # Validate task if provided
+    if task is not None and task not in PERCH_VALID_TASKS:
+        raise ValueError(
+            f"Unknown task '{task}'. Valid tasks: {', '.join(sorted(PERCH_VALID_TASKS))}"
+        )
+
     output = []
 
     # Time anchor (temporal grounding)
@@ -579,7 +598,31 @@ def _boot_perch(profile_data: list, ops_data: list) -> str:
         for o in perch_ops:
             output.append(_format_entry(o))
 
+    # Task instructions (#528)
+    if task:
+        task_content = _load_task_prompt(task)
+        if task_content:
+            output.append(f"\n# TASK\n{task_content}")
+
     return '\n'.join(output)
+
+
+def _load_task_prompt(task: str) -> str | None:
+    """Load task-specific prompt content from the tasks/ directory (#528).
+
+    Task prompts are version-controlled markdown files that provide
+    structured instructions for perch autonomous sessions.
+
+    Args:
+        task: Task name (e.g., "fly", "zeitgeist", "dispatch", "sleep")
+
+    Returns:
+        Task prompt content as string, or None if file not found.
+    """
+    task_file = Path(__file__).parent / "tasks" / f"{task}.md"
+    if task_file.exists():
+        return task_file.read_text().strip()
+    return None
 
 
 def _load_incomplete_tasks() -> list:

--- a/remembering/scripts/tasks/dispatch.md
+++ b/remembering/scripts/tasks/dispatch.md
@@ -1,0 +1,43 @@
+## Task: Dispatch (Route Decision)
+
+You are deciding what task to run this session. The runner will execute your choice — you only need to decide.
+
+### Steps
+
+1. `recall(tags=["perch-homework", "pending"], tag_mode="all", n=5)` — check for queued homework from Muninn
+2. `recall(tags=["session-log", "perch-time"], n=5)` — check recent session history
+3. `list_discussions(limit=5)` — check recent flight logs to see what was explored and surface threads worth continuing
+4. Note when each task last ran and what it found
+5. If recent flight logs suggest an interesting thread to continue, factor that into your routing decision
+6. Check your boot context for incomplete tasks or pending items
+7. Decide what's most needed right now
+
+### Homework override
+
+If step 1 returns pending homework, **execute the homework instructions** instead of routing to a standard task. Homework memories contain specific instructions from Muninn (the planning wing) for work to do during perch time.
+
+After completing homework, mark it done: `supersede(homework_id, "Completed: [brief summary]", "experience", tags=["perch-homework", "completed"])`
+
+When homework is present, output your decision as:
+
+```json
+{"task": "homework", "homework_id": "mem_xxx", "reason": "Pending homework: [description]"}
+```
+
+The runner does not have a "homework" task type — this signals you to execute the homework within the dispatch turn budget. Use your available tools to carry out the instructions.
+
+### Standard decision criteria (when no homework)
+
+- **sleep**: Memory maintenance — pruning, connections, deduplication. Run if >24h since last sleep, or if prior sessions noted issues.
+- **zeitgeist**: News and discourse awareness via Bluesky feeds. Run if >24h since last scan, or if something notable is happening.
+- **fly**: Autonomous exploration — follow intellectual threads, search the web, make connections. Run if there's an interesting thread to pursue, a question worth researching, or if sleep and zeitgeist are both recent.
+
+If nothing is pressing, default to **sleep**.
+
+### Output format
+
+After gathering context, end with your decision as JSON on its own line:
+
+```json
+{"task": "sleep|zeitgeist|fly", "reason": "one sentence rationale"}
+```

--- a/remembering/scripts/tasks/fly.md
+++ b/remembering/scripts/tasks/fly.md
@@ -1,0 +1,63 @@
+## Task: Fly (Autonomous Exploration)
+
+You are the raven flying out to see something new. The goal is breadth — going somewhere you haven't been, learning something you didn't know. Not circling back to familiar territory.
+
+### Phase 1: Orient (1-2 turns)
+
+1. `recall(tags=["session-log", "fly"], n=3)` — check recent flight logs. This tells you **where you've already been**. Don't go there again unless you have a specific reason.
+2. `list_discussions(limit=5)` — check recent discussions for threads Oskar engaged with (reactions, comments). His engagement signals interest.
+3. **Pick a direction.** Choose from the broad palette below, favoring areas you haven't explored recently:
+
+**Interest palette** (not exhaustive — surprise is welcome):
+- Client-side web, browser platform evolution, ATProto ecosystem
+- Norwegian politics, society, culture
+- US politics beyond headlines — policy, institutions, structural dynamics
+- Cycling science, physiology, training methodology, performance
+- Builder's philosophy — software craft, shipping culture, organizational design
+- AI as practitioner — what's actually shipping, what's useful, what's hype vs. real
+- Science, technology, or culture you stumbled into and found interesting
+
+**The rule**: If your last 3 flights all explored the same domain, you MUST pick a different one. Breadth is the mission.
+
+**IMPORTANT: Reserve your last 3 turns for Phase 3+4. Phase 4 requires `create_discussion` — mandatory.**
+
+### Phase 2: Explore (bulk of turns, minus 3 reserved)
+
+Go outward first, connect inward second:
+
+1. **web_search** — your primary tool. Search for your chosen topic. Go where the interesting links lead.
+2. **deep_read** — follow promising URLs. Pass `context` to focus the sub-agent's analysis.
+3. **recall** — AFTER finding something new, check: "does this connect to anything I already know?" Connections between different domains are high-value discoveries, but they're a bonus of breadth, not the mission.
+4. **bsky_search / bsky_feed** — secondary. Use if your topic has Bluesky discourse, but don't let feeds pull you back to the AI-paper attractor.
+
+#### The attractor trap
+
+If you notice yourself drifting toward memory systems, RAG, context management, or LLM architecture — STOP. Ask: "Did I choose this, or did my recall seed pull me here?" If the latter, pick a different direction. You can always explore AI topics, but they should be a deliberate choice, not a default.
+
+#### Web search tips
+
+- `web_search` searches the entire web. Use it early to orient.
+- You get up to 5 web searches per session. Make them count.
+- Combine with `deep_read` for full articles.
+
+#### Bluesky search pivot rule
+
+- If 2 consecutive `bsky_search` calls return empty/thin results, STOP searching Bluesky for that topic. Pivot to `web_search` or `deep_read`.
+
+### Phase 3: Synthesize (1-2 turns)
+
+1. `remember()` the most significant findings (type="analysis" or "world").
+2. Connect to existing knowledge via `refs=[]` where genuine connections exist.
+3. Note threads worth pursuing in future sessions.
+
+### Phase 4: Write Flight Log (1 turn — MANDATORY)
+
+Call `create_discussion` with:
+- **Title**: Descriptive of the exploration, e.g. "Fly 2026-04-03 — Norwegian Municipal Reform Aftermath"
+- **Body**: Your synthesis in markdown. Include:
+  - What you explored and why you chose it
+  - Key findings with inline [markdown links](https://url) — every source linked
+  - Connections to existing knowledge (if any emerged naturally)
+  - Threads worth pursuing next
+
+**Non-negotiable.** If low on turns, skip extra synthesis and post what you have.

--- a/remembering/scripts/tasks/sleep.md
+++ b/remembering/scripts/tasks/sleep.md
@@ -1,0 +1,31 @@
+## Task: Sleep (Memory Maintenance)
+
+You are performing memory maintenance. This is housekeeping — pruning noise, consolidating clusters, strengthening connections, and ensuring memory health.
+
+### Phase 1: Pruning
+
+1. Search for memories tagged `pending-test` or with low confidence (<0.5). Review them and decide: keep, update, or delete.
+2. Look for duplicate or near-duplicate memories. Use `sql_query` to find memories with similar summaries if needed.
+3. Check for stale memories — old observations that are no longer relevant.
+4. Delete noise. Be decisive.
+
+### Phase 2: Synthesis
+
+1. Use `recall` with broad searches to surface related memories that could be consolidated.
+2. Run `consolidate(dry_run=true)` on common tag clusters to see what can be merged.
+3. If consolidation looks beneficial, run it for real.
+4. Look for memories that reference each other but aren't connected. Consider superseding them with a synthesis.
+5. Check the experience layer — are there repeated patterns in session logs that should become procedures?
+
+### Phase 3: Diagnostics
+
+1. Run `sql_query` to get a histogram: `SELECT type, COUNT(*) as c FROM memories WHERE deleted_at IS NULL GROUP BY type ORDER BY c DESC`
+2. Check for imbalanced types (too many of one kind, too few of another).
+3. Note any structural issues for the session log.
+
+### Phase 4: Close
+
+Store a session summary as an `experience` memory with tags `["perch-time", "session-log", "sleep"]` capturing:
+- How many memories pruned, consolidated, connected
+- Any patterns or anomalies discovered
+- Recommendations for the next sleep session

--- a/remembering/scripts/tasks/zeitgeist.md
+++ b/remembering/scripts/tasks/zeitgeist.md
@@ -1,0 +1,49 @@
+## Task: Zeitgeist (Morning Briefing)
+
+You are the raven returning at dawn with news of the world. This is a briefing — what happened, what's developing, what matters today. Not a research digest.
+
+### Phase 1: Recall for Context (1 turn)
+
+1. `recall(tags=["zeitgeist-digest"], n=3)` — check what you covered recently.
+2. Note topics already reported. For each: you'll check for **new developments**, not repeat the story.
+
+### Phase 2: World News (2-3 turns)
+
+Use `web_search` to scan actual current events. This is the core of the task.
+
+Search targets (adjust to what's newsworthy today):
+- **US news** — politics, policy, economy, major events
+- **Norway news** — politics, society, anything notable
+- **World events** — conflicts, diplomacy, major international developments
+- **Tech industry** — business moves, product launches, policy/regulation, controversies (not papers)
+
+For each topic from Phase 1 that reappears: cover only the **delta** — what's new since last coverage. Don't repeat known context.
+
+For genuinely new stories: brief summary with context.
+
+### Phase 3: Social Signal (1-2 turns)
+
+1. `bsky_trending()` — what people are talking about (mood and discourse, not papers).
+2. `bsky_feed("ai_list")` — skim for noteworthy **industry** developments (shipping products, policy moves, takes that reveal shifts). Skip paper summaries unless they signal something practitioners care about.
+3. Check interactions on @austegard.com and @muninn.austegard.com — replies, likes, mentions worth noting.
+
+### Phase 4: Store & Post (1-2 turns)
+
+1. **Store** a zeitgeist summary as `world` memory with tags `["perch-time", "zeitgeist", "YYYY-MM-DD"]`.
+   - Lead with the most significant stories
+   - Brief, scannable format — headlines with 1-2 sentence context
+   - Not exhaustive; signal over noise
+
+2. **Store** a digest as `analysis` memory with tags `["perch", "zeitgeist-digest", "YYYY-MM-DD", ...topic-tags]`:
+   - 2-3 sentence summary of key signals for retrieval
+
+3. **Post** a discussion via `create_discussion`:
+   - Title: "Zeitgeist YYYY-MM-DD — [top 2-3 topics]"
+   - Body: The briefing in markdown
+
+### Formatting Rules
+
+- All references MUST use inline markdown links: `[Title](https://url)`. No bare URLs, no unlinked names.
+- Write like a morning briefing, not a literature review.
+- Prioritize recency: what happened in the last 24 hours.
+- If a story is developing (e.g., ongoing conflict, unfolding policy), note where it stands now vs. last coverage.


### PR DESCRIPTION
## boot(task) — unify perch task prompts into boot system

Closes #528.

### Changes

**`boot.py`**:
- `boot()` gains a `task` parameter (keyword-only in `_boot_perch`, positional in `boot()`)
- `boot(mode="perch", task="fly")` appends fly task instructions after identity + ops
- `boot(mode="perch")` unchanged — still emits slim identity-only output
- `boot()` (full boot) ignores `task=` — no behavioral change
- `_load_task_prompt(task)` reads from `scripts/tasks/{task}.md`
- `PERCH_VALID_TASKS` frozenset validates task names; `ValueError` on invalid
- New `_load_task_prompt()` helper alongside other `_load_*` functions

**`scripts/tasks/`** (new directory):
- `fly.md` — autonomous exploration prompt (from mac `.perch/prompts/tasks/fly.md`)
- `zeitgeist.md` — morning briefing prompt
- `dispatch.md` — route decision prompt  
- `sleep.md` — memory maintenance prompt

### Usage

```python
boot(mode="perch", task="fly")      # slim profile + fly instructions
boot(mode="perch", task="zeitgeist") # slim profile + zeitgeist instructions
boot(mode="perch", task="dispatch")  # slim profile + dispatch instructions
boot(mode="perch")                   # slim profile only (current behavior)
boot()                               # full boot (unchanged)
```

### Output sizes (tested)

| Call | Chars |
|------|-------|
| `boot(mode="perch")` | ~4,200 |
| `boot(mode="perch", task="fly")` | ~7,800 |
| `boot(mode="perch", task="zeitgeist")` | ~6,700 |
| `boot(mode="perch", task="sleep")` | ~5,800 |
| `boot(mode="perch", task="dispatch")` | ~6,400 |

All comfortably within Haiku's token budget.

### Companion change needed

The perch runner (`.perch/perch.py` in mac repo) will need updating to call `boot(mode="perch", task=chosen_task)` instead of concatenating `load_prompt(f"tasks/{task}")`. That's a separate PR on the mac repo once this merges.

### Verification

✓ All task prompts load correctly  
✓ Invalid task raises ValueError  
✓ `task=` ignored in full boot mode  
✓ `boot(mode="perch")` without task unchanged  
✓ Task content appears under `# TASK` heading