### PR TITLE
exploring-codebases v2.2.1: good/bad batching examples (salvaged from #559)

### DIFF
--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   the divergent "what's here?" skill — for targeted "where is X?" queries,
   use searching-codebases instead.
 metadata:
-  version: 2.2.0
+  version: 2.2.1
 ---
 
 # Exploring Codebases
@@ -71,12 +71,20 @@ repo" exploration, skip drilling and go to step 3 — featuring surfaces
 the interesting paths for you. Drill when a user asked about a specific
 subsystem, or when step 3's output raises a question that needs source.
 
-When you do drill, BATCH queries in one call — each extra query adds
-~0ms, separate invocations re-scan from scratch:
+**When you do drill, batch queries in one invocation.** Every treesit
+call pays the full scan cost. Multiple queries added to the same command
+share that scan and each additional query adds ~0ms. If you're about to
+make a second treesit call on the same path, fold it into the first.
 
 ```bash
+# GOOD — one scan, three answers
 $PYTHON $TREESIT /tmp/$REPO --path=SUBDIR --detail=full \
   'find:*Handler*:function' 'source:main' 'refs:Config'
+
+# BAD — three scans, three answers (3× the cost for the same information)
+$PYTHON $TREESIT /tmp/$REPO --path=SUBDIR --detail=full
+$PYTHON $TREESIT /tmp/$REPO 'find:*Handler*:function'
+$PYTHON $TREESIT /tmp/$REPO 'refs:Config'
 ```
 
 ### 3. Feature synthesis


### PR DESCRIPTION
v2.2.1 — salvages the batching rule + good/bad examples from #559.

## Context

#559 was opened earlier today by a parallel Muninn session reacting to the same MoDA review failure. It proposed two fixes: (a) a `git clone` Phase 0, and (b) promoting the batching note to a bolded rule with good/bad examples.

#559 is being closed as superseded, because:
- (a) `git clone` is blocked in claude.ai containers by the egress proxy (see `accessing-github-repos`) — #560's tarball-via-API approach is the working equivalent and already landed.
- The PR structurally targets the old Phase-1-through-4 prose, not the numbered-steps layout from #560/#561, so it's `mergeable: false`.

But (b) is a genuine improvement that didn't fully land in v2.2.0 — the current step 2 has a single sentence on batching and one example. Making the anti-pattern visible next to the good pattern is materially stronger, especially for a failure mode that repeats (the MoDA review ran 4–5 sequential treesit calls on the same path, each paying the full ~700ms scan cost).

## v2.2.1 changes

One edit inside step 2:

```diff
-When you do drill, BATCH queries in one call — each extra query adds
-~0ms, separate invocations re-scan from scratch:
-
-```bash
-$PYTHON $TREESIT /tmp/$REPO --path=SUBDIR --detail=full \
-  'find:*Handler*:function' 'source:main' 'refs:Config'
-```
+**When you do drill, batch queries in one invocation.** Every treesit
+call pays the full scan cost. Multiple queries added to the same command
+share that scan and each additional query adds ~0ms. If you're about to
+make a second treesit call on the same path, fold it into the first.
+
+```bash
+# GOOD — one scan, three answers
+$PYTHON $TREESIT /tmp/$REPO --path=SUBDIR --detail=full \
+  'find:*Handler*:function' 'source:main' 'refs:Config'
+
+# BAD — three scans, three answers (3× the cost for the same information)
+$PYTHON $TREESIT /tmp/$REPO --path=SUBDIR --detail=full
+$PYTHON $TREESIT /tmp/$REPO 'find:*Handler*:function'
+$PYTHON $TREESIT /tmp/$REPO 'refs:Config'
+```
```

Version: `2.2.0` → `2.2.1`.

Phrasing credit: #559 (closed as superseded).
