### PR TITLE
feat(claude_client): filter kwargs that break response-reader assumptions

### DIFF
--- a/orchestrating-agents/scripts/claude_client.py
+++ b/orchestrating-agents/scripts/claude_client.py
@@ -47,6 +47,44 @@ except ImportError:
     )
 
 
+# ---------------------------------------------------------------------------
+# Blocked kwargs — defensive filter against params that silently break
+# the response-reading assumptions of invoke_claude*. Inspired by Multica's
+# per-vendor BlockedArgs pattern (server/pkg/agent/*.go).
+#
+# Passing these through **kwargs would land them in the SDK call and either
+# change the response shape or duplicate a param the wrapper already owns.
+# Rather than let that fail silently (or at a confusing distance from the
+# caller), we strip them at the boundary and warn loudly.
+# ---------------------------------------------------------------------------
+
+_BLOCKED_KWARGS = {
+    "stream": "use invoke_claude_streaming() or the streaming=True kwarg instead",
+    "tools": "not supported — the wrapper reads content[0].text and assumes text",
+    "tool_choice": "requires tools; not supported by the text-only response reader",
+    "thinking": "extended thinking changes response shape; content[0] may be a thinking block",
+}
+
+
+def _filter_kwargs(kwargs: dict, fn_name: str) -> dict:
+    """Strip kwargs that would break invoke_claude*'s assumptions. Warn on drop.
+
+    Callers who genuinely need tools, thinking, or streaming should use the
+    anthropic SDK directly — the wrappers here own a narrower contract.
+    """
+    import warnings
+    safe = {}
+    for k, v in kwargs.items():
+        if k in _BLOCKED_KWARGS:
+            warnings.warn(
+                f"{fn_name}(): dropping kwarg {k!r} — {_BLOCKED_KWARGS[k]}",
+                RuntimeWarning, stacklevel=3,
+            )
+            continue
+        safe[k] = v
+    return safe
+
+
 def get_anthropic_api_key() -> str:
     """
     Get Anthropic API key from environment or project knowledge files.
@@ -372,13 +410,15 @@ def invoke_claude(
     current_system = system
     last_error = None
 
+    safe_kwargs = _filter_kwargs(kwargs, "invoke_claude")
+
     for attempt in range(max_retries + 1):
         # Build message parameters fresh each attempt (prompt/system may change)
         message_params = {
             "model": model,
             "max_tokens": max_tokens,
             "temperature": temperature,
-            **kwargs
+            **safe_kwargs
         }
 
         if messages:
@@ -518,7 +558,7 @@ def invoke_claude_streaming(
         max_tokens=max_tokens,
         temperature=temperature,
         messages=messages,
-        **kwargs
+        **_filter_kwargs(kwargs, "invoke_claude_streaming")
     )
     if system:
         stream_params["system"] = _format_system_with_cache(system, cache_system)


### PR DESCRIPTION
## Steal from multica-ai/multica: per-vendor BlockedArgs pattern

Reviewed [multica](https://github.com/multica-ai/multica) today. Their agent-backend adapters (`server/pkg/agent/*.go`) keep a `BlockedArgs` list per vendor — kwargs that would break the adapter's assumptions get filtered at the boundary, not passed to the underlying CLI.

`invoke_claude` / `invoke_claude_streaming` have the same shape of problem: `**kwargs` flows directly into `message_params` / `stream_params`, where certain params silently break the wrapper's contract:

| kwarg         | what breaks |
|---------------|-------------|
| `stream`      | conflicts with the `streaming` kwarg; wrong response shape for the non-streaming reader |
| `tools`       | response may be a `tool_use` block; `content[0].text` crashes or returns junk |
| `tool_choice` | requires `tools`; same issue |
| `thinking`    | extended thinking puts a thinking block in `content[0]`, not text |

### Change

- Add `_BLOCKED_KWARGS` dict (reason strings per arg)
- Add `_filter_kwargs(kwargs, fn_name)` helper — strips blocked args and emits a `RuntimeWarning`
- Apply at the two kwargs sites: `invoke_claude` (line ~381) and `invoke_claude_streaming` (line ~521)
- `invoke_claude_json` and `invoke_parallel` delegate to `invoke_claude`, so no separate filter needed

Behavior: legit passthroughs (`top_p`, `top_k`, `metadata`, `service_tier`, etc.) continue to work. Blocked args get dropped with a loud warning pointing the caller at the correct API.

### Out of scope

- SDK version pinning (Multica also does `MinVersions`). API evolves; preferring permissive.
- `invoke_gemini` already has a typed signature with no `**kwargs` — no attack surface there.

### Tests

Added inline verification:
- Clean kwargs pass through unmodified, no warnings
- Each blocked kwarg is stripped with a warning identifying the arg and reason
- Multiple blocked kwargs produce one warning each
