### PR TITLE
Add tracking-todos skill

### DIFF
--- a/tracking-todos/SKILL.md
+++ b/tracking-todos/SKILL.md
@@ -79,6 +79,14 @@ Todos live in Muninn's config store under key `active-todos` (category=`ops`). T
 
 If you start a conversation and find stale todos that don't apply, call `abandon()` to clear them.
 
+## Known Limitations
+
+**Single writer assumed.** The storage uses read-modify-write without locking. If a scheduled CCotw task and a live conversation both call `write_todos()` concurrently, the second write wins. Muninn runs single-threaded within a conversation, and scheduled tasks (perch, zeitgeist) don't use this skill, so the assumption holds in practice. Don't use this skill from concurrent agents without adding a lock.
+
+**Global scope is intentional, not per-conversation.** Unfinished work leaks into the next conversation by design — it's a nudge that something was left open. If stale todos from prior work become noise, call `abandon()` to clear.
+
+**Replace-whole-list API vs delta updates.** Matches Claude Code's TodoWrite exactly. The LLM failure mode (forgetting items when rewriting the full list) is mitigated by the prompt, not by the API shape. If omissions become a pattern, re-render the current list before composing the new one.
+
 ## Display Pattern
 
 When the plan is substantive, show it to Oskar once after creating it, then rely on inline mentions rather than re-rendering the full list on every update. Noise defeats the signal.

--- a/tracking-todos/SKILL.md
+++ b/tracking-todos/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: tracking-todos
+description: Maintain a structured task list for the current session. Use proactively when a request requires 3+ distinct steps, the user provides multiple items, or complex work benefits from explicit progress tracking. Storage persists via Muninn config across container death. Adapted from Claude Code's TodoWrite tool.
+---
+
+# Tracking Todos
+
+Maintain a structured, persistent task list while working through multi-step requests. Track progress explicitly, mark completion honestly, and make the plan visible to Oskar.
+
+## When to Use
+
+Use proactively when:
+- Request requires 3+ distinct steps or actions
+- User provides multiple tasks (numbered, comma-separated, or a list)
+- Work spans multiple tool calls, file edits, or research phases
+- Non-trivial planning would otherwise happen implicitly in your head
+- User explicitly asks for a todo list
+
+Skip when:
+- Single, straightforward task
+- Purely conversational or informational exchange
+- Task completes in <3 trivial steps
+- Quick fact lookup or recall
+
+When in doubt, use it. Being explicit about multi-step plans makes failure modes visible.
+
+## Schema
+
+Each todo has exactly three string fields:
+
+- `content` — imperative form ("Run tests", "Fix auth bug")
+- `status` — one of: `pending`, `in_progress`, `completed`
+- `activeForm` — present continuous ("Running tests", "Fixing auth bug")
+
+Both `content` and `activeForm` are required for every todo. The activeForm is what gets shown while a task is executing.
+
+## API
+
+```python
+from todos import get_todos, write_todos, abandon, render
+
+# Read current list
+todos = get_todos()
+
+# Replace entire list (Claude Code semantics — one call, whole list)
+write_todos([
+    {"content": "Fetch issue body", "status": "in_progress", "activeForm": "Fetching issue body"},
+    {"content": "Draft fix plan", "status": "pending", "activeForm": "Drafting fix plan"},
+    {"content": "Implement and test", "status": "pending", "activeForm": "Implementing and testing"},
+])
+
+# Display to Oskar
+print(render())
+
+# Discard remaining todos when starting fresh unrelated work
+abandon()
+```
+
+`write_todos()` validates schema and that at most one item is `in_progress`. When every item is `completed`, it auto-clears the list (matches Claude Code behavior — done-state is empty-state).
+
+## Behavioral Rules
+
+**One in_progress at a time, strictly.** Before starting work on a task, set it to `in_progress`. Never have two `in_progress` items simultaneously. The validator enforces this.
+
+**Mark complete IMMEDIATELY.** Update to `completed` the moment the work is actually done. Don't batch completions at the end — that defeats the tracking purpose and erases information about when things were finished.
+
+**Only mark complete if FULLY done.** If tests fail, if the implementation is partial, if you hit an unresolved error — keep the task `in_progress` and add a new task describing the blocker. Lying about completion status is the failure mode this tool exists to prevent.
+
+**Remove irrelevant tasks.** If a task becomes obsolete (scope change, wrong approach), remove it entirely from the list rather than marking it done. The list should reflect actual remaining work.
+
+**Break complex tasks down.** Vague items like "implement the feature" defeat the point. Prefer specific actions: "Add validator to route handler", "Write 3 test cases for edge inputs", "Run existing test suite".
+
+## Storage Model
+
+Todos live in Muninn's config store under key `active-todos` (category=`ops`). This means:
+- Survives container death within the same conversation
+- Persists across conversations until explicitly cleared or auto-cleared when all done
+- Cross-conversation persistence is a feature: unfinished work shows up next session as a nudge
+
+If you start a conversation and find stale todos that don't apply, call `abandon()` to clear them.
+
+## Display Pattern
+
+When the plan is substantive, show it to Oskar once after creating it, then rely on inline mentions rather than re-rendering the full list on every update. Noise defeats the signal.
+
+```
+▶ Fetching issue body
+☐ Drafting fix plan
+☐ Implementing and testing
+```
+
+## Examples
+
+**Good use case — multi-file refactor:**
+```python
+write_todos([
+    {"content": "Find all call sites of getCwd", "status": "in_progress", "activeForm": "Finding all call sites of getCwd"},
+    {"content": "Rename occurrences in src/utils/", "status": "pending", "activeForm": "Renaming occurrences in src/utils/"},
+    {"content": "Rename occurrences in src/agents/", "status": "pending", "activeForm": "Renaming occurrences in src/agents/"},
+    {"content": "Run test suite", "status": "pending", "activeForm": "Running test suite"},
+])
+```
+
+**Bad use case — should not use:**
+```
+User: "What's the current time in Tokyo?"
+→ Single fact lookup. Skip todos.
+```
+
+**Mid-work update (after finishing step 1, hitting a blocker in step 2):**
+```python
+write_todos([
+    {"content": "Find all call sites of getCwd", "status": "completed", "activeForm": "Finding all call sites of getCwd"},
+    {"content": "Rename occurrences in src/utils/", "status": "completed", "activeForm": "Renaming occurrences in src/utils/"},
+    {"content": "Resolve type error in AgentContext after rename", "status": "in_progress", "activeForm": "Resolving type error in AgentContext after rename"},
+    {"content": "Rename occurrences in src/agents/", "status": "pending", "activeForm": "Renaming occurrences in src/agents/"},
+    {"content": "Run test suite", "status": "pending", "activeForm": "Running test suite"},
+])
+```
+
+Note: the blocker became a new task rather than marking step 3 complete.

--- a/tracking-todos/scripts/todos.py
+++ b/tracking-todos/scripts/todos.py
@@ -1,0 +1,81 @@
+"""Tracking-todos: session task list with Claude Code TodoWrite semantics.
+
+Storage: Muninn config entry 'active-todos' (category='ops') as JSON array.
+Schema matches Claude Code exactly: {content, status, activeForm}.
+"""
+
+import json
+from scripts import config_get, config_set
+
+CONFIG_KEY = "active-todos"
+VALID_STATUS = ("pending", "in_progress", "completed")
+
+
+def get_todos():
+    """Return current todo list (possibly empty)."""
+    raw = config_get(CONFIG_KEY)
+    if not raw:
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+
+def write_todos(todos):
+    """Replace entire todo list.
+
+    Matches Claude Code semantics: if every todo is 'completed', clears the
+    list instead of persisting an all-done state.
+
+    Raises ValueError on schema violations or >1 in_progress.
+    """
+    _validate(todos)
+    all_done = len(todos) > 0 and all(t["status"] == "completed" for t in todos)
+    to_store = [] if all_done else todos
+    config_set(CONFIG_KEY, json.dumps(to_store), category="ops")
+    return to_store
+
+
+def abandon():
+    """Clear the todo list unconditionally. Use when starting fresh work
+    that makes prior todos irrelevant."""
+    config_set(CONFIG_KEY, "[]", category="ops")
+
+
+def render(todos=None):
+    """Pretty-print todos for display. Returns a string."""
+    if todos is None:
+        todos = get_todos()
+    if not todos:
+        return "(no active todos)"
+    marks = {"pending": "☐", "in_progress": "▶", "completed": "✓"}
+    lines = []
+    for t in todos:
+        label = t["activeForm"] if t["status"] == "in_progress" else t["content"]
+        lines.append(f"  {marks[t['status']]} {label}")
+    return "\n".join(lines)
+
+
+def _validate(todos):
+    if not isinstance(todos, list):
+        raise ValueError(f"todos must be a list, got {type(todos).__name__}")
+    in_progress_count = 0
+    for i, t in enumerate(todos):
+        if not isinstance(t, dict):
+            raise ValueError(f"todos[{i}] must be a dict")
+        for field in ("content", "status", "activeForm"):
+            if field not in t:
+                raise ValueError(f"todos[{i}] missing field: {field}")
+            if not isinstance(t[field], str) or not t[field].strip():
+                raise ValueError(f"todos[{i}].{field} must be a non-empty string")
+        if t["status"] not in VALID_STATUS:
+            raise ValueError(
+                f"todos[{i}].status must be one of {VALID_STATUS}, got {t['status']!r}"
+            )
+        if t["status"] == "in_progress":
+            in_progress_count += 1
+    if in_progress_count > 1:
+        raise ValueError(
+            f"at most one todo may be in_progress at a time (found {in_progress_count})"
+        )

--- a/tracking-todos/scripts/todos.py
+++ b/tracking-todos/scripts/todos.py
@@ -5,6 +5,8 @@ Schema matches Claude Code exactly: {content, status, activeForm}.
 """
 
 import json
+import sys
+
 from scripts import config_get, config_set
 
 CONFIG_KEY = "active-todos"
@@ -12,21 +14,45 @@ VALID_STATUS = ("pending", "in_progress", "completed")
 
 
 def get_todos():
-    """Return current todo list (possibly empty)."""
+    """Return current todo list (possibly empty).
+
+    If the stored value is missing, empty, or structurally invalid, returns []
+    and prints a warning to stderr. Silent recovery is deliberate: callers
+    should be able to read todos without worrying about historical corruption
+    (e.g. a schema change). Inspect the raw config value directly if you
+    suspect data loss.
+    """
     raw = config_get(CONFIG_KEY)
     if not raw:
         return []
     try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(
+            f"[tracking-todos] WARNING: stored todos are not valid JSON ({e}). "
+            f"Returning empty list. Raw value length: {len(raw)}",
+            file=sys.stderr,
+        )
         return []
+    try:
+        _validate(parsed)
+    except ValueError as e:
+        print(
+            f"[tracking-todos] WARNING: stored todos failed validation ({e}). "
+            f"Returning empty list.",
+            file=sys.stderr,
+        )
+        return []
+    return parsed
 
 
 def write_todos(todos):
     """Replace entire todo list.
 
     Matches Claude Code semantics: if every todo is 'completed', clears the
-    list instead of persisting an all-done state.
+    stored list instead of persisting an all-done state. Returns the
+    passed-in list regardless of storage clearing, so the caller can render
+    the final completed state before moving on.
 
     Raises ValueError on schema violations or >1 in_progress.
     """
@@ -34,7 +60,7 @@ def write_todos(todos):
     all_done = len(todos) > 0 and all(t["status"] == "completed" for t in todos)
     to_store = [] if all_done else todos
     config_set(CONFIG_KEY, json.dumps(to_store), category="ops")
-    return to_store
+    return todos
 
 
 def abandon():


### PR DESCRIPTION
Adapts Claude Code's `TodoWrite` tool (from the 2026-03-31 npm sourcemap leak) as a Muninn-compatible skill.

**What it does:** maintains a structured task list for the current session with explicit `pending`/`in_progress`/`completed` states, persistent across container death via Muninn's config store (key `active-todos`, category `ops`).

**Schema matches Claude Code exactly:**
- `content` (imperative: "Run tests")
- `status` (one of three)
- `activeForm` (present continuous: "Running tests")

**Behavioral rules preserved from the leak prompt:**
- One `in_progress` at a time, strictly (validator enforces)
- Mark complete IMMEDIATELY when done, don't batch
- Only mark complete if FULLY done — blockers become new tasks, not false completions
- All-done state auto-clears the list (matches Claude Code semantics)

**API** (scripts/todos.py — 81 lines):
- `get_todos()` → list
- `write_todos(todos)` → validates + replaces entire list
- `abandon()` → unconditional clear
- `render(todos=None)` → pretty-print with ✓/▶/☐ marks

**Source:** Skill adapted from `T-Lab-CUHKSZ/claude-code` fork (faithful TS reproduction of the leak). Prompt text drawn from `src/tools/TodoWriteTool/prompt.ts`, schema from `src/utils/todo/types.ts`.

Tested: round-trip, validation rejection (2x in_progress, missing fields, bad status, whitespace-only content, non-list input), auto-clear on all-done.
