### PR TITLE
Add ISO date prefix to layer release names

### DIFF
--- a/container-layer/scripts/layer_cache.py
+++ b/container-layer/scripts/layer_cache.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import urllib.request
 import urllib.error
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -60,7 +61,7 @@ def _create_release(repo: str, tag: str, token: str) -> dict:
     
     payload = json.dumps({
         "tag_name": tag,
-        "name": f"Container Layer {tag}",
+        "name": f"Container Layer {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H%M%SZ')} {tag}",
         "body": "Auto-generated container layer cache. Safe to delete.",
         "draft": False,
         "prerelease": True,


### PR DESCRIPTION
## Summary
- Layer release names now include a UTC ISO timestamp prefix (e.g. `Container Layer 2026-04-06T194642Z layer-03754835325ae8a1`)
- Tags remain hash-based for deterministic cache lookup — only the display name changes
- Makes layers much easier to find when paging through releases in the GitHub web UI

## Test plan
- [ ] Build a fresh layer and verify the release name includes the timestamp
- [ ] Verify cache restore still works (tag unchanged)

https://claude.ai/code/session_01P6VX769CefwZLi74CwbPf3