### PR TITLE
exploring-codebases: TODO-style workflow (tarball-first, batched treesit)

### DIFF
--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -9,14 +9,14 @@ description: >-
   the divergent "what's here?" skill — for targeted "where is X?" queries,
   use searching-codebases instead.
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Exploring Codebases
 
 Exploratory code analysis for unfamiliar repositories. This skill is a
 **workflow**, not a tool — it orchestrates tree-sitting (structural) and
-featuring (semantic) into a progressive disclosure sequence.
+featuring (semantic) over a local copy of the repo.
 
 ## Dependencies
 
@@ -30,67 +30,50 @@ uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
 
 ## Workflow
 
+Four steps, in order. Do not skip step 1.
+
+### 1. Get the repo (tarball, not per-file)
+
+```bash
+OWNER=... REPO=... REF=main
+curl -sL "https://api.github.com/repos/$OWNER/$REPO/tarball/$REF" -o /tmp/$REPO.tar.gz
+mkdir -p /tmp/$REPO && tar -xzf /tmp/$REPO.tar.gz -C /tmp/$REPO --strip-components=1
+```
+
+One HTTP call gets the whole repo. Do NOT curl the README, cat individual
+files, or fetch via `contents/PATH` before this — they're all in the tarball.
+Every pre-tarball `curl`/`cat` on a file that's already in the repo is
+wasted tool budget.
+
+For private repos, add `-H "Authorization: Bearer $GH_TOKEN"`.
+
+### 2. Tree-sitting (structural inventory)
+
 ```bash
 TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
 PYTHON=/home/claude/.venv/bin/python
+
+# Structural overview — files, symbol counts, languages at depth=1
+$PYTHON $TREESIT /tmp/$REPO --stats
+
+# Drill into interesting paths. BATCH queries in one call — each extra
+# query adds ~0ms on top of the scan cost. Separate invocations re-scan.
+$PYTHON $TREESIT /tmp/$REPO --path=SUBDIR --detail=full \
+  'find:*Handler*:function' 'source:main' 'refs:Config'
 ```
 
-### Phase 1: Structural Orientation
-
-Get oriented — what's here, how big, what languages?
+### 3. Featuring (feature synthesis)
 
 ```bash
-$PYTHON $TREESIT /path/to/repo --stats
-```
-
-Default depth=1 shows root-level files and one level of subdirectories
-with file counts, symbol counts, and languages. Takes ~700ms total
-(scan + output).
-
-### Phase 2: Drill Into Structure
-
-Follow what looks interesting. Each call auto-scans — no state to manage.
-
-```bash
-# Drill into a directory with full detail (signatures, docs, children, imports)
-$PYTHON $TREESIT /path/to/repo --path=src/core --detail=full
-
-# Search for patterns across the codebase
-$PYTHON $TREESIT /path/to/repo 'find:*Handler*:function'
-
-# Read a specific implementation
-$PYTHON $TREESIT /path/to/repo --no-tree 'source:handle_request'
-```
-
-**Heuristics for what to drill into first:**
-- Directories with high symbol counts relative to file counts (dense logic)
-- Entry point patterns: `main`, `cli`, `app`, `server`, `routes`, `handler`
-- Files with many imports (integration points)
-- The root directory's top-level files (often config + entry points)
-
-### Phase 3: Feature Synthesis (featuring)
-
-Once you understand the structure, generate the "what does it DO?" layer:
-
-```bash
-$PYTHON /mnt/skills/user/featuring/scripts/gather.py /path/to/repo \
+$PYTHON /mnt/skills/user/featuring/scripts/gather.py /tmp/$REPO \
   --skip tests,.github,node_modules --source-budget 8000
 ```
 
-Read the gather output, then synthesize `_FEATURES.md` following the featuring
-skill's format. This is the LLM step — identify capabilities, group symbols
-into features, write user-facing descriptions.
+### 4. Reason about the combined output
 
-### Phase 4: Targeted Deep Dives
-
-With structural inventory + feature map in hand, read specific implementations
-where the feature narrative needs verification or behavior isn't clear:
-
-```bash
-$PYTHON $TREESIT /path/to/repo --no-tree 'source:authenticate' 'refs:AuthToken'
-```
-
-Multiple queries in one call — each adds ~0ms on top of the scan cost.
+Synthesize steps 2+3 into understanding — identify capabilities, group symbols
+into features, write user-facing descriptions. Produce `_FEATURES.md` when
+warranted. This is the LLM step; everything before was mechanical.
 
 ## When to Use This vs Other Skills
 
@@ -106,19 +89,12 @@ Exploring is the **divergent** skill — you don't know what you're looking
 for yet. Searching is the **convergent** skill — you know what you want,
 you need to find it.
 
-## Output
+## Notes
 
-The exploration produces understanding, not necessarily files. But the
-concrete artifacts, when warranted, are:
-
-- `_FEATURES.md` — top-down feature documentation (via featuring)
-- Mental model of codebase structure, entry points, and architecture
-
-## Scaling
-
-For large repos (>100 files), use `--skip` aggressively in Phase 1 to
-exclude tests, vendored code, generated files, and docs. Focus the initial
-scan on `--path=src` or the primary source directory. Expand scope as needed.
-
-For monorepos, treat each package/service as a separate exploration.
-Generate per-subsystem `_FEATURES.md` files linked from a root index.
+- **Scale**: For large repos (>100 files), use `--skip tests,vendored,docs,...`
+  in step 2 to focus the initial scan. Expand scope as needed.
+- **Monorepos**: Treat each package/service as a separate exploration.
+  Generate per-subsystem `_FEATURES.md` files linked from a root index.
+- **Drill heuristics** (for step 2): directories with high symbol count vs
+  file count (dense logic), entry-point patterns (`main`, `cli`, `app`,
+  `server`, `routes`), files with many imports (integration points).


### PR DESCRIPTION
Rewrites the Workflow section as an explicit 4-step TODO list.

## Why

Diagnosis from a MoDA repo review (@oaustegard flagged — chat thread 2026-04-20):

1. **Preamble waste** — before invoking the skill, I curl'd the README and cat'd individual `__init__.py` files via the GitHub contents API. All of that data was already in the tarball that got downloaded seconds later. Double fetch.
2. **No batching** — tree-sitting ran as 4–5 separate invocations (stats, tree, symbols, names, kernels) instead of batching queries into one scan. Each separate call re-scans the repo.
3. **Phase-framed prose** invited interpreting the skill as guidance rather than a checklist. Easy to reorder, easy to "just peek at the README first."

## What changes

- **Step 1 is tarball-first, mandatory**: one `curl` to `/tarball/$REF`, extract to `/tmp/$REPO`. Explicit "do NOT curl README or cat individual files before this" note.
- **Step 2 emphasizes batching**: shows combined `'find:...' 'source:...' 'refs:...'` in one treesit call, with note that separate invocations re-scan.
- **Step 3/4 unchanged in substance** but moved into numbered steps rather than "phases."
- Heuristics, scaling, monorepo notes demoted to a `## Notes` section at the bottom — they're reference material, not steps.
- Version bumped `2.0.0` → `2.1.0`.

## Not changed

- Dependencies section
- "When to Use This vs Other Skills" triage table
- Overall skill scope and positioning vs searching-codebases


## Update: v2.2.0 based on dogfooding

Ran the v2.1.0 skill on this repo itself. Counted tool calls: 11 when 5–6 would have sufficed. Concrete failures:

1. **Dependencies section read as decorative setup** → skipped install → treesit silently returned `Scanned 0 files` → three diagnostic calls before I realized the language pack wasn't loaded.
2. **`REF=main` hardcoded** with no mention of branches/tags/PRs → fetched stale tarball (missing my own PR changes) → had to refetch from the PR branch.
3. **No post-extract sanity check** → I had to add `ls` separately when something looked wrong.
4. **Step 2 implied drill-always** → I drilled into a prose-only subdir (`exploring-codebases/` itself, no code) and got empty results.
5. **No diagnostic pointer** for the silent-failure mode above.

v2.2.0 fixes:
- **New step 0 (setup)**: explicit venv + install + env exports. Once per session. Includes the silent-failure diagnostic: "if step 2 reports Scanned 0 files, come back here."
- **Step 1 ref guidance**: `REF=main` now annotated with `# branch name, tag, or SHA. For a PR: pull/N/head`. Plus a note that default `main` silently gives stale code for unmerged work.
- **Step 1 sanity check**: `ls /tmp/$REPO | head` appended to the tarball block.
- **Step 2 drill-optional**: explicit "for pure 'what is this repo' exploration, skip drilling and go to step 3 — featuring surfaces interesting paths for you."
- Drill heuristics moved to Notes (they're reference, not part of the mandatory flow).

Version: `2.1.0` → `2.2.0`.