### PR TITLE
tree-sitting: show line ranges in sparse/normal tree overviews

### DIFF
--- a/tree-sitting/CHANGELOG.md
+++ b/tree-sitting/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `tree-sitting` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0] - 2026-04-21
+
+### Added
+
+- Tree overview now shows `:start-end` line ranges per symbol in `sparse` and `normal` detail levels, not just `full`. The default orientation output (used by `exploring-codebases` step 2) becomes actionable: pick a symbol's line window and feed it directly to `Read` via `offset`/`limit` without a second treesit call.
+
 ## [0.3.0] - 2026-04-08
 
 ### Added

--- a/tree-sitting/SKILL.md
+++ b/tree-sitting/SKILL.md
@@ -2,7 +2,7 @@
 name: tree-sitting
 description: AST-powered code navigation via tree-sitter. Auto-scans codebases and provides progressive-disclosure tree views with symbol search, source retrieval, and reference finding. Each invocation is self-contained — no cross-process state. Use when exploring unfamiliar repos, navigating code, or needing fast symbol lookup. Triggers on "map this codebase", "explore repo", "find symbol", "navigate code", "tree-sitter", or when starting work on an unfamiliar repository.
 metadata:
-  version: 0.3.0
+  version: 0.4.0
 ---
 
 # tree-sitting
@@ -56,11 +56,14 @@ TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
 
 ### Detail Levels
 
-| Level | Per-node output | Use case |
-|-------|----------------|----------|
-| `sparse` | `name (kind) :lines` | featuring: see the full shape |
-| `normal` | `name(kind_initial)` per file (compact) | exploring: quick orientation |
-| `full` | signature + doc + children + imports | exploring: deep dive into a directory |
+All levels include line ranges (`:start-end`) so you can feed the
+window straight into `Read --offset/--limit` without another scan.
+
+| Level | Tree-overview row (per file) | Use case |
+|-------|------------------------------|----------|
+| `sparse` | `file: name:1-10, Other:30-90 +3` | featuring: see the full shape |
+| `normal` | `file: name(f):1-10, Other(c):30-90 +3` | exploring: quick orientation |
+| `full` | full per-symbol formatter + children + imports | exploring: deep dive into a directory |
 
 ### Queries
 

--- a/tree-sitting/scripts/treesit.py
+++ b/tree-sitting/scripts/treesit.py
@@ -29,10 +29,10 @@ Queries:
 
 No queries = tree overview only.
 
-Detail levels:
-    sparse  — name (kind) :lines                    [featuring: complete shape]
-    normal  — name (kind) signature :lines — doc     [exploring: orientation]
-    full    — normal + children + imports per file    [exploring: deep dive]
+Detail levels (tree overview rows show per-file symbol lists with line ranges):
+    sparse  — name:start-end                         [featuring: complete shape]
+    normal  — name(kind_initial):start-end            [exploring: orientation]
+    full    — per-symbol formatter + children + imports [exploring: deep dive]
 """
 
 import sys
@@ -159,7 +159,7 @@ def tree_overview(cache, depth, detail, scope_path=''):
             for entry in info['files']:
                 fname = os.path.basename(entry.path)
                 sym_summary = ', '.join(
-                    f"{s.name}({s.kind[0]})" for s in entry.symbols[:6]
+                    f"{s.name}({s.kind[0]}):{s.line}-{s.end_line}" for s in entry.symbols[:6]
                 )
                 if len(entry.symbols) > 6:
                     sym_summary += f' +{len(entry.symbols) - 6}'
@@ -167,7 +167,7 @@ def tree_overview(cache, depth, detail, scope_path=''):
         else:  # sparse
             for entry in info['files']:
                 fname = os.path.basename(entry.path)
-                sym_names = ', '.join(s.name for s in entry.symbols[:8])
+                sym_names = ', '.join(f"{s.name}:{s.line}-{s.end_line}" for s in entry.symbols[:8])
                 if len(entry.symbols) > 8:
                     sym_names += f' +{len(entry.symbols) - 8}'
                 lines.append(f"{dir_indent}  {fname}: {sym_names}" if sym_names else f"{dir_indent}  {fname}")


### PR DESCRIPTION
## Summary

Previously only `--detail=full` included `:start-end` line ranges per symbol in tree overviews. `sparse` and `normal` — the latter being the default, and what `exploring-codebases` step 2 runs — collapsed to `name(k)` with no positional info. This forced a second treesit call whenever you wanted to `Read` a specific symbol, even though the engine already had the ranges in hand.

### Before / After

Default (`--detail=normal`), for `tree-sitting/scripts/treesit.py`:

**Before:**
```
treesit.py: find_engine(f), format_symbol_sparse(f), format_symbol_normal(f), format_symbol_full(f), tree_overview(f), run_query(f) +1
```

**After:**
```
treesit.py: find_engine(f):44-55, format_symbol_sparse(f):58-60, format_symbol_normal(f):63-71, format_symbol_full(f):74-79, tree_overview(f):89-220, run_query(f):223-301 +1
```

Now the orientation output is actionable: pick a symbol's window and feed it straight into `Read` via `offset`/`limit`.

## Changes

- `tree-sitting/scripts/treesit.py`: append `:line-end_line` to each symbol entry in the `normal` and `sparse` branches of `tree_overview()`. `full` unchanged (it already used `format_symbol_*` which carried ranges).
- `tree-sitting/SKILL.md`: version bump `0.3.0 → 0.4.0`, updated Detail Levels table to show the new row format.
- `tree-sitting/CHANGELOG.md`: new `[0.4.0]` entry.
- Docstring in `treesit.py` updated to match.

## Test plan

- [x] Run `tests/test_engine.py` — 27/27 pass
- [x] Manual `treesit.py --detail=sparse` on the skills repo — ranges present
- [x] Manual `treesit.py --detail=normal` on the skills repo — ranges present
- [x] Manual `treesit.py --detail=full` on the skills repo — unchanged output