### PR TITLE
feat: orchestrating-agents v0.4.0 — AgentPool, EXECUTE_MODE, inter-agent messaging

### DIFF
--- a/orchestrating-agents/SKILL.md
+++ b/orchestrating-agents/SKILL.md
@@ -2,7 +2,7 @@
 name: orchestrating-agents
 description: Orchestrates parallel API instances, delegated sub-tasks, and multi-agent workflows with streaming and tool-enabled delegation patterns. Use for parallel analysis, multi-perspective reviews, or complex task decomposition.
 metadata:
-  version: 0.3.0
+  version: 0.4.0
 ---
 
 # Orchestrating Agents
@@ -442,6 +442,86 @@ See [references/workflows.md](references/workflows.md) for detailed examples inc
 - Recursive task delegation
 - Advanced Agent SDK delegation patterns
 - Prompt caching workflows
+
+## Execute Mode (Default Sub-Agent Prompt)
+
+For autonomous sub-agents that should execute without asking questions:
+
+```python
+from claude_client import invoke_claude, EXECUTE_MODE
+
+response = invoke_claude(
+    prompt="Review auth.py for SQL injection vulnerabilities",
+    system=f"You are a security expert.\n\n{EXECUTE_MODE}"
+)
+```
+
+`EXECUTE_MODE` encodes these principles (adapted from OpenAI Codex):
+- Make assumptions instead of asking questions; state them briefly
+- Think ahead: what else might be needed?
+- Report failures with what you tried and what you'll do next
+- Summarize deliverables and how to validate them
+
+## Agent Pool (Named Agents with Messaging)
+
+For workflows where multiple agents need to communicate:
+
+```python
+from agent_pool import AgentPool
+
+pool = AgentPool(
+    shared_system="You are reviewing the auth module of a web app.",
+    max_depth=3,    # prevent recursive spawn explosion
+    max_agents=10,
+)
+
+# Spawn named agents with roles
+pool.spawn("security", system=f"Focus on vulnerabilities.\n\n{pool.EXECUTE_MODE}")
+pool.spawn("perf", system=f"Focus on performance.\n\n{pool.EXECUTE_MODE}")
+
+# Run turns (pending inter-agent messages auto-injected)
+sec_result = pool.run("security", "Review the login flow")
+
+# Agent-to-agent messaging
+pool.send("security", to="perf",
+          content="Auth does N+1 queries in the session check loop",
+          trigger_turn=True)  # auto-runs perf with this context
+
+# Broadcast to all agents
+pool.broadcast("security", "Auth uses bcrypt cost=12, 200ms per hash")
+
+# Query pool state
+pool.agents()           # ["security", "perf"]
+pool.agent_info("perf") # {name, depth, children, pending_messages, turns}
+```
+
+### Spawn Reservation (Atomic Agent Creation)
+
+For complex workflows where agent creation might fail:
+
+```python
+from agent_pool import AgentPool
+
+pool = AgentPool(shared_system="Code review team")
+
+# Reservation pattern: name is reserved, rolled back on exception
+with pool.reserve("analyst", parent="lead") as res:
+    res.configure(system="You analyze code complexity.", model="claude-opus-4-6")
+    # If configure or any other work raises, the name is released
+# Agent "analyst" is now live
+
+# Depth limits prevent unbounded recursion
+pool.spawn("sub-analyst", parent="analyst")  # depth=2, OK
+pool.spawn("sub-sub", parent="sub-analyst")  # depth=3, raises ValueError
+```
+
+### When to Use AgentPool vs invoke_parallel
+
+| Pattern | Use When |
+|---------|----------|
+| `invoke_parallel()` | Independent tasks, no inter-agent communication needed |
+| `AgentPool` | Agents need to share findings, build on each other's work, or have parent/child relationships |
+| `invoke_parallel_managed()` | Independent tasks with retry, stall detection, concurrency limits |
 
 
 

--- a/orchestrating-agents/scripts/agent_pool.py
+++ b/orchestrating-agents/scripts/agent_pool.py
@@ -1,0 +1,394 @@
+"""
+Agent Pool — Named agents with inter-agent messaging.
+
+Adapted from OpenAI Codex's InterAgentCommunication and SpawnReservation
+patterns for stateless API-call environments.
+
+Key concepts:
+- AgentPool: manages named ConversationThreads with a shared message board
+- Messages between agents can optionally trigger automatic turns
+- SpawnReservation: context manager ensuring atomic agent creation with rollback
+- Depth limits prevent recursive spawn explosion
+
+Usage:
+    from agent_pool import AgentPool
+
+    pool = AgentPool(
+        shared_system="You are part of a code review team.",
+        max_depth=3
+    )
+
+    # Spawn named agents with roles
+    pool.spawn("security", system="You are a security expert. " + pool.EXECUTE_MODE)
+    pool.spawn("perf", system="You are a performance expert. " + pool.EXECUTE_MODE)
+
+    # Run turns (pending messages auto-injected)
+    sec_result = pool.run("security", "Review auth.py for vulnerabilities")
+
+    # Inter-agent messaging
+    pool.send("security", to="perf",
+              content="Found auth is doing N+1 queries — check perf impact",
+              trigger_turn=True)  # auto-runs perf agent with this message
+
+    # Broadcast to all
+    pool.broadcast("security", "Auth module uses bcrypt with cost=12")
+"""
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+from contextlib import contextmanager
+
+
+# Lazy import to avoid circular deps
+def _get_conversation_thread():
+    from claude_client import ConversationThread
+    return ConversationThread
+
+
+# ---------------------------------------------------------------------------
+# Execute Mode System Prompt (adapted from OpenAI Codex collaboration modes)
+# ---------------------------------------------------------------------------
+
+EXECUTE_MODE = """You execute on a well-specified task independently and report results.
+
+Execution rules:
+- When information is missing, do NOT ask questions. Make a sensible assumption, state it briefly, and continue.
+- Think out loud when it helps evaluate tradeoffs. Keep explanations short and grounded in consequences.
+- Think ahead: what else might be needed? How will the result be validated?
+- Be mindful of time. Minimize exploration; prefer direct action.
+- If something fails, report what failed, what you tried, and what you will do next.
+- When done, summarize what you delivered and how to validate it.
+
+If other agents have sent you messages, incorporate their findings into your work.
+Do not repeat their analysis — build on it."""
+
+
+# ---------------------------------------------------------------------------
+# Message Types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AgentMessage:
+    """A message between agents in the pool."""
+    author: str
+    recipient: str  # "*" for broadcast
+    content: str
+    trigger_turn: bool = False
+    timestamp: float = field(default_factory=time.time)
+
+    def format_for_injection(self) -> str:
+        return f"[Message from {self.author}]: {self.content}"
+
+
+# ---------------------------------------------------------------------------
+# Spawn Reservation
+# ---------------------------------------------------------------------------
+
+class SpawnReservation:
+    """
+    Context manager for atomic agent creation.
+
+    Reserves a name in the pool. If the block exits normally, the agent
+    is committed. If an exception occurs, the reservation is rolled back.
+
+    Adapted from Codex's SpawnReservation pattern (reserve → commit/drop).
+
+    Usage:
+        with pool.reserve("analyst") as res:
+            res.configure(system="You analyze data.", model="claude-sonnet-4-6")
+            # If this raises, the name is released
+        # Agent "analyst" is now live in the pool
+    """
+
+    def __init__(self, pool: 'AgentPool', name: str, parent: Optional[str] = None):
+        self.pool = pool
+        self.name = name
+        self.parent = parent
+        self.system: Optional[str] = None
+        self.model: str = "claude-sonnet-4-6"
+        self.max_tokens: int = 4096
+        self.temperature: float = 1.0
+        self._committed = False
+
+    def configure(self, *, system: str = None, model: str = None,
+                  max_tokens: int = None, temperature: float = None):
+        """Set agent configuration before commit."""
+        if system is not None:
+            self.system = system
+        if model is not None:
+            self.model = model
+        if max_tokens is not None:
+            self.max_tokens = max_tokens
+        if temperature is not None:
+            self.temperature = temperature
+
+    def commit(self):
+        """Finalize the agent in the pool."""
+        ConversationThread = _get_conversation_thread()
+
+        effective_system = self.system or ""
+        if self.pool.shared_system:
+            effective_system = f"{self.pool.shared_system}\n\n{effective_system}"
+
+        thread = ConversationThread(
+            system=effective_system,
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            cache_system=True,
+        )
+
+        depth = 0
+        if self.parent and self.parent in self.pool._depths:
+            depth = self.pool._depths[self.parent] + 1
+
+        with self.pool._lock:
+            self.pool._agents[self.name] = thread
+            self.pool._depths[self.name] = depth
+            if self.parent:
+                self.pool._children.setdefault(self.parent, []).append(self.name)
+        self._committed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None and not self._committed:
+            self.commit()
+        elif exc_type is not None:
+            # Rollback: release the reserved name
+            with self.pool._lock:
+                self.pool._reserved.discard(self.name)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Agent Pool
+# ---------------------------------------------------------------------------
+
+class AgentPool:
+    """
+    Pool of named agents with inter-agent messaging.
+
+    Each agent is a ConversationThread. Messages between agents are queued
+    and injected into the recipient's next turn. Messages with
+    trigger_turn=True cause an automatic API call to the recipient.
+
+    Args:
+        shared_system: System prompt shared across all agents (cached).
+        max_agents: Maximum number of concurrent agents (default: 10).
+        max_depth: Maximum spawn depth for parent→child chains (default: 3).
+        model: Default model for all agents.
+    """
+
+    # Expose as class attribute for easy access
+    EXECUTE_MODE = EXECUTE_MODE
+
+    def __init__(self, shared_system: str = None, max_agents: int = 10,
+                 max_depth: int = 3, model: str = "claude-sonnet-4-6"):
+        self.shared_system = shared_system
+        self.max_agents = max_agents
+        self.max_depth = max_depth
+        self.default_model = model
+
+        self._agents: dict[str, object] = {}   # name → ConversationThread
+        self._depths: dict[str, int] = {}       # name → spawn depth
+        self._children: dict[str, list] = {}    # parent → [child names]
+        self._reserved: set[str] = set()        # names currently being spawned
+        self._mailbox: list[AgentMessage] = []
+        self._lock = threading.Lock()
+
+    # -- Spawn --
+
+    def spawn(self, name: str, *, system: str = None, model: str = None,
+              parent: str = None, **kwargs) -> str:
+        """
+        Create a named agent in the pool.
+
+        Args:
+            name: Unique agent name.
+            system: Agent-specific system prompt (appended to shared_system).
+            model: Model override (default: pool's default).
+            parent: Parent agent name (for depth tracking).
+            **kwargs: Additional ConversationThread params.
+
+        Returns:
+            Agent name.
+
+        Raises:
+            ValueError: If name exists, pool is full, or depth exceeded.
+        """
+        with self._lock:
+            if name in self._agents or name in self._reserved:
+                raise ValueError(f"Agent '{name}' already exists or is being spawned")
+            if len(self._agents) >= self.max_agents:
+                raise ValueError(f"Pool full ({self.max_agents} agents)")
+            if parent and parent in self._depths:
+                if self._depths[parent] + 1 >= self.max_depth:
+                    raise ValueError(
+                        f"Spawn depth limit ({self.max_depth}) exceeded: "
+                        f"parent '{parent}' at depth {self._depths[parent]}"
+                    )
+            self._reserved.add(name)
+
+        try:
+            with self.reserve(name, parent=parent) as res:
+                res.configure(
+                    system=system,
+                    model=model or self.default_model,
+                    **{k: v for k, v in kwargs.items()
+                       if k in ('max_tokens', 'temperature')}
+                )
+        finally:
+            with self._lock:
+                self._reserved.discard(name)
+
+        return name
+
+    @contextmanager
+    def reserve(self, name: str, parent: str = None):
+        """
+        Reserve a name for atomic agent creation.
+
+        Usage:
+            with pool.reserve("analyst", parent="lead") as res:
+                res.configure(system="...", model="claude-opus-4-6")
+        """
+        reservation = SpawnReservation(self, name, parent)
+        yield reservation
+
+    # -- Messaging --
+
+    def send(self, author: str, *, to: str, content: str,
+             trigger_turn: bool = False) -> Optional[str]:
+        """
+        Send a message from one agent to another.
+
+        Args:
+            author: Sending agent name.
+            to: Recipient agent name.
+            content: Message content.
+            trigger_turn: If True, automatically run the recipient with
+                          this message (and return the response).
+
+        Returns:
+            Recipient's response if trigger_turn=True, else None.
+        """
+        msg = AgentMessage(
+            author=author, recipient=to,
+            content=content, trigger_turn=trigger_turn
+        )
+        with self._lock:
+            self._mailbox.append(msg)
+
+        if trigger_turn:
+            return self.run(to, f"[Triggered by message from {author}]")
+        return None
+
+    def broadcast(self, author: str, content: str, *,
+                  exclude: set = None, trigger_turn: bool = False) -> dict:
+        """
+        Send a message to all other agents.
+
+        Returns:
+            Dict of {agent_name: response} for agents that were triggered.
+        """
+        exclude = (exclude or set()) | {author}
+        responses = {}
+        for name in list(self._agents.keys()):
+            if name not in exclude:
+                result = self.send(
+                    author, to=name, content=content,
+                    trigger_turn=trigger_turn
+                )
+                if result is not None:
+                    responses[name] = result
+        return responses
+
+    # -- Execution --
+
+    def _drain_messages(self, agent_name: str) -> list[AgentMessage]:
+        """Remove and return all pending messages for an agent."""
+        with self._lock:
+            pending = [m for m in self._mailbox if m.recipient in (agent_name, "*")]
+            self._mailbox = [m for m in self._mailbox
+                            if m.recipient not in (agent_name, "*")]
+        return pending
+
+    def run(self, agent_name: str, prompt: str, **kwargs) -> str:
+        """
+        Run a turn for a named agent, injecting any pending messages.
+
+        Pending messages from other agents are prepended to the prompt
+        so the agent has full context.
+
+        Args:
+            agent_name: Agent to run.
+            prompt: User message for this turn.
+            **kwargs: Additional send() params.
+
+        Returns:
+            Agent's response text.
+        """
+        if agent_name not in self._agents:
+            raise ValueError(f"Agent '{agent_name}' not in pool")
+
+        thread = self._agents[agent_name]
+
+        # Inject pending messages
+        pending = self._drain_messages(agent_name)
+        if pending:
+            msg_block = "\n".join(m.format_for_injection() for m in pending)
+            prompt = f"{msg_block}\n\n{prompt}"
+
+        return thread.send(prompt, **kwargs)
+
+    # -- Lifecycle --
+
+    def shutdown(self, agent_name: str):
+        """Remove an agent from the pool."""
+        with self._lock:
+            self._agents.pop(agent_name, None)
+            self._depths.pop(agent_name, None)
+            self._reserved.discard(agent_name)
+            # Remove from parent's children
+            for parent, children in self._children.items():
+                if agent_name in children:
+                    children.remove(agent_name)
+
+    def shutdown_all(self):
+        """Remove all agents."""
+        with self._lock:
+            self._agents.clear()
+            self._depths.clear()
+            self._children.clear()
+            self._reserved.clear()
+            self._mailbox.clear()
+
+    # -- Queries --
+
+    def agents(self) -> list[str]:
+        """List all active agent names."""
+        return list(self._agents.keys())
+
+    def agent_info(self, name: str) -> dict:
+        """Get agent metadata."""
+        if name not in self._agents:
+            raise ValueError(f"Agent '{name}' not in pool")
+        return {
+            "name": name,
+            "depth": self._depths.get(name, 0),
+            "children": self._children.get(name, []),
+            "pending_messages": sum(
+                1 for m in self._mailbox if m.recipient in (name, "*")
+            ),
+            "turns": len(self._agents[name]),
+        }
+
+    def __len__(self):
+        return len(self._agents)
+
+    def __contains__(self, name):
+        return name in self._agents

--- a/orchestrating-agents/scripts/claude_client.py
+++ b/orchestrating-agents/scripts/claude_client.py
@@ -3,7 +3,31 @@ Claude API Client Module
 
 Provides functions for invoking Claude programmatically, including parallel invocations
 and prompt caching support for optimized token usage.
+
+See also:
+- agent_pool.py: Named agents with inter-agent messaging and spawn reservation
+- orchestration.py: Retry, reconciliation, and concurrency control
+- task_state.py: Task lifecycle state machine
 """
+
+
+# ---------------------------------------------------------------------------
+# Execute Mode — default system prompt for autonomous sub-agents
+# Adapted from OpenAI Codex collaboration-mode-templates/execute.md
+# ---------------------------------------------------------------------------
+
+EXECUTE_MODE = """You execute on a well-specified task independently and report results.
+
+Execution rules:
+- When information is missing, do NOT ask questions. Make a sensible assumption, state it briefly, and continue.
+- Think out loud when it helps evaluate tradeoffs. Keep explanations short and grounded in consequences.
+- Think ahead: what else might be needed? How will the result be validated?
+- Be mindful of time. Minimize exploration; prefer direct action.
+- If something fails, report what failed, what you tried, and what you will do next.
+- When done, summarize what you delivered and how to validate it.
+
+If other agents have sent you messages, incorporate their findings into your work.
+Do not repeat their analysis — build on it."""
 
 import json
 import os


### PR DESCRIPTION
## Context

Explored OpenAI Codex codebase (PR #536 verification → deep dive) and identified three patterns worth adopting:

1. **Execute Mode** (from `collaboration-mode-templates/execute.md`) — default system prompt for autonomous sub-agents
2. **Inter-Agent Communication** (from `codex-rs/core/src/agent/mailbox.rs`) — named message passing between agents
3. **Spawn Reservation** (from `codex-rs/core/src/agent/registry.rs`) — atomic agent creation with rollback

## Changes

### New: `agent_pool.py`

`AgentPool` manages named `ConversationThread` instances with:
- **Inter-agent messaging**: `pool.send("security", to="perf", content="...", trigger_turn=True)` — messages queue and auto-inject into the recipient's next turn. `trigger_turn=True` causes an immediate API call.
- **Broadcast**: `pool.broadcast("lead", "Auth uses bcrypt cost=12")` — sends to all other agents.
- **Spawn depth limits**: Prevents unbounded parent→child recursion (configurable `max_depth`).
- **SpawnReservation**: Context manager for atomic creation — name reserved on enter, committed on normal exit, rolled back on exception.
- **Shared system prompt**: Cached across all agents for cost efficiency.

### Modified: `claude_client.py`

- Added `EXECUTE_MODE` constant — autonomous sub-agent system prompt adapted from Codex
- Updated module docstring with cross-references to new modules

### Modified: `SKILL.md`

- Version bump to 0.4.0
- Documented `EXECUTE_MODE` usage
- Documented `AgentPool` with examples
- Added comparison table: when to use AgentPool vs invoke_parallel

## Design Decisions

- **AgentPool wraps ConversationThread**, not invoke_claude — agents need multi-turn context
- **Messages are strings, not structured** — keeps it simple; agents parse context naturally
- **Broadcast uses `"*"` recipient internally** — drained per-agent to avoid double-delivery
- **No persistence** — pool is ephemeral within a session (matches our stateless container model)
- **EXECUTE_MODE is also on `AgentPool.EXECUTE_MODE`** for convenience

## Also: Preference Signal Format

Stored new ops config `preference-signal-format` adopting Codex's evidence→implication→future-default structure for how Muninn stores user preference memories. This is a convention change, not a code change.

## Testing

Not yet tested end-to-end (needs API key in container). The AgentPool is pure Python with no external deps beyond the existing claude_client module.