### PR TITLE
Add plugin directory structure documentation and marketplace metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,6 +2,9 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "oaustegard-claude-skills",
   "description": "Community skills for Claude Code and Claude.ai",
+  "metadata": {
+    "version": "2026.0404.1742"
+  },
   "owner": {
     "name": "Oskar Austegard"
   },

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/marketplace.json
+          git add .claude-plugin/marketplace.json plugins/
           if git diff --cached --quiet; then
             echo "No changes to marketplace.json"
             exit 0

--- a/_MAP.md
+++ b/_MAP.md
@@ -1,5 +1,5 @@
 # claude-skills/
-*Files: 1 | Subdirectories: 65*
+*Files: 1 | Subdirectories: 66*
 
 ## Subdirectories
 
@@ -50,6 +50,7 @@
 - [mapping-webapp/](./mapping-webapp/_MAP.md)
 - [orchestrating-agents/](./orchestrating-agents/_MAP.md)
 - [orchestrating-skills/](./orchestrating-skills/_MAP.md)
+- [plugins/](./plugins/_MAP.md)
 - [processing-images/](./processing-images/_MAP.md)
 - [processing-video/](./processing-video/_MAP.md)
 - [reasoning-semiformally/](./reasoning-semiformally/_MAP.md)

--- a/plugins/_MAP.md
+++ b/plugins/_MAP.md
@@ -1,0 +1,17 @@
+# plugins/
+*Subdirectories: 11*
+
+## Subdirectories
+
+- [ai-and-reasoning/](./ai-and-reasoning/_MAP.md)
+- [code-intelligence/](./code-intelligence/_MAP.md)
+- [data-and-visualization/](./data-and-visualization/_MAP.md)
+- [development-tools/](./development-tools/_MAP.md)
+- [environment-and-config/](./environment-and-config/_MAP.md)
+- [github-and-git/](./github-and-git/_MAP.md)
+- [knowledge-and-memory/](./knowledge-and-memory/_MAP.md)
+- [media-processing/](./media-processing/_MAP.md)
+- [skill-development/](./skill-development/_MAP.md)
+- [social-and-lifestyle/](./social-and-lifestyle/_MAP.md)
+- [web-and-retrieval/](./web-and-retrieval/_MAP.md)
+

--- a/plugins/ai-and-reasoning/_MAP.md
+++ b/plugins/ai-and-reasoning/_MAP.md
@@ -1,0 +1,7 @@
+# ai-and-reasoning/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/ai-and-reasoning/skills/_MAP.md
+++ b/plugins/ai-and-reasoning/skills/_MAP.md
@@ -1,0 +1,13 @@
+# skills/
+*Subdirectories: 7*
+
+## Subdirectories
+
+- [convening-experts/](./convening-experts/_MAP.md)
+- [down-skilling/](./down-skilling/_MAP.md)
+- [invoking-gemini/](./invoking-gemini/_MAP.md)
+- [llm-as-computer/](./llm-as-computer/_MAP.md)
+- [orchestrating-agents/](./orchestrating-agents/_MAP.md)
+- [reviewing-ai-papers/](./reviewing-ai-papers/_MAP.md)
+- [tiling-tree/](./tiling-tree/_MAP.md)
+

--- a/plugins/code-intelligence/_MAP.md
+++ b/plugins/code-intelligence/_MAP.md
@@ -1,0 +1,7 @@
+# code-intelligence/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/code-intelligence/skills/_MAP.md
+++ b/plugins/code-intelligence/skills/_MAP.md
@@ -1,0 +1,14 @@
+# skills/
+*Subdirectories: 8*
+
+## Subdirectories
+
+- [exploring-codebases/](./exploring-codebases/_MAP.md)
+- [featuring/](./featuring/_MAP.md)
+- [generating-lattice/](./generating-lattice/_MAP.md)
+- [mapping-codebases/](./mapping-codebases/_MAP.md)
+- [mapping-webapp/](./mapping-webapp/_MAP.md)
+- [reasoning-semiformally/](./reasoning-semiformally/_MAP.md)
+- [searching-codebases/](./searching-codebases/_MAP.md)
+- [tree-sitting/](./tree-sitting/_MAP.md)
+

--- a/plugins/data-and-visualization/_MAP.md
+++ b/plugins/data-and-visualization/_MAP.md
@@ -1,0 +1,7 @@
+# data-and-visualization/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/data-and-visualization/skills/_MAP.md
+++ b/plugins/data-and-visualization/skills/_MAP.md
@@ -1,0 +1,12 @@
+# skills/
+*Subdirectories: 6*
+
+## Subdirectories
+
+- [charting/](./charting/_MAP.md)
+- [charting-vega-lite/](./charting-vega-lite/_MAP.md)
+- [exploring-data/](./exploring-data/_MAP.md)
+- [extracting-keywords/](./extracting-keywords/_MAP.md)
+- [forecasting-reverso/](./forecasting-reverso/_MAP.md)
+- [json-render-ui/](./json-render-ui/_MAP.md)
+

--- a/plugins/development-tools/_MAP.md
+++ b/plugins/development-tools/_MAP.md
@@ -1,0 +1,7 @@
+# development-tools/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/development-tools/skills/_MAP.md
+++ b/plugins/development-tools/skills/_MAP.md
@@ -1,0 +1,12 @@
+# skills/
+*Subdirectories: 6*
+
+## Subdirectories
+
+- [check-tools/](./check-tools/_MAP.md)
+- [coding-mojo/](./coding-mojo/_MAP.md)
+- [creating-bookmarklets/](./creating-bookmarklets/_MAP.md)
+- [creating-mcp-servers/](./creating-mcp-servers/_MAP.md)
+- [developing-preact/](./developing-preact/_MAP.md)
+- [generating-patches/](./generating-patches/_MAP.md)
+

--- a/plugins/environment-and-config/_MAP.md
+++ b/plugins/environment-and-config/_MAP.md
@@ -1,0 +1,7 @@
+# environment-and-config/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/environment-and-config/skills/_MAP.md
+++ b/plugins/environment-and-config/skills/_MAP.md
@@ -1,0 +1,10 @@
+# skills/
+*Subdirectories: 4*
+
+## Subdirectories
+
+- [api-credentials/](./api-credentials/_MAP.md)
+- [configuring/](./configuring/_MAP.md)
+- [container-layer/](./container-layer/_MAP.md)
+- [flowing/](./flowing/_MAP.md)
+

--- a/plugins/github-and-git/_MAP.md
+++ b/plugins/github-and-git/_MAP.md
@@ -1,0 +1,7 @@
+# github-and-git/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/github-and-git/skills/_MAP.md
+++ b/plugins/github-and-git/skills/_MAP.md
@@ -1,0 +1,11 @@
+# skills/
+*Subdirectories: 5*
+
+## Subdirectories
+
+- [accessing-github-repos/](./accessing-github-repos/_MAP.md)
+- [building-github-index/](./building-github-index/_MAP.md)
+- [building-github-index-v2/](./building-github-index-v2/_MAP.md)
+- [githubbing/](./githubbing/_MAP.md)
+- [invoking-github/](./invoking-github/_MAP.md)
+

--- a/plugins/knowledge-and-memory/_MAP.md
+++ b/plugins/knowledge-and-memory/_MAP.md
@@ -1,0 +1,7 @@
+# knowledge-and-memory/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/knowledge-and-memory/skills/_MAP.md
+++ b/plugins/knowledge-and-memory/skills/_MAP.md
@@ -1,0 +1,11 @@
+# skills/
+*Subdirectories: 5*
+
+## Subdirectories
+
+- [asking-questions/](./asking-questions/_MAP.md)
+- [cloning-project/](./cloning-project/_MAP.md)
+- [iterating/](./iterating/_MAP.md)
+- [remembering/](./remembering/_MAP.md)
+- [updating-knowledge/](./updating-knowledge/_MAP.md)
+

--- a/plugins/media-processing/_MAP.md
+++ b/plugins/media-processing/_MAP.md
@@ -1,0 +1,7 @@
+# media-processing/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/media-processing/skills/_MAP.md
+++ b/plugins/media-processing/skills/_MAP.md
@@ -1,0 +1,10 @@
+# skills/
+*Subdirectories: 4*
+
+## Subdirectories
+
+- [image-to-svg/](./image-to-svg/_MAP.md)
+- [processing-images/](./processing-images/_MAP.md)
+- [processing-video/](./processing-video/_MAP.md)
+- [seeing-images/](./seeing-images/_MAP.md)
+

--- a/plugins/skill-development/_MAP.md
+++ b/plugins/skill-development/_MAP.md
@@ -1,0 +1,7 @@
+# skill-development/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/skill-development/skills/_MAP.md
+++ b/plugins/skill-development/skills/_MAP.md
@@ -1,0 +1,12 @@
+# skills/
+*Subdirectories: 6*
+
+## Subdirectories
+
+- [crafting-instructions/](./crafting-instructions/_MAP.md)
+- [creating-skill/](./creating-skill/_MAP.md)
+- [inspecting-skills/](./inspecting-skills/_MAP.md)
+- [installing-skills/](./installing-skills/_MAP.md)
+- [orchestrating-skills/](./orchestrating-skills/_MAP.md)
+- [versioning-skills/](./versioning-skills/_MAP.md)
+

--- a/plugins/social-and-lifestyle/_MAP.md
+++ b/plugins/social-and-lifestyle/_MAP.md
@@ -1,0 +1,7 @@
+# social-and-lifestyle/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/social-and-lifestyle/skills/_MAP.md
+++ b/plugins/social-and-lifestyle/skills/_MAP.md
@@ -1,0 +1,11 @@
+# skills/
+*Subdirectories: 5*
+
+## Subdirectories
+
+- [browsing-bluesky/](./browsing-bluesky/_MAP.md)
+- [categorizing-bsky-accounts/](./categorizing-bsky-accounts/_MAP.md)
+- [controlling-spotify/](./controlling-spotify/_MAP.md)
+- [making-waffles/](./making-waffles/_MAP.md)
+- [sorting-groceries/](./sorting-groceries/_MAP.md)
+

--- a/plugins/web-and-retrieval/_MAP.md
+++ b/plugins/web-and-retrieval/_MAP.md
@@ -1,0 +1,7 @@
+# web-and-retrieval/
+*Subdirectories: 1*
+
+## Subdirectories
+
+- [skills/](./skills/_MAP.md)
+

--- a/plugins/web-and-retrieval/skills/_MAP.md
+++ b/plugins/web-and-retrieval/skills/_MAP.md
@@ -1,0 +1,9 @@
+# skills/
+*Subdirectories: 3*
+
+## Subdirectories
+
+- [fetching-blocked-urls/](./fetching-blocked-urls/_MAP.md)
+- [hello-demo/](./hello-demo/_MAP.md)
+- [using-webctl/](./using-webctl/_MAP.md)
+

--- a/registry/schema.py
+++ b/registry/schema.py
@@ -1,6 +1,7 @@
 """Data classes for the Claude Code plugin marketplace."""
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -10,7 +11,6 @@ class PluginEntry:
     name: str
     description: str
     source: str = "./"
-    strict: bool = False
     version: Optional[str] = None
     author: Optional[dict] = None
     repository: Optional[str] = None
@@ -54,10 +54,12 @@ class Marketplace:
     plugins: list[PluginEntry] = field(default_factory=list)
 
     def to_dict(self) -> dict:
+        version = datetime.now(timezone.utc).strftime("%Y.%m%d.%H%M")
         return {
             "$schema": self.schema,
             "name": self.name,
             "description": self.description,
+            "metadata": {"version": version},
             "owner": self.owner,
             "plugins": [p.to_dict() for p in self.plugins],
         }


### PR DESCRIPTION
## Summary
This PR adds comprehensive directory structure documentation for the plugins directory and updates the marketplace schema to include version metadata.

## Key Changes
- **Added plugin directory maps**: Created `_MAP.md` files documenting the hierarchical structure of the plugins directory, including:
  - Root-level plugins map listing 11 plugin categories
  - Individual category maps for each plugin type (ai-and-reasoning, code-intelligence, data-and-visualization, etc.)
  - Skills subdirectory maps for each category showing available skills (ranging from 3-8 skills per category)

- **Updated marketplace schema**: Modified `registry/schema.py` to:
  - Remove the `strict` field from `PluginEntry` dataclass
  - Add automatic version metadata generation using UTC timestamp in `YYYY.MMDD.HHMM` format
  - Include metadata in the marketplace dictionary output

- **Updated marketplace.json**: Added metadata section with generated version timestamp (`2026.0404.1742`)

- **Updated root documentation**: Modified `_MAP.md` to reflect the new plugins directory as a subdirectory

- **Updated CI/CD**: Modified `.github/workflows/skill-release.yml` to include the `plugins/` directory in git add operations for automated releases

## Implementation Details
- The version metadata is dynamically generated at runtime using `datetime.now(timezone.utc)` rather than being hardcoded
- The plugin directory structure follows a consistent pattern: category → skills → individual skill implementations
- Total of 59 individual skills documented across 11 plugin categories

https://claude.ai/code/session_0129SRt7oiWbiqW1hZZonoj2