### PR TITLE
finding-skills: on-demand skill catalog discovery (list / search / show)

### DIFF
--- a/finding-skills/SKILL.md
+++ b/finding-skills/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: finding-skills
+description: Discover and load skills on demand from /mnt/skills/user/. Use when you need a capability but don't know which skill provides it, when the boot-emitted skill list is names-only and you need a full description, or when you want to list the catalog. Verbs are list (names only), search (rank by name/description match against a query), and show (emit the full SKILL.md for a named skill).
+metadata:
+  version: 0.1.0
+---
+
+# Finding Skills
+
+Skills on disk at `/mnt/skills/user/` are a catalog — too expensive to preload as descriptions in every session's context. This skill is the on-demand accessor, analogous to Anthropic's ToolSearch for MCP tools.
+
+## Usage
+
+```bash
+PY=/home/user/.spokes/claude-skills/finding-skills/scripts/skills.py
+
+# List every skill by name (cheap, ~1.4KB)
+python3 "$PY" list
+
+# Search by keyword — ranks name matches above description matches
+python3 "$PY" search "adversarial review"
+
+# Load the full SKILL.md of a specific skill
+python3 "$PY" show challenging
+```
+
+In a live CCotw session the script lives at `/mnt/skills/user/finding-skills/scripts/skills.py`.
+
+## When to reach for this
+
+- You have a task where a skill might help but no obvious name comes to mind → `search <keywords>`
+- The boot emitted names-only and you want the description of a candidate → `show <name>`
+- You want catalog breadth before picking an approach → `list`
+
+## Pattern
+
+1. `search "<what you want to do>"` — get 3–10 ranked candidates
+2. `show <top-pick>` — read its SKILL.md
+3. Follow the SKILL.md's instructions (which may point at `scripts/`, `references/`, etc.)
+
+Stop at step 1 if none of the candidates fit — don't shoehorn an unrelated skill onto the task.
+
+## Ranking
+
+- Exact match on skill name: 100
+- Substring match on skill name: 10
+- Substring match in description: 1 per match (multiple hits compound)
+
+Case-insensitive throughout. Results sorted high-to-low, ties broken by name.
+
+## Output format
+
+- `list`: one skill name per line
+- `search`: tab-separated `<name>\t<description (truncated to 200 chars)>`, one per line
+- `show`: raw SKILL.md contents to stdout; exit 1 with a stderr message if not found
+
+All three are line-oriented so they compose with `grep`, `head`, etc.

--- a/finding-skills/scripts/skills.py
+++ b/finding-skills/scripts/skills.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""On-demand skill discovery over /mnt/skills/user/.
+
+Verbs:
+  list                    Print every skill name, one per line.
+  search <query>          Print ranked name+description matches (tab-separated).
+  show <name>             Print full SKILL.md for <name> to stdout.
+
+Exit codes:
+  0 success
+  1 skill not found (show)
+  2 invalid usage
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import signal
+import sys
+from typing import Iterator
+
+# Restore default SIGPIPE handling so piping into `head` etc. exits cleanly.
+if hasattr(signal, "SIGPIPE"):
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+SKILLS_DIR = pathlib.Path(os.environ.get("SKILLS_DIR", "/mnt/skills/user"))
+DESC_TRUNCATE = 200
+
+
+def _iter_skills() -> Iterator[tuple[str, pathlib.Path]]:
+    if not SKILLS_DIR.is_dir():
+        return
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        skill_md = entry / "SKILL.md"
+        if skill_md.is_file():
+            yield entry.name, skill_md
+
+
+def _parse_meta(path: pathlib.Path) -> tuple[str | None, str | None]:
+    """Return (name, description) from a SKILL.md's YAML frontmatter.
+
+    description may span multiple lines — we capture until the next
+    top-level YAML key or the closing '---'.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None, None
+
+    fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n", text, re.S)
+    if not fm_match:
+        return None, None
+    frontmatter = fm_match.group(1)
+
+    name = None
+    name_match = re.search(r"^name:\s*(.+)$", frontmatter, re.M)
+    if name_match:
+        name = name_match.group(1).strip()
+
+    desc = None
+    desc_match = re.search(
+        r"^description:\s*(.+?)(?=^\S|^\s*$)",
+        frontmatter,
+        re.M | re.S,
+    )
+    if desc_match:
+        desc = " ".join(desc_match.group(1).split())
+
+    return name, desc
+
+
+def cmd_list() -> int:
+    for name, _ in _iter_skills():
+        print(name)
+    return 0
+
+
+def cmd_search(query: str) -> int:
+    q = query.lower().strip()
+    if not q:
+        print("search: empty query", file=sys.stderr)
+        return 2
+
+    hits: list[tuple[int, str, str]] = []
+    for name, path in _iter_skills():
+        parsed_name, desc = _parse_meta(path)
+        display_name = parsed_name or name
+        score = 0
+        name_lower = name.lower()
+        if q == name_lower:
+            score += 100
+        elif q in name_lower:
+            score += 10
+        if desc:
+            score += desc.lower().count(q)
+        if score > 0:
+            hits.append((score, display_name, desc or ""))
+
+    hits.sort(key=lambda h: (-h[0], h[1]))
+    for _, display_name, desc in hits:
+        truncated = desc if len(desc) <= DESC_TRUNCATE else desc[:DESC_TRUNCATE] + "…"
+        print(f"{display_name}\t{truncated}")
+    return 0
+
+
+def cmd_show(name: str) -> int:
+    path = SKILLS_DIR / name / "SKILL.md"
+    if not path.is_file():
+        print(f"skill not found: {name}", file=sys.stderr)
+        return 1
+    sys.stdout.write(path.read_text(encoding="utf-8", errors="replace"))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    verb = argv[1]
+    rest = argv[2:]
+    if verb == "list" and not rest:
+        return cmd_list()
+    if verb == "search" and rest:
+        return cmd_search(" ".join(rest))
+    if verb == "show" and len(rest) == 1:
+        return cmd_show(rest[0])
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/lat.md/skill-lifecycle.md
+++ b/lat.md/skill-lifecycle.md
@@ -22,6 +22,12 @@ It handles path resolution and module registration. [[inspecting-skills/scripts/
 
 [[scripts/frontmatter_utils.py#parse_skill_md]] separates YAML frontmatter from markdown body in SKILL.md files. [[scripts/frontmatter_utils.py#write_skill_md]] reassembles them. [[scripts/frontmatter_utils.py#extract_version]] finds the version from frontmatter or legacy version files. These utilities serve both the registry and the migration script [[scripts/migrate-version-to-frontmatter.py#migrate_skill]].
 
+## On-Demand Discovery
+
+[[finding-skills/scripts/skills.py#cmd_list]], [[finding-skills/scripts/skills.py#cmd_search]], and [[finding-skills/scripts/skills.py#cmd_show]] expose the skill catalog as a CLI so contexts that can't afford to preload every SKILL.md frontmatter can still find and load skills. [[finding-skills/scripts/skills.py#_parse_meta]] extracts name + description from the YAML frontmatter; [[finding-skills/scripts/skills.py#_iter_skills]] walks `/mnt/skills/user/`.
+
+The search ranker scores exact name matches highest (100), substring name matches next (10), and description substring hits last (1 per occurrence). Analogous to Anthropic's ToolSearch for MCP tools, one layer up. Enables CCotw boot to emit names-only instead of full descriptions and still preserve skill awareness.
+
 ## Knowledge Skills
 
 Seventeen of ~60 skills contain only a SKILL.md with no scripts — the markdown IS the implementation.


### PR DESCRIPTION
## Problem

The CCotw boot emits `<available_skills>` XML with full descriptions for ~70 skills — ~35KB per session that mostly never fires. Preloading descriptive metadata is ToolSearch's exact anti-pattern: push when you should pull. The cost is paid every session; the benefit (description-match skill triggering) isn't actually showing up in usage.

## Fix

New meta-skill `finding-skills` with a tiny CLI:

- `python3 skills.py list` → names only, one per line (~1.2KB for the current catalog)
- `python3 skills.py search <query>` → ranked name + description matches (tab-separated `name\tdescription`)
- `python3 skills.py show <name>` → full SKILL.md

Ranker: exact name match 100, substring name match 10, +1 per description substring hit. Ties broken by name. SIGPIPE handled so `| head` etc. work cleanly.

## Follow-up (not in this PR)

`claude-workspace`'s `_output_skills()` in `boot-ccotw.sh` gets swapped to emit names-only + a pointer at this skill. That lands once this PR merges.

## Test

```bash
PY=/mnt/skills/user/finding-skills/scripts/skills.py
python3 $PY list | wc -l                 # → 71 (70 skills + finding-skills)
python3 $PY list | wc -c                 # → ~1200B
python3 $PY search adversarial           # → challenging at top
python3 $PY search memory | head -3      # → session-memory, remembering, ...
python3 $PY show challenging | head -5   # → frontmatter
python3 $PY show no-such                 # → stderr + exit 1
python3 $PY                              # → usage on stderr + exit 2
```

All verified locally against a cached `/mnt/skills/user/`. lat.md/skill-lifecycle.md updated with an "On-Demand Discovery" section linking the three verbs.