### PR TITLE
feat: treesit.py CLI + cross-process cache fix + Symbol dict bug

### DIFF
--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   the divergent "what's here?" skill — for targeted "where is X?" queries,
   use searching-codebases instead.
 metadata:
-  version: 1.0.0
+  version: 2.0.0
 ---
 
 # Exploring Codebases
@@ -25,45 +25,41 @@ featuring (semantic) into a progressive disclosure sequence.
 
 ```bash
 uv venv /home/claude/.venv 2>/dev/null
-uv pip install tree-sitter-language-pack fastmcp --python /home/claude/.venv/bin/python
+uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
 ```
 
 ## Workflow
 
-### Phase 1: Structural Inventory (tree-sitting)
+```bash
+TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
+PYTHON=/home/claude/.venv/bin/python
+```
+
+### Phase 1: Structural Orientation
 
 Get oriented — what's here, how big, what languages?
 
 ```bash
-cd /mnt/skills/user/tree-sitting/scripts
-/home/claude/.venv/bin/python -c "
-import sys; sys.path.insert(0, '.')
-from engine import cache
-
-stats = cache.scan('/path/to/repo')
-print(cache.tree_overview())
-"
+$PYTHON $TREESIT /path/to/repo --stats
 ```
 
-This gives you the directory tree with file counts, symbol counts, and
-languages per directory. Takes ~700ms for a 250-file repo, then all
-subsequent queries are sub-millisecond.
+Default depth=1 shows root-level files and one level of subdirectories
+with file counts, symbol counts, and languages. Takes ~700ms total
+(scan + output).
 
 ### Phase 2: Drill Into Structure
 
-Follow what looks interesting. Use tree-sitting queries to build understanding:
+Follow what looks interesting. Each call auto-scans — no state to manage.
 
 ```bash
-/home/claude/.venv/bin/python -c "
-import sys; sys.path.insert(0, '/mnt/skills/user/tree-sitting/scripts')
-from engine import cache
+# Drill into a directory with full detail (signatures, docs, children, imports)
+$PYTHON $TREESIT /path/to/repo --path=src/core --detail=full
 
-# Already scanned — these are instant
-print(cache.dir_overview('src/core'))       # Files + top symbols in a directory
-print(cache.find_symbol('*Handler*'))       # Glob search across codebase
-print(cache.file_symbols('src/api/routes.py'))  # Full API of a single file
-print(cache.get_source('handle_request'))   # Read a specific implementation
-"
+# Search for patterns across the codebase
+$PYTHON $TREESIT /path/to/repo 'find:*Handler*:function'
+
+# Read a specific implementation
+$PYTHON $TREESIT /path/to/repo --no-tree 'source:handle_request'
 ```
 
 **Heuristics for what to drill into first:**
@@ -77,7 +73,7 @@ print(cache.get_source('handle_request'))   # Read a specific implementation
 Once you understand the structure, generate the "what does it DO?" layer:
 
 ```bash
-/home/claude/.venv/bin/python /mnt/skills/user/featuring/scripts/gather.py /path/to/repo \
+$PYTHON /mnt/skills/user/featuring/scripts/gather.py /path/to/repo \
   --skip tests,.github,node_modules --source-budget 8000
 ```
 
@@ -87,20 +83,14 @@ into features, write user-facing descriptions.
 
 ### Phase 4: Targeted Deep Dives
 
-With structural inventory + feature map in hand, use tree-sitting's
-`get_source()` to read specific implementations where the feature
-narrative needs verification or where behavior isn't clear from signatures.
+With structural inventory + feature map in hand, read specific implementations
+where the feature narrative needs verification or behavior isn't clear:
 
 ```bash
-/home/claude/.venv/bin/python -c "
-import sys; sys.path.insert(0, '/mnt/skills/user/tree-sitting/scripts')
-from engine import cache
-
-# Read implementations that matter
-print(cache.get_source('authenticate'))
-print(cache.references('AuthToken'))
-"
+$PYTHON $TREESIT /path/to/repo --no-tree 'source:authenticate' 'refs:AuthToken'
 ```
+
+Multiple queries in one call — each adds ~0ms on top of the scan cost.
 
 ## When to Use This vs Other Skills
 
@@ -128,7 +118,7 @@ concrete artifacts, when warranted, are:
 
 For large repos (>100 files), use `--skip` aggressively in Phase 1 to
 exclude tests, vendored code, generated files, and docs. Focus the initial
-scan on `src/` or the primary source directory. Expand scope as needed.
+scan on `--path=src` or the primary source directory. Expand scope as needed.
 
 For monorepos, treat each package/service as a separate exploration.
 Generate per-subsystem `_FEATURES.md` files linked from a root index.

--- a/featuring/SKILL.md
+++ b/featuring/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   or needs to understand a codebase's purpose before modifying it. Complements
   tree-sitting (structural) with semantic (why/what-for) layer.
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # Featuring
@@ -31,6 +31,15 @@ Requires **tree-sitting** skill. Uses its engine for AST scanning.
 ```bash
 uv venv /home/claude/.venv 2>/dev/null
 uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
+```
+
+For quick structural orientation before running gather.py, use tree-sitting's CLI:
+
+```bash
+TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
+
+# Complete tree, sparse detail — see the full shape
+/home/claude/.venv/bin/python $TREESIT /path/to/repo --depth=-1 --detail=sparse
 ```
 
 ## Workflow: Multi-Pass Synthesis
@@ -277,16 +286,14 @@ jobs:
 
 ## Claude Code Integration
 
-In Claude Code, the tree-sitting MCP server replaces the gather script.
-The agent should:
+In Claude Code, use tree-sitting's CLI or engine directly. The agent should:
 
-1. Call `scan()` to parse the codebase
-2. Call `tree_overview()` for orientation
-3. **Pass 1:** Form a hypothesis about what the codebase does
-4. Call `dir_overview()` and `file_symbols()` to understand each capability area
-5. Call `get_source()` for key symbols where intent isn't clear from signatures
-6. **Pass 2:** Write detailed feature sections, deciding hierarchy per-feature
-7. **Pass 3:** Rewrite the overview now that all features are documented
+1. Run `treesit.py /path --depth=-1 --detail=sparse` for full structural overview
+2. **Pass 1:** Form a hypothesis about what the codebase does
+3. Run `treesit.py /path --path=DIR --detail=full` for each capability area
+4. Run `treesit.py /path --no-tree 'source:symbol_name'` where intent isn't clear
+5. **Pass 2:** Write detailed feature sections, deciding hierarchy per-feature
+6. **Pass 3:** Rewrite the overview now that all features are documented
 
 Add to CLAUDE.md:
 ```markdown

--- a/searching-codebases/scripts/context.py
+++ b/searching-codebases/scripts/context.py
@@ -87,32 +87,33 @@ def _expand_from_ast(file_path: str, line_number: int, search_root: str,
     # Find the innermost symbol containing this line
     containing = None
     for sym in entry.symbols:
-        start = sym.get("start_line") or sym.get("line", 0)
-        end = sym.get("end_line", start)
-        if start <= line_number <= end:
+        if sym.line <= line_number <= sym.end_line:
             # Prefer the most specific (innermost) match
             if containing is None:
                 containing = sym
             else:
-                prev_start = containing.get("start_line") or containing.get("line", 0)
-                if start >= prev_start:
+                if sym.line >= containing.line:
                     containing = sym
+        # Also check children (methods within classes)
+        for child in getattr(sym, 'children', []):
+            if child.line <= line_number <= child.end_line:
+                if containing is None or child.line >= containing.line:
+                    containing = child
 
     if not containing:
         # No containing symbol — try nearest preceding symbol
         best = None
         for sym in entry.symbols:
-            start = sym.get("start_line") or sym.get("line", 0)
-            if start <= line_number:
-                if best is None or start > (best.get("start_line") or best.get("line", 0)):
+            if sym.line <= line_number:
+                if best is None or sym.line > best.line:
                     best = sym
         containing = best
 
     if not containing:
         return _expand_window(file_path, line_number)
 
-    start_line = containing.get("start_line") or containing.get("line", 1)
-    end_line = containing.get("end_line") or start_line
+    start_line = containing.line
+    end_line = containing.end_line or start_line
 
     try:
         with open(file_path, "r") as f:
@@ -129,8 +130,8 @@ def _expand_from_ast(file_path: str, line_number: int, search_root: str,
 
     source = "".join(lines[start_line - 1:end_line])
 
-    name = containing.get("name", "")
-    kind = containing.get("kind", "function")
+    name = containing.name or ""
+    kind = containing.kind or "function"
     # Normalize kind to node_type
     kind_map = {
         "class": "class", "struct": "class", "interface": "class",
@@ -142,7 +143,7 @@ def _expand_from_ast(file_path: str, line_number: int, search_root: str,
 
     signature = None
     if signatures_only:
-        sig = containing.get("signature", "")
+        sig = containing.signature or ""
         if sig:
             signature = sig
         else:
@@ -150,12 +151,9 @@ def _expand_from_ast(file_path: str, line_number: int, search_root: str,
             first_line = lines[start_line - 1].rstrip() if start_line <= len(lines) else name
             signature = first_line
 
-    parent = containing.get("parent")
-    display = f"{parent}.{name}" if parent else name
-
     return CodeContext(
         file_path=file_path, start_line=start_line, end_line=end_line,
-        match_line=line_number, node_type=node_type, name=display,
+        match_line=line_number, node_type=node_type, name=name,
         source=source, language=entry.lang, signature=signature,
     )
 

--- a/tree-sitting/SKILL.md
+++ b/tree-sitting/SKILL.md
@@ -1,83 +1,112 @@
 ---
 name: tree-sitting
-description: AST-powered code navigation via tree-sitter. Parses codebases into in-memory ASTs and exposes query tools for symbol search, file/directory overview, source retrieval, and references. Use when exploring unfamiliar repos, navigating code, or needing fast symbol lookup. Replaces serial file reads with sub-millisecond cached queries. Triggers on "map this codebase", "explore repo", "find symbol", "navigate code", "tree-sitter", or when starting work on an unfamiliar repository.
+description: AST-powered code navigation via tree-sitter. Auto-scans codebases and provides progressive-disclosure tree views with symbol search, source retrieval, and reference finding. Each invocation is self-contained — no cross-process state. Use when exploring unfamiliar repos, navigating code, or needing fast symbol lookup. Triggers on "map this codebase", "explore repo", "find symbol", "navigate code", "tree-sitter", or when starting work on an unfamiliar repository.
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # tree-sitting
 
-AST-powered code navigation using tree-sitter. Parses all source files into in-memory syntax trees, then provides fast query tools. One scan (~700ms for a 250-file repo), then all queries are sub-millisecond.
+AST-powered code navigation using tree-sitter. Each invocation auto-scans
+the codebase (~700ms for 250 files), then runs queries at sub-millisecond speed.
 
 ## Setup
 
 ```bash
 uv venv /home/claude/.venv 2>/dev/null
-uv pip install tree-sitter-language-pack fastmcp --python /home/claude/.venv/bin/python
+uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
 ```
 
 Total install: <2s cold cache, <400ms warm.
 
-## Usage: Claude.ai (direct calls)
+## Usage: CLI (treesit.py)
+
+Every call auto-scans, prints a tree overview, then runs any queries.
+No state to manage between calls.
 
 ```bash
-cd /mnt/skills/user/tree-sitting/scripts
-/home/claude/.venv/bin/python -c "
-import sys; sys.path.insert(0, '.')
-from engine import cache
+TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
 
-stats = cache.scan('/path/to/repo')
-print(cache.tree_overview())
-print(cache.find_symbol('ClassName'))
-print(cache.dir_overview('src/core'))
-print(cache.file_symbols('src/core/parser.c'))
-print(cache.get_source_range('src/core/parser.c', 100, 150))
-"
+# Orient: root-level overview (default depth=1)
+/home/claude/.venv/bin/python $TREESIT /path/to/repo
+
+# Featuring: complete tree, minimal detail
+/home/claude/.venv/bin/python $TREESIT /path/to/repo --depth=-1 --detail=sparse
+
+# Explore a subdirectory in full detail
+/home/claude/.venv/bin/python $TREESIT /path/to/repo --path=src/core --detail=full
+
+# Run queries (tree overview + query results)
+/home/claude/.venv/bin/python $TREESIT /path/to/repo 'find:Parser*' 'source:parse_input'
+
+# Queries only, no tree
+/home/claude/.venv/bin/python $TREESIT /path/to/repo --no-tree 'refs:AuthToken'
 ```
 
-Multiple queries in one bash call = one parse cost + N × <1ms queries.
+### Options
 
-## Usage: Claude Code (MCP server)
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--depth N` | 1 | Directory depth: -1=all, 0=root only, 1=one level |
+| `--detail LEVEL` | normal | Node detail: sparse, normal, full |
+| `--path DIR` | (root) | Scope to subdirectory |
+| `--skip DIRS` | | Extra dirs to skip (comma-separated) |
+| `--no-tree` | | Suppress tree overview, show only queries |
+| `--stats` | | Show scan timing and counts |
 
-Add to Claude Code MCP config:
+### Detail Levels
 
-```json
-{
-  "mcpServers": {
-    "tree-sitting": {
-      "command": "/path/to/.venv/bin/python",
-      "args": ["/path/to/tree-sitting/scripts/server.py"],
-      "cwd": "/path/to/tree-sitting/scripts"
-    }
-  }
-}
-```
+| Level | Per-node output | Use case |
+|-------|----------------|----------|
+| `sparse` | `name (kind) :lines` | featuring: see the full shape |
+| `normal` | `name(kind_initial)` per file (compact) | exploring: quick orientation |
+| `full` | signature + doc + children + imports | exploring: deep dive into a directory |
 
-The server persists between tool calls — scan once, query many times.
+### Queries
 
-### MCP Tools
+Append after the repo path. Multiple queries per call.
 
-| Tool | Purpose |
-|------|---------|
-| `scan` | Parse codebase into ASTs. Call first. ~700ms for 250 files. |
-| `tree_overview` | Directory tree with file/symbol counts. First orientation. |
-| `dir_overview` | Files + top symbols for one directory. Dynamic _MAP.md. |
-| `find_symbol` | Search by name/substring/glob across codebase. |
-| `file_symbols` | All symbols in a file with signatures and docs. |
-| `get_source` | Source code of a specific symbol. Prefers implementation over declaration. |
-| `references` | Find all textual references to a symbol. Fast grep against cached source. |
+| Query | Example | Description |
+|-------|---------|-------------|
+| `find:PATTERN[:KIND[:LIMIT]]` | `find:*Handler*:function` | Symbol search (glob/substring) |
+| `symbols:FILE` | `symbols:src/api.py` | All symbols in a file |
+| `source:SYMBOL[:FILE]` | `source:parse_input` | Source code of a symbol |
+| `refs:SYMBOL[:LIMIT]` | `refs:AuthToken:30` | Text references across codebase |
+| `imports:FILE` | `imports:src/api.py` | Import list for a file |
+| `dir:PATH` | `dir:src/core` | Directory overview (engine format) |
 
 ### Workflow
 
 ```
-1. scan("/path/to/repo")           → parse everything, build index
-2. tree_overview()                  → orient: what dirs, how big, what languages
-3. dir_overview("src/core")         → drill into interesting directory
-4. find_symbol("Parser*")           → find specific symbols
-5. file_symbols("src/core/parser.c") → see full API of a file
-6. get_source("parse_input")        → read the implementation
-7. references("ParseState")         → find usage across codebase
+1. treesit.py /repo                           → orient: what dirs, how big
+2. treesit.py /repo --path=src/core           → drill into interesting directory
+3. treesit.py /repo 'find:Parser*'            → find specific symbols
+4. treesit.py /repo 'source:parse_input'      → read implementation
+5. treesit.py /repo 'refs:ParseState'         → find usage across codebase
 ```
+
+Each call is self-contained. No need to "scan first, query later" —
+scan happens automatically every time (~700ms).
+
+## Usage: Direct Python (single invocation)
+
+For custom scripts that need the engine API directly:
+
+```python
+import sys; sys.path.insert(0, '/mnt/skills/user/tree-sitting/scripts')
+from engine import CodeCache
+
+cache = CodeCache()
+cache.scan('/path/to/repo')
+# All queries in the SAME invocation:
+print(cache.tree_overview())
+print(cache.find_symbol('ClassName'))
+print(cache.get_source_range('src/core/parser.c', 100, 150))
+```
+
+**Important:** The cache is in-memory only. All scan + query calls MUST
+happen in the same Python process. Splitting across separate `python -c`
+invocations loses the cache — use `treesit.py` instead.
 
 ## Supported Languages
 
@@ -89,13 +118,11 @@ Three-tier extraction:
 2. **tags.scm queries** (community-maintained — kinds, docs where grammars support it): Java, C++, C#
 3. **Generic heuristic** (names + kinds + locations): all others
 
-tags.scm queries use the same patterns maintained by tree-sitter grammar repos, giving correct symbol classification (e.g. Rust `impl` methods vs free functions, Go interfaces vs structs) without hand-written extractors.
-
 ## What It Extracts
 
 - **Symbols**: functions, classes, structs, enums, methods, constants, defines, types
 - **Signatures**: parameter lists and return types (Python, C; partial for others)
-- **Doc comments**: first-line summaries from docstrings, JSDoc, Doxygen, `///`, `#` 
+- **Doc comments**: first-line summaries from docstrings, JSDoc, Doxygen, `///`, `#`
 - **Line ranges**: start and end line for every symbol
 - **Imports**: per-file dependency tracking
 - **Hierarchy**: class→methods, struct→fields (Python, C)
@@ -103,13 +130,14 @@ tags.scm queries use the same patterns maintained by tree-sitter grammar repos, 
 ## Architecture
 
 ```
-CodeCache (in-memory singleton)
+CodeCache (in-memory, per-invocation)
   ├── files: {relpath → FileEntry(source, tree, symbols, imports)}
   ├── _symbol_index: {name → [Symbol, ...]}  ← fast lookup
   └── methods: scan(), find_symbol(), file_symbols(), dir_overview(), ...
        │
-       ├── FastMCP server (Claude Code) — long-lived process, stdio transport
-       └── Direct Python calls (Claude.ai) — one bash invocation per query batch
+       └── treesit.py CLI — auto-scan + progressive-disclosure tree + queries
 ```
 
-Parse cost is paid once. The symbol index enables O(1) exact match and O(n) substring/glob search where n is the number of unique symbol names (not files).
+Parse cost is paid once per invocation. The symbol index enables O(1) exact
+match and O(n) substring/glob search where n is the number of unique symbol
+names (not files).

--- a/tree-sitting/scripts/treesit.py
+++ b/tree-sitting/scripts/treesit.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+treesit.py — AST-powered code navigation CLI.
+
+Auto-scans on every invocation (~700ms), then runs queries.
+Designed for environments where each call is a separate process.
+
+Always prints a tree overview first (progressive disclosure context),
+then any query results.
+
+Usage:
+    treesit.py REPO [OPTIONS] [QUERIES...]
+
+Options:
+    --depth N        Directory depth: -1=all, 0=root only, 1=one level (default: 1)
+    --detail LEVEL   Node detail: sparse|normal|full (default: normal)
+    --path DIR       Scope to subdirectory (relative to repo root)
+    --skip DIRS      Comma-separated dirs to skip (added to defaults)
+    --no-tree        Suppress tree overview, show only query results
+    --stats          Show scan statistics
+
+Queries:
+    find:PATTERN[:KIND[:LIMIT]]    Search symbols by name/glob
+    symbols:FILE_PATH              All symbols in a file
+    source:SYMBOL[:FILE]           Source code of a symbol
+    refs:SYMBOL[:LIMIT]            Find references across codebase
+    imports:FILE_PATH              Imports for a file
+    dir:DIR_PATH                   Directory overview
+
+No queries = tree overview only.
+
+Detail levels:
+    sparse  — name (kind) :lines                    [featuring: complete shape]
+    normal  — name (kind) signature :lines — doc     [exploring: orientation]
+    full    — normal + children + imports per file    [exploring: deep dive]
+"""
+
+import sys
+import os
+import argparse
+import time
+
+
+def find_engine():
+    """Locate tree-sitting engine."""
+    candidates = [
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), '.'),
+        '/mnt/skills/user/tree-sitting/scripts',
+    ]
+    for p in candidates:
+        if os.path.exists(os.path.join(p, 'engine.py')):
+            if p not in sys.path:
+                sys.path.insert(0, p)
+            return p
+    return None
+
+
+def format_symbol_sparse(sym, indent=''):
+    """name (kind) :line-end"""
+    return f"{indent}{sym.name} ({sym.kind}) :{sym.line}-{sym.end_line}"
+
+
+def format_symbol_normal(sym, indent=''):
+    """name (kind) signature :line-end — doc"""
+    parts = [f"{indent}{sym.name} ({sym.kind})"]
+    if sym.signature:
+        parts.append(f"{sym.signature}")
+    parts.append(f":{sym.line}-{sym.end_line}")
+    if sym.doc:
+        parts.append(f"— {sym.doc}")
+    return ' '.join(parts)
+
+
+def format_symbol_full(sym, indent=''):
+    """Normal + children."""
+    lines = [format_symbol_normal(sym, indent)]
+    for child in sym.children:
+        lines.append(format_symbol_normal(child, indent + '  '))
+    return '\n'.join(lines)
+
+
+FORMATTERS = {
+    'sparse': format_symbol_sparse,
+    'normal': format_symbol_normal,
+    'full': format_symbol_full,
+}
+
+
+def tree_overview(cache, depth, detail, scope_path=''):
+    """Progressive-disclosure tree overview with depth/detail control."""
+    if not cache.root:
+        return "No codebase scanned."
+
+    fmt = FORMATTERS[detail]
+
+    # Collect directory stats
+    dir_entries = {}  # dirpath -> {files: [...], subdirs: set()}
+    for relpath, entry in sorted(cache.files.items()):
+        # Apply scope filter
+        if scope_path:
+            if not relpath.startswith(scope_path.rstrip('/') + '/') and relpath != scope_path:
+                continue
+
+        # Compute directory relative to scope
+        if scope_path:
+            rest = relpath[len(scope_path.rstrip('/')) + 1:]
+        else:
+            rest = relpath
+
+        parts = rest.split('/')
+        dirpart = '/'.join(parts[:-1]) if len(parts) > 1 else ''
+
+        if dirpart not in dir_entries:
+            dir_entries[dirpart] = {'files': [], 'subdirs': set()}
+        dir_entries[dirpart]['files'].append(entry)
+
+        # Register parent dirs
+        for i in range(1, len(parts) - 1):
+            parent = '/'.join(parts[:i])
+            child_dir = parts[i]
+            if parent not in dir_entries:
+                dir_entries[parent] = {'files': [], 'subdirs': set()}
+            dir_entries[parent]['subdirs'].add(child_dir)
+
+        # Root-level subdirs
+        if len(parts) > 1:
+            if '' not in dir_entries:
+                dir_entries[''] = {'files': [], 'subdirs': set()}
+            dir_entries['']['subdirs'].add(parts[0])
+
+    if not dir_entries:
+        return f"No files found under '{scope_path}'" if scope_path else "No files scanned."
+
+    lines = []
+    display_root = scope_path or (cache.root.name if cache.root else '.')
+    total_files = sum(len(d['files']) for d in dir_entries.values())
+    total_symbols = sum(
+        len(e.symbols) for d in dir_entries.values() for e in d['files']
+    )
+    lines.append(f"# {display_root}/ ({total_files} files, {total_symbols} symbols)\n")
+
+    def render_dir(dirpath, current_depth):
+        info = dir_entries.get(dirpath, {'files': [], 'subdirs': set()})
+        dir_indent = '  ' * current_depth
+
+        # Show files at this level
+        if detail == 'full':
+            for entry in info['files']:
+                fname = os.path.basename(entry.path)
+                lines.append(f"{dir_indent}  {fname}")
+                if entry.imports:
+                    preview = ', '.join(entry.imports[:6])
+                    if len(entry.imports) > 6:
+                        preview += f' +{len(entry.imports) - 6}'
+                    lines.append(f"{dir_indent}    imports: {preview}")
+                for sym in entry.symbols:
+                    lines.append(fmt(sym, dir_indent + '    '))
+        elif detail == 'normal':
+            for entry in info['files']:
+                fname = os.path.basename(entry.path)
+                sym_summary = ', '.join(
+                    f"{s.name}({s.kind[0]})" for s in entry.symbols[:6]
+                )
+                if len(entry.symbols) > 6:
+                    sym_summary += f' +{len(entry.symbols) - 6}'
+                lines.append(f"{dir_indent}  {fname}: {sym_summary}" if sym_summary else f"{dir_indent}  {fname}")
+        else:  # sparse
+            for entry in info['files']:
+                fname = os.path.basename(entry.path)
+                sym_names = ', '.join(s.name for s in entry.symbols[:8])
+                if len(entry.symbols) > 8:
+                    sym_names += f' +{len(entry.symbols) - 8}'
+                lines.append(f"{dir_indent}  {fname}: {sym_names}" if sym_names else f"{dir_indent}  {fname}")
+
+        # Show subdirs (respecting depth)
+        if depth == -1 or current_depth < depth:
+            for subdir in sorted(info['subdirs']):
+                child_path = f"{dirpath}/{subdir}" if dirpath else subdir
+                child_info = dir_entries.get(child_path, {'files': [], 'subdirs': set()})
+
+                # Count total files recursively under this subdir
+                prefix = child_path + '/'
+                file_count = sum(
+                    len(d['files']) for dp, d in dir_entries.items()
+                    if dp == child_path or dp.startswith(prefix)
+                )
+                sym_count = sum(
+                    len(e.symbols)
+                    for dp, d in dir_entries.items()
+                    if dp == child_path or dp.startswith(prefix)
+                    for e in d['files']
+                )
+                langs = set()
+                for dp, d in dir_entries.items():
+                    if dp == child_path or dp.startswith(prefix):
+                        for e in d['files']:
+                            langs.add(e.lang)
+
+                lang_str = ','.join(sorted(langs))
+                lines.append(f"{dir_indent}{subdir}/ — {file_count} files, {sym_count} symbols [{lang_str}]")
+                render_dir(child_path, current_depth + 1)
+        else:
+            # At depth limit — show collapsed subdirs
+            for subdir in sorted(info['subdirs']):
+                child_path = f"{dirpath}/{subdir}" if dirpath else subdir
+                prefix = child_path + '/'
+                file_count = sum(
+                    len(d['files']) for dp, d in dir_entries.items()
+                    if dp == child_path or dp.startswith(prefix)
+                )
+                sym_count = sum(
+                    len(e.symbols)
+                    for dp, d in dir_entries.items()
+                    if dp == child_path or dp.startswith(prefix)
+                    for e in d['files']
+                )
+                lines.append(f"{dir_indent}{subdir}/ — {file_count} files, {sym_count} symbols [...]")
+
+    render_dir('', 0)
+    return '\n'.join(lines)
+
+
+def run_query(cache, query_str, detail='normal'):
+    """Parse and execute a query string."""
+    fmt = FORMATTERS[detail]
+
+    if ':' in query_str:
+        cmd, _, args = query_str.partition(':')
+    else:
+        return f"Unknown query format: {query_str}\nExpected: find:PATTERN, symbols:FILE, source:SYMBOL, refs:SYMBOL, imports:FILE, dir:PATH"
+
+    cmd = cmd.strip().lower()
+    args = args.strip()
+
+    if cmd == 'find':
+        # find:PATTERN[:KIND[:LIMIT]]
+        parts = args.split(':')
+        pattern = parts[0]
+        kind = parts[1] if len(parts) > 1 and parts[1] else None
+        limit = int(parts[2]) if len(parts) > 2 else 20
+        results = cache.find_symbol(pattern, kind=kind, limit=limit)
+        if not results:
+            return f"No symbols matching '{pattern}'"
+        lines = [f"Found {len(results)} symbol(s) matching '{pattern}':\n"]
+        for sym in results:
+            lines.append(f"  {sym.file}:{fmt(sym)}")
+        return '\n'.join(lines)
+
+    elif cmd == 'symbols':
+        syms = cache.file_symbols(args)
+        if not syms:
+            return f"No symbols found for '{args}'"
+        lines = [f"Symbols in {args}:\n"]
+        for sym in syms:
+            lines.append(fmt(sym, '  '))
+            if detail == 'full':
+                for child in sym.children:
+                    lines.append(fmt(child, '    '))
+        return '\n'.join(lines)
+
+    elif cmd == 'source':
+        # source:SYMBOL[:FILE]
+        parts = args.split(':', 1)
+        symbol_name = parts[0]
+        file_filter = parts[1] if len(parts) > 1 else None
+        results = cache.find_symbol(symbol_name, limit=5)
+        if file_filter:
+            results = [s for s in results if file_filter in s.file]
+        if not results:
+            return f"Symbol '{symbol_name}' not found"
+        sym = max(results, key=lambda s: s.end_line - s.line)
+        header = f"# {sym.name} ({sym.kind}) in {sym.file}:{sym.line}-{sym.end_line}"
+        if sym.doc:
+            header += f"\n# {sym.doc}"
+        source = cache.get_source_range(sym.file, sym.line, sym.end_line)
+        return f"{header}\n\n{source}"
+
+    elif cmd == 'refs':
+        # refs:SYMBOL[:LIMIT]
+        parts = args.split(':', 1)
+        symbol_name = parts[0]
+        limit = int(parts[1]) if len(parts) > 1 else 20
+        refs = cache.references(symbol_name, limit=limit)
+        if not refs:
+            return f"No references to '{symbol_name}'"
+        lines = [f"Found {len(refs)} reference(s) to '{symbol_name}':\n"]
+        for ref in refs:
+            lines.append(f"  {ref['file']}:{ref['line']} | {ref['text']}")
+        return '\n'.join(lines)
+
+    elif cmd == 'imports':
+        imps = cache.file_imports(args)
+        if not imps:
+            return f"No imports found for '{args}'"
+        return f"Imports in {args}:\n  " + '\n  '.join(imps)
+
+    elif cmd == 'dir':
+        return cache.dir_overview(args)
+
+    else:
+        return f"Unknown command: {cmd}\nAvailable: find, symbols, source, refs, imports, dir"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='AST-powered code navigation. Auto-scans, then queries.',
+        epilog='Queries: find:PATTERN symbols:FILE source:SYMBOL refs:SYMBOL imports:FILE dir:PATH'
+    )
+    parser.add_argument('repo', help='Path to codebase root')
+    parser.add_argument('queries', nargs='*', help='Queries to run after scan')
+    parser.add_argument('--depth', type=int, default=1,
+                        help='Directory depth: -1=all, 0=root, 1=one level (default: 1)')
+    parser.add_argument('--detail', choices=['sparse', 'normal', 'full'], default='normal',
+                        help='Node detail level (default: normal)')
+    parser.add_argument('--path', default='',
+                        help='Scope to subdirectory (relative to repo root)')
+    parser.add_argument('--skip', default='',
+                        help='Comma-separated dirs to skip (added to defaults)')
+    parser.add_argument('--no-tree', action='store_true',
+                        help='Suppress tree overview, show only query results')
+    parser.add_argument('--stats', action='store_true',
+                        help='Show scan statistics')
+
+    args, extra = parser.parse_known_args()
+    # Extra args are queries (argparse struggles with nargs='*' after options)
+    args.queries = list(args.queries) + extra
+
+    # Find and import engine
+    engine_path = find_engine()
+    if not engine_path:
+        print("ERROR: tree-sitting engine not found.", file=sys.stderr)
+        sys.exit(1)
+
+    from engine import CodeCache
+
+    # Scan
+    cache = CodeCache()
+    skip = set(args.skip.split(',')) if args.skip else None
+    t0 = time.perf_counter()
+    stats = cache.scan(args.repo, skip=skip)
+    elapsed = (time.perf_counter() - t0) * 1000
+
+    if args.stats:
+        print(f"Scanned {stats['files']} files ({stats['bytes']//1024} KB) in {elapsed:.0f}ms")
+        print(f"Symbols: {stats['symbols']} | Languages: {', '.join(stats['languages'])}")
+        if stats['errors']:
+            print(f"Errors: {stats['errors']}")
+        print()
+
+    # Tree overview (unless suppressed)
+    if not args.no_tree:
+        print(tree_overview(cache, args.depth, args.detail, args.path))
+
+    # Run queries
+    for q in args.queries:
+        print(f"\n{'─' * 60}")
+        print(run_query(cache, q, args.detail))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Problem

tree-sitting's in-memory `CodeCache` dies between `bash_tool` calls in Claude.ai. Each `python3 -c` invocation is a separate process — scan in one, query in another = empty cache.

The SKILL.md showed the correct single-invocation pattern, but the exploring-codebases examples and natural LLM usage patterns split scan and query across calls.

Additionally, `searching-codebases/scripts/context.py` treated `Symbol` dataclass instances as dicts (`.get("start_line")`), which would fail at runtime.

## Solution

### tree-sitting
- **`treesit.py`**: New CLI that auto-scans on every invocation (~700ms), then runs queries. Each call is self-contained.
- **Progressive disclosure**: `--depth` (directory traversal) and `--detail` (node verbosity: sparse/normal/full) knobs serve different consumers:
  - `--depth=-1 --detail=sparse` → **featuring**: complete tree, minimal nodes
  - `--depth=1 --detail=normal` → **exploring**: quick orientation
  - `--path=src/core --detail=full` → **exploring**: deep dive
- **MCP server removed from docs**: `server.py` served no purpose in Claude.ai's process-per-call environment

### exploring-codebases
- All phases now use `treesit.py` CLI calls instead of `python -c` with manual engine imports
- No more "Already scanned — these are instant" lie (they were separate processes)

### featuring
- Added `treesit.py --depth=-1 --detail=sparse` as orientation step
- Removed fastmcp install dependency
- Updated Claude Code section to use CLI instead of MCP

### searching-codebases
- Fixed `context.py`: `Symbol` is a dataclass with `.line`, `.end_line`, `.name`, `.kind`, `.signature` attributes — not a dict
- Added child symbol traversal for finding innermost containing symbol

## Testing

```bash
# Sparse overview (featuring use case) — 31 files, 127 symbols in ~130ms
python treesit.py /repo --depth=-1 --detail=sparse --stats

# Orientation (exploring use case)
python treesit.py /repo --stats

# Deep dive with queries
python treesit.py /repo --path=scripts --detail=full 'find:remember*'
```

## Note

`server.py` is not deleted in this PR (only removed from SKILL.md). Follow-up cleanup.
