### PR TITLE
Simplify marketplace entries to match official Anthropic pattern

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "oaustegard-claude-skills",
+  "version": "1.0.0",
   "description": "Community skills for Claude Code and Claude.ai",
   "owner": {
     "name": "Oskar Austegard"
@@ -11,191 +12,77 @@
       "description": "AI model invocation, multi-agent orchestration, prompt distillation, and structured reasoning frameworks.",
       "source": "./plugins/ai-and-reasoning",
       "version": "1.1.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Ai And Reasoning",
-      "keywords": [
-        "orchestrating-agents",
-        "convening-experts",
-        "down-skilling",
-        "invoking-gemini",
-        "llm-as-computer",
-        "reviewing-ai-papers",
-        "tiling-tree"
-      ]
+      "category": "ai-and-reasoning"
     },
     {
       "name": "code-intelligence",
       "description": "Codebase exploration, navigation, mapping, and static analysis tools for understanding unfamiliar codebases.",
       "source": "./plugins/code-intelligence",
       "version": "2.0.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Code Intelligence",
-      "keywords": [
-        "exploring-codebases",
-        "featuring",
-        "generating-lattice",
-        "mapping-codebases",
-        "mapping-webapp",
-        "reasoning-semiformally",
-        "searching-codebases",
-        "tree-sitting"
-      ]
+      "category": "code-intelligence"
     },
     {
       "name": "data-and-visualization",
       "description": "Data analysis, charting, forecasting, and interactive visualization tools.",
       "source": "./plugins/data-and-visualization",
       "version": "1.0.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Data And Visualization",
-      "keywords": [
-        "charting",
-        "charting-vega-lite",
-        "exploring-data",
-        "extracting-keywords",
-        "forecasting-reverso",
-        "json-render-ui"
-      ]
+      "category": "data-and-visualization"
     },
     {
       "name": "development-tools",
       "description": "Software development utilities: MCP servers, bookmarklets, frameworks, patching, and environment validation.",
       "source": "./plugins/development-tools",
       "version": "1.2.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Development Tools",
-      "keywords": [
-        "check-tools",
-        "coding-mojo",
-        "creating-bookmarklets",
-        "creating-mcp-servers",
-        "developing-preact",
-        "generating-patches"
-      ]
+      "category": "development-tools"
     },
     {
       "name": "environment-and-config",
       "description": "Environment setup, credential management, container building, and workflow orchestration.",
       "source": "./plugins/environment-and-config",
       "version": "2.0.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Environment And Config",
-      "keywords": [
-        "api-credentials",
-        "configuring",
-        "container-layer",
-        "flowing"
-      ]
+      "category": "environment-and-config"
     },
     {
       "name": "github-and-git",
       "description": "GitHub repository access, CLI operations, indexing, and git workflow tools.",
       "source": "./plugins/github-and-git",
       "version": "2.0.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Github And Git",
-      "keywords": [
-        "accessing-github-repos",
-        "building-github-index",
-        "building-github-index-v2",
-        "githubbing",
-        "invoking-github"
-      ]
+      "category": "github-and-git"
     },
     {
       "name": "knowledge-and-memory",
       "description": "Research methodology, persistent memory, iterative workflows, and project knowledge management.",
       "source": "./plugins/knowledge-and-memory",
       "version": "5.4.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Knowledge And Memory",
-      "keywords": [
-        "asking-questions",
-        "cloning-project",
-        "iterating",
-        "remembering",
-        "updating-knowledge"
-      ]
+      "category": "knowledge-and-memory"
     },
     {
       "name": "media-processing",
       "description": "Image manipulation, video/audio processing, SVG conversion, and computer vision augmentation.",
       "source": "./plugins/media-processing",
       "version": "1.0.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Media Processing",
-      "keywords": [
-        "image-to-svg",
-        "processing-images",
-        "processing-video",
-        "seeing-images"
-      ]
+      "category": "media-processing"
     },
     {
       "name": "skill-development",
       "description": "Tools for creating, versioning, installing, inspecting, and orchestrating Claude skills.",
       "source": "./plugins/skill-development",
       "version": "2.1.2",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Skill Development",
-      "keywords": [
-        "crafting-instructions",
-        "creating-skill",
-        "inspecting-skills",
-        "installing-skills",
-        "orchestrating-skills",
-        "versioning-skills"
-      ]
+      "category": "skill-development"
     },
     {
       "name": "social-and-lifestyle",
       "description": "Social media browsing, content analysis, music control, and everyday utility tools.",
       "source": "./plugins/social-and-lifestyle",
       "version": "1.0.0",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Social And Lifestyle",
-      "keywords": [
-        "browsing-bluesky",
-        "categorizing-bsky-accounts",
-        "controlling-spotify",
-        "making-waffles",
-        "sorting-groceries"
-      ]
+      "category": "social-and-lifestyle"
     },
     {
       "name": "web-and-retrieval",
       "description": "Web content fetching, browser automation, and URL handling tools.",
       "source": "./plugins/web-and-retrieval",
       "version": "1.0.4",
-      "repository": "https://github.com/oaustegard/claude-skills",
-      "homepage": "https://github.com/oaustegard/claude-skills",
-      "license": "MIT",
-      "category": "Web And Retrieval",
-      "keywords": [
-        "fetching-blocked-urls",
-        "hello-demo",
-        "using-webctl"
-      ]
+      "category": "web-and-retrieval"
     }
   ]
 }

--- a/registry/generate.py
+++ b/registry/generate.py
@@ -69,22 +69,6 @@ def compute_category_version(skill_dirs: list[Path]) -> str:
     return ".".join(str(x) for x in max_parts)
 
 
-def collect_keywords(skill_dir: Path) -> list[str]:
-    """Collect keywords from a skill's frontmatter."""
-    try:
-        fm, _ = parse_skill_md(skill_dir / "SKILL.md")
-        meta = fm.get("metadata") or {}
-        keywords = []
-        deps = meta.get("depends_on")
-        if isinstance(deps, list):
-            keywords.extend(str(d) for d in deps)
-        elif isinstance(deps, str):
-            keywords.extend(s.strip() for s in deps.split(",") if s.strip())
-        return keywords
-    except Exception:
-        return []
-
-
 def build_plugins_dir(root: Path, categories: dict) -> None:
     """Create plugins/ directory structure with symlinks to skill directories."""
     plugins_dir = root / "plugins"
@@ -157,30 +141,12 @@ def build_marketplace(root: Path, categories: dict) -> Marketplace:
         if not skill_dirs:
             continue
 
-        # Collect all keywords from constituent skills
-        all_keywords: list[str] = []
-        for sd in skill_dirs:
-            all_keywords.extend(collect_keywords(sd))
-        # Add skill names as keywords for discoverability
-        all_keywords.extend(sd.name for sd in skill_dirs)
-        # Deduplicate preserving order
-        seen: set[str] = set()
-        unique_keywords: list[str] = []
-        for kw in all_keywords:
-            if kw not in seen:
-                seen.add(kw)
-                unique_keywords.append(kw)
-
         entry = PluginEntry(
             name=cat_name,
             description=cat_info["description"],
             source=f"./plugins/{cat_name}",
             version=compute_category_version(skill_dirs),
-            homepage=f"https://github.com/{REPO}",
-            repository=f"https://github.com/{REPO}",
-            license="MIT",
-            category=cat_name.replace("-", " ").title(),
-            keywords=unique_keywords,
+            category=cat_name,
         )
         marketplace.plugins.append(entry)
 

--- a/registry/schema.py
+++ b/registry/schema.py
@@ -10,14 +10,9 @@ class PluginEntry:
     name: str
     description: str
     source: str = "./"
-    strict: bool = False
     version: Optional[str] = None
     author: Optional[dict] = None
-    repository: Optional[str] = None
-    homepage: Optional[str] = None
-    license: Optional[str] = None
     category: Optional[str] = None
-    keywords: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         d: dict = {
@@ -29,16 +24,8 @@ class PluginEntry:
             d["version"] = self.version
         if self.author:
             d["author"] = self.author
-        if self.repository:
-            d["repository"] = self.repository
-        if self.homepage:
-            d["homepage"] = self.homepage
-        if self.license:
-            d["license"] = self.license
         if self.category:
             d["category"] = self.category
-        if self.keywords:
-            d["keywords"] = self.keywords
         return d
 
 
@@ -47,6 +34,7 @@ class Marketplace:
     """Top-level marketplace manifest."""
     schema: str = "https://anthropic.com/claude-code/marketplace.schema.json"
     name: str = "oaustegard-claude-skills"
+    version: str = "1.0.0"
     description: str = "Community skills for Claude Code and Claude.ai"
     owner: dict = field(default_factory=lambda: {
         "name": "Oskar Austegard",
@@ -57,6 +45,7 @@ class Marketplace:
         return {
             "$schema": self.schema,
             "name": self.name,
+            "version": self.version,
             "description": self.description,
             "owner": self.owner,
             "plugins": [p.to_dict() for p in self.plugins],


### PR DESCRIPTION
## Summary

- Simplified marketplace plugin entries to match the official `claude-code-plugins` marketplace pattern (minimal fields: name, description, source, version, category)
- Removed extra fields (`repository`, `homepage`, `license`, `keywords`) not used by Anthropic's official marketplace
- Added marketplace-level `version` field (present in official marketplace, was missing)
- Changed `category` values from Title Case to lowercase kebab-case to match official conventions

## Context

Plugins from this marketplace appear in the Claude Code Desktop Directory but lack an install button. Comparing our `marketplace.json` against Anthropic's official `claude-code-plugins` marketplace revealed several structural differences. This PR aligns our entries with the working official pattern.

## Testing

After merging, update the marketplace in Claude Code Desktop:
```
/plugin marketplace update oaustegard-claude-skills
```

Then try installing a category plugin:
```
/plugin install code-intelligence@oaustegard-claude-skills
```

https://claude.ai/code/session_01Bnh7BY3LnR51KoEuvxWi4w