### PR TITLE
challenging v0.8.2: add LOCAL_CONVENTIONS_GUARDRAIL

### DIFF
--- a/challenging/CHANGELOG.md
+++ b/challenging/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `challenging` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.2] - 2026-04-18
+
+### Added
+- **`LOCAL_CONVENTIONS_GUARDRAIL`** — new constant appended to every system prompt (alongside `KNOWLEDGE_CUTOFF_GUARDRAIL`). Instructs the adversary to classify findings as `unverifiable` when the critique depends on generic domain priors that may conflict with artifact-local conventions, and to state the assumption in `reasoning`. Uses `ln(0) = -∞` (domain error under pure math vs. intentional IEEE-754 signed-infinity feature) as the anchoring example.
+- Anti-rationalization row in `references/analysis.md`, `references/code.md`, and `references/recommendation.md`: "I know this field / language / domain" — prompts the adversary to check whether generic knowledge contradicts local conventions before flagging.
+
+### Rationale
+Observed failure mode (2026-04-18): Gemini review of an EML↔mythology claim correctly killed the core parallel (findings #1 and #3) but issued a partially-wrong finding #2 ("`ln` is a domain error on `y ≤ 0`") because it applied generic real-analysis priors without knowing the referenced codebase's CLAUDE.md invariant that `ln(0) = -∞` is intentional. The existing `KNOWLEDGE_CUTOFF_GUARDRAIL` handles "I don't recognize this API"; the new guardrail handles "I think I recognize this term but my default may disagree with local convention." Verdict was unaffected (the bad finding wasn't load-bearing), but the review was messier than it needed to be.
+
 ## [0.8.1] - 2026-04-17
 
 ### Other

--- a/challenging/SKILL.md
+++ b/challenging/SKILL.md
@@ -2,7 +2,7 @@
 name: challenging
 description: Cross-context adversarial review for deliverables before shipping. Use when producing blog posts, technical recommendations, analysis briefs, code, or any artifact where accuracy matters more than speed. Triggers on "challenge this", "review before shipping", "adversarial pass", "stress test this".
 metadata:
-  version: 0.8.1
+  version: 0.8.2
 ---
 
 # Challenging — Adversarial Review

--- a/challenging/references/analysis.md
+++ b/challenging/references/analysis.md
@@ -14,6 +14,7 @@
 | "The sources are authoritative" | Authority is not independence. Are the sources citing each other circularly? Is there a primary source behind the secondary ones? |
 | "I can't find counterevidence" | Did you search with negative terms? "X fails," "X criticism," "X alternative to"? Absence of search ≠ absence of evidence. |
 | "The framework applied is sound" | Does the framework fit the problem, or was the problem reshaped to fit the framework? Hammer/nail test. |
+| "I know this field" | Do you know the conventions of **this artifact's specific** codebase, paper, or claim tradition? Generic field knowledge can contradict local conventions (e.g. `ln(0) = -∞` is a domain error in pure math, a feature under IEEE-754). If your critique depends on a convention not stated in the artifact or `<context>`, mark the finding `unverifiable` and state the assumption. |
 
 ## Evaluation Criteria
 

--- a/challenging/references/code.md
+++ b/challenging/references/code.md
@@ -14,6 +14,7 @@
 | "I don't see security issues" | Did you trace every user-controlled input to its consumption? Did you check for path traversal, injection, SSRF, insecure deserialization? "I don't see" ≠ "none exist." |
 | "The tests cover the functionality" | Do the tests test the contract or the implementation? Would they catch a regression? Do they test failure modes or only success? |
 | "Performance seems reasonable" | For what scale? What's the O(n) for the expected data size? Are there hidden allocations in hot loops? |
+| "I know this language/library" | Do you know the conventions of **this specific** codebase? Generic language/library knowledge can contradict project-local invariants (e.g. `ln(0) = -∞` is a bug in pure Python, intentional under IEEE-754 / NumPy). Before flagging code as wrong, check whether the artifact or `<context>` establishes a local convention. If your critique depends on an unstated assumption, mark the finding `unverifiable` and state the assumption. |
 
 ## Evaluation Criteria
 

--- a/challenging/references/recommendation.md
+++ b/challenging/references/recommendation.md
@@ -14,6 +14,7 @@
 | "This is the industry standard approach" | Industry standard for which industry, which scale, which context? Are we in that context? |
 | "The risks are acceptable" | Acceptable to whom? What's the blast radius if the risk materializes? Is there a rollback path? |
 | "We should do this because X does it" | Survivorship bias. You're seeing the companies where it worked. How many tried and failed silently? |
+| "I know this domain" | Do you know the conventions of **this specific** org, stack, or problem context? Generic best-practice can contradict local reality (e.g. "always use transactions" assumes a relational store; "prefer microservices" assumes team independence that may not exist). If your critique depends on a context-specific assumption not stated in the artifact or `<context>`, mark the finding `unverifiable` and state the assumption. |
 
 ## Evaluation Criteria
 

--- a/challenging/scripts/challenger.py
+++ b/challenging/scripts/challenger.py
@@ -63,6 +63,25 @@ KNOWLEDGE_CUTOFF_GUARDRAIL = (
     "treat those as authoritative for the purpose of this review."
 )
 
+# Appended to every system prompt to mitigate generic-domain-knowledge overrides of local conventions.
+# Sibling to KNOWLEDGE_CUTOFF_GUARDRAIL: where that handles "I don't recognize this term," this handles
+# "I think I recognize this term, but my generic priors may disagree with the artifact's local convention."
+LOCAL_CONVENTIONS_GUARDRAIL = (
+    "\n\nLOCAL CONVENTIONS DISCIPLINE: Generic domain knowledge can contradict the "
+    "specific conventions of the artifact's codebase, paper, or field tradition. "
+    "Before flagging a technical claim as wrong based on what you know about the "
+    "subject in general, check whether the artifact or <context> suggests a local "
+    "convention that overrides the default. If your critique depends on an "
+    "assumption you cannot verify from what was provided, classify the finding "
+    "severity as 'unverifiable' and state in `reasoning` the assumption your "
+    "critique rests on. "
+    "Example: 'ln(0) = -∞' looks like a domain error by default, but is valid "
+    "under IEEE-754 signed-infinity semantics used in NumPy/PyTorch/C <math.h>. "
+    "If the artifact's context suggests that convention applies, flagging it as "
+    "a domain error is incorrect — mark it 'unverifiable' with the IEEE-754 "
+    "assumption noted instead."
+)
+
 
 def _retry_api(fn, *args, **kwargs):
     """Retry API calls with exponential backoff on transient errors."""
@@ -403,7 +422,7 @@ def prepare(
             raise ValueError(
                 "finding / chain / synthesize are only valid when profile='drill'."
             )
-        system = _load_system_prompt(profile) + KNOWLEDGE_CUTOFF_GUARDRAIL
+        system = _load_system_prompt(profile) + KNOWLEDGE_CUTOFF_GUARDRAIL + LOCAL_CONVENTIONS_GUARDRAIL
         user = _build_user_prompt(artifact, context)
         return {
             'prompt': _build_subagent_prompt(system, user),
@@ -416,7 +435,7 @@ def prepare(
         raise ValueError("profile='drill' requires finding=... (dict or str).")
     chain = chain or []
     stage = 'synthesize' if synthesize else 'deepen'
-    system = _load_drill_prompt(stage) + KNOWLEDGE_CUTOFF_GUARDRAIL
+    system = _load_drill_prompt(stage) + KNOWLEDGE_CUTOFF_GUARDRAIL + LOCAL_CONVENTIONS_GUARDRAIL
     if synthesize:
         user = _build_drill_synth_user_prompt(artifact, finding, chain, context)
     else:
@@ -533,7 +552,7 @@ def challenge(
     if max_iter < 1:
         raise ValueError(f"max_iterations must be >= 1, got {max_iter}")
 
-    system_prompt = _load_system_prompt(profile) + KNOWLEDGE_CUTOFF_GUARDRAIL
+    system_prompt = _load_system_prompt(profile) + KNOWLEDGE_CUTOFF_GUARDRAIL + LOCAL_CONVENTIONS_GUARDRAIL
     invoke_fn = _invoke_gemini if adversary == 'gemini' else _invoke_claude
 
     def invoke(art, ctx, sp):
@@ -648,8 +667,8 @@ def _build_drill_synth_user_prompt(artifact: str, finding, chain, context: str) 
 
 def _run_drill(artifact: str, finding, context: str, raw_invoker, max_depth: int) -> dict:
     """Sequential deepen loop followed by a synthesis pass (API path)."""
-    deepen_system = _load_drill_prompt('deepen') + KNOWLEDGE_CUTOFF_GUARDRAIL
-    synth_system = _load_drill_prompt('synthesize') + KNOWLEDGE_CUTOFF_GUARDRAIL
+    deepen_system = _load_drill_prompt('deepen') + KNOWLEDGE_CUTOFF_GUARDRAIL + LOCAL_CONVENTIONS_GUARDRAIL
+    synth_system = _load_drill_prompt('synthesize') + KNOWLEDGE_CUTOFF_GUARDRAIL + LOCAL_CONVENTIONS_GUARDRAIL
 
     chain: list = []
     iterations: list = []


### PR DESCRIPTION
Sibling guardrail to `KNOWLEDGE_CUTOFF_GUARDRAIL`. Where that handles "I don't recognize this term," this handles "I think I recognize this term, but my generic priors may disagree with the artifact's local convention."

## Why

Observed failure mode 2026-04-18: Gemini review of an EML ↔ Huginn/Muninn mythology claim correctly killed the core parallel (findings on structural fit + architectural mapping) but issued a partially-wrong secondary finding — `ln` flagged as "a domain error on y ≤ 0" — by applying generic real-analysis priors without knowing the referenced codebase (eml-sr) treats `ln(0) = -∞` as intentional IEEE-754 behavior per `CLAUDE.md` invariant #6. The verdict was unaffected (the bad finding wasn't load-bearing), but the review was messier than it needed to be, and a future reviewer acting only on the JSON output might chase the phantom.

The existing `KNOWLEDGE_CUTOFF_GUARDRAIL` only catches the "I don't recognize this" case. The new guardrail covers the symmetric "I do recognize this generically, and my default overrides the artifact's local convention" case.

## Changes

- **`scripts/challenger.py`** — new `LOCAL_CONVENTIONS_GUARDRAIL` constant defined alongside `KNOWLEDGE_CUTOFF_GUARDRAIL`, appended at all 5 prompt-assembly sites (review prepare, drill prepare, blocking `challenge()`, drill deepen, drill synthesize). Uses `ln(0) = -∞` as the anchoring example.
- **`references/analysis.md`**, **`references/code.md`**, **`references/recommendation.md`** — one anti-rationalization row added to each: "I know this field / language / domain."
- **`SKILL.md`** — version bump 0.8.1 → 0.8.2.
- **`CHANGELOG.md`** — v0.8.2 entry with rationale.

## Not changed

No JSON schema changes — `unverifiable` severity and `reasoning` field already exist. No change to `prose.md` (local-convention mismatches are a technical-review failure mode, not a prose one). No change to `drill.md` (drill inherits the guardrail via the same append chain in `_load_drill_prompt()` usage sites; no profile-level content edits needed).

## Test

Dry-read verified: all 5 append sites now end with `+ KNOWLEDGE_CUTOFF_GUARDRAIL + LOCAL_CONVENTIONS_GUARDRAIL`; Python syntax clean; CHANGELOG front-matter preserved.
