### PR TITLE
uploading-files v0.1.1: add README

### DIFF
--- a/uploading-files/CHANGELOG.md
+++ b/uploading-files/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `uploading-files` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1] - 2026-04-20
+
+### Added
+
+- README.md with skill description
+
 ## [0.1.0] - 2026-04-20
 
 ### Other

--- a/uploading-files/README.md
+++ b/uploading-files/README.md
@@ -1,0 +1,3 @@
+# uploading-files
+
+File-upload bridge for Claude Code on the Web. CCotw has no native file mount; this skill creates a throwaway GitHub branch the user can drop files onto via the github.com web UI, then fetches them locally on the next turn. Use when the user wants to upload, share, or send files into the session, or when a task clearly needs files the user has on disk that aren't in the repo.

--- a/uploading-files/SKILL.md
+++ b/uploading-files/SKILL.md
@@ -2,7 +2,7 @@
 name: uploading-files
 description: File-upload bridge for Claude Code on the Web. CCotw has no native file mount; this skill creates a throwaway GitHub branch the user can drop files onto via the github.com web UI, then fetches them locally on the next turn. Use when the user wants to upload, share, or send files into the session, or when a task clearly needs files the user has on disk that aren't in the repo.
 metadata:
-  version: 0.1.0
+  version: 0.1.1
 ---
 
 # Uploading Files


### PR DESCRIPTION
## Summary

- Add `uploading-files/README.md` matching the sibling-skill convention (top-line name + description from SKILL.md frontmatter).
- Bump `metadata.version` 0.1.0 → 0.1.1.
- Record the change in `uploading-files/CHANGELOG.md`.

## Test plan

- [ ] Confirm README renders on github.com with the skill description.
- [ ] Confirm version bump triggers a release on merge.

https://claude.ai/code/session_01U2Z2cVoUZYsd9Tsz4k5cvJ