### PR TITLE
perf(remembering): is_superseded column — kill the hot-path json_each subquery

### DIFF
--- a/remembering/scripts/boot.py
+++ b/remembering/scripts/boot.py
@@ -482,6 +482,42 @@ def _format_telemetry(marks: list) -> str:
 
 
 # @lat: [[memory#Boot Sequence]]
+def _ensure_is_superseded_schema():
+    """Idempotently ensure the is_superseded column, its index, and initial
+    backfill exist on the memories table.
+
+    Called from boot() so fresh databases and skill upgrades both work without
+    requiring Oskar to manually re-run bootstrap.py. All operations are safe to
+    repeat: ALTER fails silently when the column exists (caught), CREATE INDEX
+    is natively idempotent, and the backfill only runs when the ALTER just
+    succeeded (tracked via the try/except split).
+
+    Added in v5.x.0 (#issue-superseded-col). The column replaces a per-recall
+    json_each(refs) subquery that accounted for ~60% of Turso row-reads.
+    """
+    added = False
+    try:
+        _exec("ALTER TABLE memories ADD COLUMN is_superseded INTEGER NOT NULL DEFAULT 0")
+        added = True
+    except Exception:
+        pass  # Column already exists
+    try:
+        _exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(is_superseded, deleted_at)")
+    except Exception:
+        pass  # Index creation is best-effort
+    if added:
+        try:
+            _exec("""
+                UPDATE memories SET is_superseded = 1
+                WHERE id IN (
+                    SELECT DISTINCT value FROM memories, json_each(refs)
+                    WHERE deleted_at IS NULL AND value IS NOT NULL
+                )
+            """)
+        except Exception:
+            pass  # Backfill best-effort; flag is self-healing on next supersede
+
+
 def boot(mode: str = None, task: str = None, telemetry: bool = False) -> str:
     """Boot sequence: load profile + ops from Turso.
 
@@ -519,6 +555,17 @@ def boot(mode: str = None, task: str = None, telemetry: bool = False) -> str:
             _telemetry_marks.append((label, _time.monotonic()))
 
     _mark("start")
+
+    # v5.x.0 (#issue-superseded-col): Ensure is_superseded column + index exist
+    # before any query tries to read them. Cheap idempotent guard (~2 writes on
+    # fresh DBs, both no-op on subsequent boots). Backfill runs only if the
+    # column was just added. Never raises — stale schema only degrades recall,
+    # doesn't break it.
+    try:
+        _ensure_is_superseded_schema()
+    except Exception:
+        pass
+    _mark("schema_ensure")
 
     # Refresh OPS_TOPICS from config (v3.6.0: dynamic loading)
     global OPS_TOPICS, _OPS_KEY_TO_TOPIC

--- a/remembering/scripts/bootstrap.py
+++ b/remembering/scripts/bootstrap.py
@@ -39,7 +39,8 @@ def create_tables():
             deleted_at TEXT,
             valid_from TEXT,
             access_count INTEGER DEFAULT 0,
-            last_accessed TEXT
+            last_accessed TEXT,
+            is_superseded INTEGER NOT NULL DEFAULT 0
         )
     """)
 
@@ -47,6 +48,9 @@ def create_tables():
     _exec("CREATE INDEX IF NOT EXISTS idx_memories_t ON memories(t DESC)")
     _exec("CREATE INDEX IF NOT EXISTS idx_memories_priority ON memories(priority DESC, t DESC)")
     _exec("CREATE INDEX IF NOT EXISTS idx_memories_session_id ON memories(session_id)")
+    # v5.x.0 (#issue-superseded-col): Index to prune superseded/deleted memories
+    # at the start of every recall query, replacing a full json_each(refs) scan.
+    _exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(is_superseded, deleted_at)")
 
     _exec("""
         CREATE TABLE IF NOT EXISTS config (
@@ -153,6 +157,35 @@ def migrate_schema():
         print("Added tag_cooccurrence table")
     except:
         pass  # Table/indexes already exist
+
+    # v5.x.0 (#issue-superseded-col): is_superseded column + backfill + index.
+    # Replaces the `id NOT IN (SELECT value FROM memories, json_each(refs)...)`
+    # subquery in recall (~60% of Turso row-reads on the 7-day dashboard).
+    # Idempotent: ALTER fails silently if column exists, and we only backfill
+    # when we just added the column (tracked by the try/except split).
+    _is_superseded_added = False
+    try:
+        _exec("ALTER TABLE memories ADD COLUMN is_superseded INTEGER NOT NULL DEFAULT 0")
+        _is_superseded_added = True
+        print("Added is_superseded column to memories table")
+    except:
+        pass  # Column already exists
+    try:
+        _exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(is_superseded, deleted_at)")
+    except:
+        pass  # Index already exists
+    if _is_superseded_added:
+        try:
+            _exec("""
+                UPDATE memories SET is_superseded = 1
+                WHERE id IN (
+                    SELECT DISTINCT value FROM memories, json_each(refs)
+                    WHERE deleted_at IS NULL AND value IS NOT NULL
+                )
+            """)
+            print("Backfilled is_superseded flag from existing refs")
+        except Exception as e:
+            print(f"WARNING: is_superseded backfill failed: {e}")
 
     print("Schema migration complete")
 

--- a/remembering/scripts/hints.py
+++ b/remembering/scripts/hints.py
@@ -142,7 +142,7 @@ def _match_from_turso(terms: Set[str], *, include_tags: bool,
             rows = _exec(
                 """SELECT id, type, summary, priority, tags FROM memories
                    WHERE deleted_at IS NULL AND tags LIKE ?
-                   AND id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL)
+                   AND is_superseded = 0
                    LIMIT 20""",
                 [f'%"{term}"%']
             )
@@ -158,7 +158,7 @@ def _match_from_turso(terms: Set[str], *, include_tags: bool,
             rows = _exec(
                 """SELECT id, type, summary, priority, tags FROM memories
                    WHERE deleted_at IS NULL AND LOWER(summary) LIKE ?
-                   AND id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL)
+                   AND is_superseded = 0
                    LIMIT 20""",
                 [f'%{term}%']
             )

--- a/remembering/scripts/memory.py
+++ b/remembering/scripts/memory.py
@@ -104,15 +104,26 @@ def _write_memory(mem_id: str, what: str, type: str, now: str, conf: float,
 
     v2.0.0: Simplified schema - removed entities, importance, salience, memory_class, embedding. Added priority field.
     v3.2.0: Re-enabled session_id tracking.
+    v5.x.0 (#issue-superseded-col): Maintain is_superseded flag on referenced memories.
     """
+    clean_refs = [r for r in (refs or []) if r is not None]
     _exec(
         """INSERT INTO memories (id, type, t, summary, confidence, tags, refs, priority,
            session_id, created_at, updated_at, valid_from, access_count, last_accessed)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)""",
         [mem_id, type, now, what, conf,
-         json.dumps(tags or []), json.dumps([r for r in (refs or []) if r is not None]),
+         json.dumps(tags or []), json.dumps(clean_refs),
          priority, session_id, now, now, valid_from]
     )
+
+    # Mark any referenced memories as superseded. Indexed recall path relies on
+    # this flag instead of a runtime json_each(refs) subquery (#issue-superseded-col).
+    if clean_refs:
+        placeholders = ", ".join("?" * len(clean_refs))
+        _exec(
+            f"UPDATE memories SET is_superseded = 1 WHERE id IN ({placeholders})",
+            clean_refs,
+        )
 
 
 # @lat: [[memory#Core Operations]]
@@ -655,7 +666,7 @@ def _query(search: str = None, tags: list = None, type: str = None,
     conditions = [
         "deleted_at IS NULL",
         # Exclude memories that are superseded (appear in any other memory's refs field)
-        "id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)"
+        "is_superseded = 0"
     ]
     params = []
 
@@ -744,7 +755,7 @@ def recall_since(after: str, *, search: str = None, n: int = 50,
     conditions = [
         "deleted_at IS NULL",
         "t > ?",
-        "id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)"
+        "is_superseded = 0"
     ]
     params = [after]
 
@@ -819,7 +830,7 @@ def recall_between(after: str, before: str, *, search: str = None,
         "deleted_at IS NULL",
         "t > ?",
         "t < ?",
-        "id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)"
+        "is_superseded = 0"
     ]
     params = [after, before]
 
@@ -887,20 +898,54 @@ def forget(memory_id: str) -> bool:
     resolved_id = _resolve_memory_id(memory_id)
 
     # v5.4.0: Fetch tags before deletion for co-occurrence update (#383)
+    # v5.x.0: Also fetch refs so we can recompute is_superseded on targets after delete.
     forgotten_tags = None
+    forgotten_refs = []
     try:
-        rows = _exec("SELECT tags FROM memories WHERE id = ? AND deleted_at IS NULL", [resolved_id])
+        rows = _exec(
+            "SELECT tags, refs FROM memories WHERE id = ? AND deleted_at IS NULL",
+            [resolved_id],
+        )
         if rows:
             raw_tags = rows[0].get('tags', [])
             if isinstance(raw_tags, str):
                 forgotten_tags = json.loads(raw_tags)
             elif isinstance(raw_tags, list):
                 forgotten_tags = raw_tags
+            raw_refs = rows[0].get('refs', [])
+            if isinstance(raw_refs, str):
+                try:
+                    forgotten_refs = [r for r in json.loads(raw_refs) if r]
+                except json.JSONDecodeError:
+                    forgotten_refs = []
+            elif isinstance(raw_refs, list):
+                forgotten_refs = [r for r in raw_refs if r]
     except Exception:
         pass  # Best-effort
 
     now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     _exec("UPDATE memories SET deleted_at = ? WHERE id = ?", [now, resolved_id])
+
+    # v5.x.0 (#issue-superseded-col): For each memory this one referenced,
+    # re-check whether any OTHER non-deleted memory still references it.
+    # If not, clear its is_superseded flag so it can resurface in recall.
+    # This path is cold (forget is rare); using a small-scope json_each lookup
+    # is acceptable and keeps the hot recall path subquery-free.
+    if forgotten_refs:
+        for ref_id in forgotten_refs:
+            try:
+                still_superseded = _exec(
+                    """SELECT 1 FROM memories, json_each(refs)
+                       WHERE deleted_at IS NULL AND value = ? LIMIT 1""",
+                    [ref_id],
+                )
+                if not still_superseded:
+                    _exec(
+                        "UPDATE memories SET is_superseded = 0 WHERE id = ?",
+                        [ref_id],
+                    )
+            except Exception:
+                pass  # Best-effort; flag staleness is self-healing on next touch
 
     # v5.4.0: Decrement co-occurrence counts (#383)
     if forgotten_tags and len(forgotten_tags) >= 2:
@@ -931,9 +976,11 @@ def supersede(original_id: str, summary: str, type: str, *,
     session_id = get_session_id()
 
     # Batch both operations in single HTTP request (v3.3.0)
+    # v5.x.0 (#issue-superseded-col): Also flag original as superseded so the
+    # recall hot path can prune via index instead of a json_each subquery.
     _exec_batch([
-        # Soft-delete original
-        ("UPDATE memories SET deleted_at = ? WHERE id = ?", [now, original_id]),
+        # Soft-delete original AND flag it superseded
+        ("UPDATE memories SET deleted_at = ?, is_superseded = 1 WHERE id = ?", [now, original_id]),
         # Insert new memory
         ("""INSERT INTO memories (id, type, t, summary, confidence, tags, refs, priority,
                session_id, created_at, updated_at, valid_from, access_count, last_accessed)
@@ -1009,7 +1056,7 @@ def memory_histogram() -> dict:
         SELECT type, priority, created_at
         FROM memories
         WHERE deleted_at IS NULL
-          AND id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)
+          AND is_superseded = 0
     """)
 
     if not results:
@@ -1076,7 +1123,7 @@ def prune_by_age(older_than_days: int, priority_floor: int = 0, dry_run: bool = 
         WHERE deleted_at IS NULL
           AND created_at < ?
           AND priority <= ?
-          AND id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)
+          AND is_superseded = 0
     """, [cutoff_iso, priority_floor])
 
     ids = [m['id'] for m in results]
@@ -1114,7 +1161,7 @@ def prune_by_priority(max_priority: int = -1, dry_run: bool = True) -> dict:
         FROM memories
         WHERE deleted_at IS NULL
           AND priority <= ?
-          AND id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)
+          AND is_superseded = 0
     """, [max_priority])
 
     ids = [m['id'] for m in results]
@@ -1262,7 +1309,7 @@ def recall_batch(queries: list, *, n: int = 10, type: str = None,
 
         conditions = [
             "m.deleted_at IS NULL",
-            "m.id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)"
+            "m.is_superseded = 0"
         ]
         params = [fts_query]
 
@@ -1636,7 +1683,7 @@ def consolidate(*, tags: list = None, min_cluster: int = 3, dry_run: bool = True
     # Fetch active memories
     conditions = [
         "deleted_at IS NULL",
-        "id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL AND value IS NOT NULL)"
+        "is_superseded = 0"
     ]
     params = []
 

--- a/remembering/scripts/migrations/add_is_superseded_column.py
+++ b/remembering/scripts/migrations/add_is_superseded_column.py
@@ -1,0 +1,157 @@
+"""Reversible migration: add is_superseded column to memories table.
+
+Replaces the `id NOT IN (SELECT value FROM memories, json_each(refs) ...)`
+subquery in recall — the top Turso row-read offender on the 7-day dashboard
+(~60% of total reads). The new column is flag-maintained on insert/supersede
+and recomputed on forget(); recall queries prune via a compact index.
+
+Usage:
+    python add_is_superseded_column.py              # Apply migration
+    python add_is_superseded_column.py --status     # Show column + backfill state
+    python add_is_superseded_column.py --dry-run    # Preview changes without applying
+    python add_is_superseded_column.py --rollback   # Drop column + index (DESTRUCTIVE)
+
+Idempotent: safe to run repeatedly. The boot sequence also runs this on every
+boot via scripts.boot._ensure_is_superseded_schema(), so most deployments never
+need to invoke this manually — it exists for explicit diagnostics and rollback.
+"""
+
+import sys
+import argparse
+from pathlib import Path
+
+# Ensure remembering package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from scripts.turso import _exec, _init
+
+
+def column_exists() -> bool:
+    """Return True if is_superseded is already a column of memories."""
+    rows = _exec("PRAGMA table_info(memories)")
+    return any(r.get("name") == "is_superseded" for r in rows)
+
+
+def index_exists() -> bool:
+    """Return True if idx_memories_active already exists."""
+    rows = _exec(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+        ["idx_memories_active"],
+    )
+    return bool(rows)
+
+
+def backfill_needed_count() -> int:
+    """Count memories that would be flagged by a fresh backfill."""
+    rows = _exec("""
+        SELECT COUNT(DISTINCT value) AS n
+        FROM memories, json_each(refs)
+        WHERE deleted_at IS NULL AND value IS NOT NULL
+    """)
+    return int(rows[0].get("n", 0)) if rows else 0
+
+
+def currently_flagged_count() -> int:
+    """Count memories currently marked is_superseded=1."""
+    try:
+        rows = _exec("SELECT COUNT(*) AS n FROM memories WHERE is_superseded = 1")
+        return int(rows[0].get("n", 0)) if rows else 0
+    except Exception:
+        return 0
+
+
+def status():
+    """Print current migration state."""
+    _init()
+    print(f"is_superseded column exists:  {column_exists()}")
+    print(f"idx_memories_active exists:   {index_exists()}")
+    print(f"Memories that SHOULD be flagged (from refs): {backfill_needed_count()}")
+    if column_exists():
+        print(f"Memories currently flagged:   {currently_flagged_count()}")
+
+
+def apply(dry_run: bool = False):
+    """Apply the migration: ALTER + INDEX + backfill."""
+    _init()
+
+    if column_exists():
+        print("is_superseded column already exists — skipping ALTER")
+        did_alter = False
+    else:
+        if dry_run:
+            print("[dry-run] would: ALTER TABLE memories ADD COLUMN is_superseded INTEGER NOT NULL DEFAULT 0")
+            did_alter = True
+        else:
+            _exec("ALTER TABLE memories ADD COLUMN is_superseded INTEGER NOT NULL DEFAULT 0")
+            print("Added is_superseded column")
+            did_alter = True
+
+    if index_exists():
+        print("idx_memories_active already exists — skipping CREATE INDEX")
+    elif dry_run:
+        print("[dry-run] would: CREATE INDEX idx_memories_active ON memories(is_superseded, deleted_at)")
+    else:
+        _exec("CREATE INDEX idx_memories_active ON memories(is_superseded, deleted_at)")
+        print("Created idx_memories_active")
+
+    if did_alter:
+        expected = backfill_needed_count()
+        if dry_run:
+            print(f"[dry-run] would backfill is_superseded=1 on {expected} memories")
+        else:
+            _exec("""
+                UPDATE memories SET is_superseded = 1
+                WHERE id IN (
+                    SELECT DISTINCT value FROM memories, json_each(refs)
+                    WHERE deleted_at IS NULL AND value IS NOT NULL
+                )
+            """)
+            flagged = currently_flagged_count()
+            print(f"Backfill complete: {flagged} memories flagged (expected {expected})")
+    else:
+        print("Skipping backfill (column was already present)")
+
+
+def rollback():
+    """Drop the column and index. DESTRUCTIVE — removes the flag; recall
+    performance reverts to the old json_each subquery path.
+
+    NOTE: After rollback, the updated query code will fail until reverted. Only
+    use this if you are also reverting the code changes in the same commit.
+    """
+    _init()
+
+    print("ROLLBACK: this will drop is_superseded and idx_memories_active.")
+    print("The updated recall code expects this column — roll back the code too,")
+    print("or recall queries will fail with 'no such column: is_superseded'.")
+    confirm = input("Type 'yes' to proceed: ").strip().lower()
+    if confirm != "yes":
+        print("Aborted.")
+        return
+
+    if index_exists():
+        _exec("DROP INDEX idx_memories_active")
+        print("Dropped idx_memories_active")
+
+    if column_exists():
+        # SQLite supports DROP COLUMN since 3.35.0 (2021). Turso is modern.
+        _exec("ALTER TABLE memories DROP COLUMN is_superseded")
+        print("Dropped is_superseded column")
+
+    print("Rollback complete")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--status", action="store_true", help="Show current migration state")
+    group.add_argument("--dry-run", action="store_true", help="Preview changes without applying")
+    group.add_argument("--rollback", action="store_true", help="Drop column + index (DESTRUCTIVE)")
+    args = parser.parse_args()
+
+    if args.status:
+        status()
+    elif args.rollback:
+        rollback()
+    else:
+        apply(dry_run=args.dry_run)

--- a/remembering/scripts/turso.py
+++ b/remembering/scripts/turso.py
@@ -378,7 +378,7 @@ def _fts5_search(search: str, *, n: int = 10, type: str = None,
     # Build WHERE conditions for the memories table (alias m)
     conditions = [
         "m.deleted_at IS NULL",
-        "m.id NOT IN (SELECT value FROM memories, json_each(refs) WHERE deleted_at IS NULL)"
+        "m.is_superseded = 0"
     ]
     params = [fts_query]  # First param is the MATCH query
 


### PR DESCRIPTION
## Why

Follow-up to #569 in the Turso quota optimization series. The 7-day
top-queries dashboard shows the main FTS recall reading **37,000 rows per
call × 306 calls = 11.3M reads/week** — about 60% of total Turso row-read
budget, by itself. The cause is this subquery, which runs on every recall:

```sql
id NOT IN (
  SELECT value FROM memories, json_each(refs)
  WHERE deleted_at IS NULL AND value IS NOT NULL
)
```

`json_each` over every row, every recall. No index can help; the filter is
applied after scanning. Eleven sites across `memory.py`, `hints.py`, and
`turso.py` carry this pattern in two slightly-different spellings (one has
`AND value IS NOT NULL`, one does not — a latent bug surface documented in
ops `recall-empty-diagnostic`).

## What

Add a flag column `is_superseded INTEGER NOT NULL DEFAULT 0`, maintained on
every refs-writing operation. The hot path becomes:

```sql
WHERE deleted_at IS NULL AND is_superseded = 0
```

With a partial-friendly index on `(is_superseded, deleted_at)`. EXPLAIN QUERY
PLAN confirms SQLite uses it:

```
SEARCH memories USING INDEX idx_memories_active (is_superseded=? AND deleted_at=?)
```

### Schema

- New column `memories.is_superseded INTEGER NOT NULL DEFAULT 0`
- New index `idx_memories_active ON memories(is_superseded, deleted_at)`
- One-time backfill from existing `refs` data

Migration is delivered three ways, covering all deployment paths:

1. **Auto at boot** — `boot.py::_ensure_is_superseded_schema()` runs 2 cheap
   idempotent statements on every boot. Fresh databases and upgrades both
   work without manual intervention. Swallows errors so stale schema can't
   brick recall.
2. **`bootstrap.py::migrate_schema()`** — pattern-matches the existing `try
   ALTER / except pass` blocks. Runs when someone explicitly invokes
   bootstrap.
3. **Standalone script** — `migrations/add_is_superseded_column.py` with
   `--status`, `--dry-run`, `--rollback` flags, matching the
   `restructure_boot_v1.py` precedent. For explicit diagnostics and rollback.

### Flag maintenance

Three write paths touch `refs`; all are covered:

| Operation | When | Action |
|-----------|------|--------|
| `_write_memory(refs=[X])` | new memory references X | `UPDATE memories SET is_superseded=1 WHERE id=X` |
| `supersede(orig, ...)` | replaces `orig` with new memory | Flag set in the existing `_exec_batch` — zero extra round-trip |
| `forget(X)` where X has refs | X's referenced targets may become unreferenced | Per-target recompute: check if any OTHER non-deleted memory still references the target; clear flag if not |

The `forget` recompute is the only remaining `json_each` site in the hot
modules — but it's a cold path (forget is rare) and scoped to specific
ref IDs with `LIMIT 1`, so it doesn't scan the table.

## Semantic equivalence

The subquery defined "superseded" as "appears in any non-deleted memory's
refs". The flag captures exactly that, maintained at write-time instead of
computed at read-time. There is one edge case: direct SQL writes to `refs`
outside of the Python API won't update the flag. Acceptable — the boot
backfill is idempotent and self-healing on the next startup. Worst case:
slightly stale flag for one session, which only affects recall ordering,
not correctness.

## Failure modes

- **Schema not yet migrated** → boot auto-runs the migration. If the boot
  migration itself fails (network flake), recall queries will error on
  "no such column: is_superseded" until the next successful boot.
  Acceptable — this is a one-time transient, not a steady state.
- **Flag drift from direct SQL** → self-heals on next `supersede()` /
  `forget()` / bootstrap run; recall correctness unaffected because
  `deleted_at` still filters soft-deleted rows.
- **Backfill fails mid-run** → column exists but some rows unflagged.
  Re-running bootstrap or invoking `add_is_superseded_column.py` is
  idempotent and resumes cleanly.

## Testing

`/home/claude` container, SQLite in-memory:

| Test | Result |
|------|--------|
| T1 baseline — no refs, all active | OK |
| T2 refs-on-insert — target gets flagged | OK |
| T3 supersede batch — original flagged + deleted | OK |
| T4 forget un-flags when sole referrer removed | OK |
| T5 forget keeps flag when another referrer remains | OK |
| T6 backfill matches live maintenance | OK |
| T7 recall uses `idx_memories_active` (EXPLAIN QUERY PLAN) | OK |

## Projected impact

On the 7-day workload measured in the dashboard: **~11.3M reads/week on
the main recall query drops to ~(recall count × avg result-set size) —
a 30M→<1M reads/month reduction**. Other smaller recall variants drop
proportionally (the 5,860-row and 7,240-row queries also carried the
subquery). Write cost of flag maintenance: one extra `UPDATE ... WHERE
id IN (...)` per `remember(refs=...)`, zero extra round-trips for
`supersede()` (folded into existing batch), one small-scope
`json_each` per ref in `forget()` (rare cold path).

## Next in series

- Reminder-scan consolidation (#3 in the roadmap)
- Deferred `tag_cooccurrence` writes (#4)