### PR TITLE
uploading-files: warn agent against wrapping the upload URL in markdown

### DIFF
--- a/uploading-files/SKILL.md
+++ b/uploading-files/SKILL.md
@@ -29,7 +29,7 @@ The script lives at `/mnt/skills/user/uploading-files/scripts/upload.py` once in
 python3 /mnt/skills/user/uploading-files/scripts/upload.py init
 ```
 
-This creates `upload-<short-session-id>` on origin (from the default branch) and prints a GitHub upload URL. **Show that URL to the user verbatim** and tell them:
+This creates `upload-<short-session-id>` on origin (from the default branch) and prints a GitHub upload URL. **Show that URL to the user on its own line, with no surrounding markdown** — no `**bold**`, no `[link](...)`, no backticks. Some chat renderers concatenate trailing punctuation/markup onto the URL when the user clicks it, breaking the branch name. Bare URL only. Then tell them:
 
 > Open that link, drag the file(s) into the page, scroll to the bottom and click **Commit changes** (the default options are fine). Reply here when done.
 


### PR DESCRIPTION
## Summary

Tiny SKILL.md tweak. Caught this in dogfooding right after #562 merged: I rendered the upload URL as `**<url>**` for emphasis, the chat renderer treated the trailing `**` as part of the URL when the user clicked, and they hit a 404 on a branch named `upload-XXXX**`.

The instruction now explicitly says: bare URL on its own line, no `**bold**`, no `[link](text)`, no backticks. No code change.