### PR TITLE
tree-sitting: drop tree_sitter_language_pack, load bundled .so directly (fixes #572)

### DIFF
--- a/tree-sitting/CHANGELOG.md
+++ b/tree-sitting/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `tree-sitting` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0] - 2026-04-23
+
+### Fixed
+
+- Drop `tree-sitter-language-pack` dependency (#572). The 1.6.x wheels install into `_native/` with no top-level package directory, making imports fail in Claude.ai containers. Even if the import is patched, the pack tries to download grammars at runtime from a domain outside the network allowlist. Grammars are now loaded directly from bundled `parsers/*.so` via `ctypes`, against the bare `tree-sitter` package (which installs cleanly). Setup is simpler (no venv) and install is ~1s.
+
+### Changed
+
+- Setup command is now `uv pip install --system --break-system-packages tree-sitter` — no venv required.
+- Supported-languages list narrowed to the 11 bundled grammars (Python, JavaScript, TypeScript, TSX, Go, Rust, Ruby, Java, C, HTML, Markdown). Previously advertised languages without bundled parsers silently returned empty before this change anyway; now they're documented honestly with instructions for adding a grammar.
+
 ## [0.4.0] - 2026-04-21
 
 ### Other

--- a/tree-sitting/README.md
+++ b/tree-sitting/README.md
@@ -9,11 +9,11 @@ AST-powered code navigation using tree-sitter. Parses all source files in a code
 - **Directory and file overview** — structural summaries with symbol counts, signatures, and doc comments
 - **Source retrieval** — fetch implementation of any symbol, preferring definitions over declarations
 - **Reference finding** — locate all textual references to a symbol via fast grep against cached source
-- **26 languages** — Python, JavaScript, TypeScript, Go, Rust, Ruby, Java, C, C++, C#, Swift, Kotlin, and more
+- **11 bundled grammars** — Python, JavaScript, TypeScript, TSX, Go, Rust, Ruby, Java, C, HTML, Markdown (extensible: drop more `.so` files in `parsers/`)
 - **Three-tier extraction** — custom extractors (richest), community tags.scm queries, and generic heuristic fallback
 - **Dual deployment** — direct Python calls in Claude.ai, or long-lived MCP server in Claude Code
 
 ## Dependencies
 
-- **tree-sitter-language-pack** — grammar bundles for all supported languages
+- **tree-sitter** — bare parser runtime, loads grammars from bundled `parsers/*.so`
 - **fastmcp** — required only for MCP server mode (Claude Code)

--- a/tree-sitting/SKILL.md
+++ b/tree-sitting/SKILL.md
@@ -2,7 +2,7 @@
 name: tree-sitting
 description: AST-powered code navigation via tree-sitter. Auto-scans codebases and provides progressive-disclosure tree views with symbol search, source retrieval, and reference finding. Each invocation is self-contained — no cross-process state. Use when exploring unfamiliar repos, navigating code, or needing fast symbol lookup. Triggers on "map this codebase", "explore repo", "find symbol", "navigate code", "tree-sitter", or when starting work on an unfamiliar repository.
 metadata:
-  version: 0.4.0
+  version: 0.5.0
 ---
 
 # tree-sitting
@@ -13,11 +13,11 @@ the codebase (~700ms for 250 files), then runs queries at sub-millisecond speed.
 ## Setup
 
 ```bash
-uv venv /home/claude/.venv 2>/dev/null
-uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
+uv pip install --system --break-system-packages tree-sitter
 ```
 
-Total install: <2s cold cache, <400ms warm.
+Grammars are loaded from bundled `parsers/*.so` files — no network fetch,
+no `tree-sitter-language-pack` dependency. Install is <1s.
 
 ## Usage: CLI (treesit.py)
 
@@ -28,19 +28,19 @@ No state to manage between calls.
 TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
 
 # Orient: root-level overview (default depth=1)
-/home/claude/.venv/bin/python $TREESIT /path/to/repo
+python3 $TREESIT /path/to/repo
 
 # Featuring: complete tree, minimal detail
-/home/claude/.venv/bin/python $TREESIT /path/to/repo --depth=-1 --detail=sparse
+python3 $TREESIT /path/to/repo --depth=-1 --detail=sparse
 
 # Explore a subdirectory in full detail
-/home/claude/.venv/bin/python $TREESIT /path/to/repo --path=src/core --detail=full
+python3 $TREESIT /path/to/repo --path=src/core --detail=full
 
 # Run queries (tree overview + query results)
-/home/claude/.venv/bin/python $TREESIT /path/to/repo 'find:Parser*' 'source:parse_input'
+python3 $TREESIT /path/to/repo 'find:Parser*' 'source:parse_input'
 
 # Queries only, no tree
-/home/claude/.venv/bin/python $TREESIT /path/to/repo --no-tree 'refs:AuthToken'
+python3 $TREESIT /path/to/repo --no-tree 'refs:AuthToken'
 ```
 
 ### Options
@@ -113,13 +113,20 @@ invocations loses the cache — use `treesit.py` instead.
 
 ## Supported Languages
 
-Python, JavaScript, TypeScript, TSX, Go, Rust, Ruby, Java, C, C++, C#, Swift, Kotlin, Scala, HTML, CSS, Markdown, JSON, YAML, TOML, Lua, Bash, Elisp, Zig, Elixir.
+Bundled grammars (work out of the box):
+**Python, JavaScript, TypeScript, TSX, Go, Rust, Ruby, Java, C, HTML, Markdown.**
 
-Three-tier extraction:
+Three-tier extraction for bundled languages:
 
 1. **Custom extractors** (richest — signatures, hierarchy, docstrings): Python, C, Go, Rust, JavaScript, TypeScript, TSX, Ruby, Markdown (heading outline)
-2. **tags.scm queries** (community-maintained — kinds, docs where grammars support it): Java, C++, C#
-3. **Generic heuristic** (names + kinds + locations): all others
+2. **tags.scm queries** (community-maintained — kinds, docs): Java
+3. **Generic heuristic** (names + kinds + locations): HTML and any future bundled grammars
+
+### Adding a grammar
+
+Files with unsupported extensions are silently skipped (they show as `SKIP (no parser)` with `--stats`). To add a grammar, drop a compiled `libtree_sitter_<lang>.so` into `parsers/` — the engine picks it up automatically on the next run. Build from the grammar's repo (each `tree-sitter/tree-sitter-<lang>` repo has a `src/` directory you can compile with `cc -shared -fPIC -I src src/parser.c src/scanner.c -o libtree_sitter_<lang>.so`, or use `tree-sitter build`).
+
+If you need a language urgently and can't build the `.so`, you can try installing `tree-sitter-language-pack` as a fallback (`uv pip install --system --break-system-packages tree-sitter-language-pack`) — but note its 1.6.x wheels have a broken install layout in some containers and try to download grammars at runtime from a domain that may not be in your network allowlist. Bundling the `.so` is the reliable path.
 
 ## What It Extracts
 

--- a/tree-sitting/scripts/engine.py
+++ b/tree-sitting/scripts/engine.py
@@ -11,43 +11,53 @@ from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional
 
-# Lazy import — tree-sitter installed at skill activation time
+# Lazy load — parsers loaded on demand from bundled .so files.
+# We deliberately do NOT depend on tree-sitter-language-pack: its 1.6.x
+# wheel layout is broken in the Claude.ai container (installs into
+# _native/ with no top-level package dir) AND it tries to download
+# grammars at runtime from a domain that isn't in the network allowlist.
+# The bundled parsers/*.so files are loaded directly via ctypes against
+# the bare `tree-sitter` package, which does install cleanly.
 _parsers: dict = {}
-_bootstrapped = False
+_PARSERS_DIR = Path(__file__).parent.parent / 'parsers'
 
 
-def _bootstrap_parsers():
-    """Ensure tree-sitter parsers are available.
+def _so_path(lang: str) -> Optional[Path]:
+    """Resolve a language name to its bundled .so path, or None if not bundled."""
+    # Grammar filenames follow libtree_sitter_<lang>.so and export a
+    # matching tree_sitter_<lang> symbol.
+    p = _PARSERS_DIR / f'libtree_sitter_{lang}.so'
+    return p if p.is_file() else None
 
-    In proxied environments (Claude.ai), tree-sitter-language-pack can't download
-    parsers due to SSL certificate issues. This copies bundled .so files from
-    the skill's parsers/ directory to the cache location.
+
+def _load_language(lang: str):
+    """Load a tree_sitter.Language from a bundled .so via ctypes.
+
+    Returns None if the grammar isn't bundled or loading fails.
     """
-    global _bootstrapped
-    if _bootstrapped:
-        return
-    _bootstrapped = True
+    so = _so_path(lang)
+    if so is None:
+        return None
 
     try:
-        from tree_sitter_language_pack import get_parser
-        get_parser('python')
-        return  # Already available
-    except Exception as e:
-        if 'Download error' not in str(e) and 'DownloadError' not in type(e).__name__:
-            raise
+        from ctypes import CDLL, c_void_p, c_char_p, py_object, pythonapi
+        from tree_sitter import Language
+    except ImportError:
+        return None
 
-    # Copy bundled parsers to cache
-    import shutil
-    from tree_sitter_language_pack import cache_dir
-    cache_libs = Path(cache_dir())
-    cache_libs.mkdir(parents=True, exist_ok=True)
-
-    bundled = Path(__file__).parent.parent / 'parsers'
-    if bundled.is_dir():
-        for so in bundled.glob('*.so'):
-            dest = cache_libs / so.name
-            if not dest.exists():
-                shutil.copy2(so, dest)
+    try:
+        lib = CDLL(str(so))
+        fn = getattr(lib, f'tree_sitter_{lang}')
+        fn.restype = c_void_p
+        # Wrap the language function's return value in a PyCapsule, which is
+        # the forward-compatible API for tree_sitter.Language in 0.23+.
+        # (Passing the raw int still works but emits a DeprecationWarning.)
+        pythonapi.PyCapsule_New.restype = py_object
+        pythonapi.PyCapsule_New.argtypes = [c_void_p, c_char_p, c_void_p]
+        capsule = pythonapi.PyCapsule_New(fn(), b"tree_sitter.Language", None)
+        return Language(capsule)
+    except Exception:
+        return None
 
 EXT_TO_LANG = {
     '.py': 'python', '.pyi': 'python',
@@ -122,14 +132,27 @@ class Symbol:
 
 
 def _get_parser(lang: str):
-    """Get or create a cached parser for the given language. Returns None if unavailable."""
+    """Get or create a cached parser for the given language.
+
+    Returns None if the grammar isn't bundled (or fails to load). Callers
+    handle None by skipping the file — the same behaviour the scan loop
+    already expects.
+    """
     if lang not in _parsers:
-        _bootstrap_parsers()
         try:
-            from tree_sitter_language_pack import get_parser
-            _parsers[lang] = get_parser(lang)
-        except Exception:
+            from tree_sitter import Parser
+        except ImportError:
             _parsers[lang] = None
+            return None
+
+        language = _load_language(lang)
+        if language is None:
+            _parsers[lang] = None
+        else:
+            try:
+                _parsers[lang] = Parser(language)
+            except Exception:
+                _parsers[lang] = None
     return _parsers[lang]
 
 

--- a/tree-sitting/tests/test_engine.py
+++ b/tree-sitting/tests/test_engine.py
@@ -13,20 +13,6 @@ from pathlib import Path
 # Bootstrap parsers before importing engine
 sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
 
-# If running in proxied environment, bootstrap from bundled parsers
-_parsers_dir = Path(__file__).parent.parent / 'parsers'
-if _parsers_dir.is_dir():
-    try:
-        from tree_sitter_language_pack import get_parser as _test, cache_dir
-        _test('python')
-    except Exception:
-        cache_libs = Path(cache_dir())
-        cache_libs.mkdir(parents=True, exist_ok=True)
-        for so in _parsers_dir.glob('*.so'):
-            dest = cache_libs / so.name
-            if not dest.exists():
-                shutil.copy2(so, dest)
-
 from engine import (
     Symbol, CodeCache, extract_symbols, extract_imports,
     _get_parser, _extract_via_tags, EXTRACTORS, TAGS_SCM,


### PR DESCRIPTION
Fixes #572.

## Root cause
`tree-sitter-language-pack` 1.6.x wheels install code into `site-packages/_native/` with no top-level package directory, so `from tree_sitter_language_pack import get_parser` raises `ModuleNotFoundError`. Even after a symlink workaround, the pack tries to download grammars at runtime from `github.com/kreuzberg-dev/tree-sitter-language-pack` — a domain not in the Claude.ai container's network allowlist.

## Fix
Drop `tree-sitter-language-pack` entirely. Load bundled `parsers/libtree_sitter_<lang>.so` files directly via `ctypes` + `tree_sitter.Language` (wrapped in a PyCapsule for forward-compat with tree-sitter 0.23+). The bare `tree-sitter` package installs cleanly from PyPI; the 11 bundled grammars cover the common-case languages (Python, JavaScript, TypeScript, TSX, Go, Rust, Ruby, Java, C, HTML, Markdown).

## Trade-off
Languages in `EXT_TO_LANG` without a bundled `.so` (cpp, c_sharp, kotlin, css, json, yaml, toml, lua, bash, elisp, zig, elixir, ...) now return `None` cleanly and their files are skipped. Before this PR they were *advertised* but also non-functional in practice — the pack couldn't download them either. The `Supported Languages` section in SKILL.md is now honest about what actually works, with instructions for adding a grammar by dropping a compiled `.so` into `parsers/`.

## Setup change
Before: `uv venv /home/claude/.venv && uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python`
After:  `uv pip install --system --break-system-packages tree-sitter`

No venv needed. Install is ~1s.

## Verified
- All 27 tests in `tests/test_engine.py` pass against the patched engine.
- End-to-end CLI smoke test: scan of the skill's own repo returns correct symbol index and hierarchy.
- Java `tags.scm` path still works (unchanged — `TAGS_SCM` dict is inline, never was a pack dependency).

## Files changed
- `tree-sitting/scripts/engine.py` — replace `_bootstrap_parsers` and `_get_parser` with direct ctypes loading; remove all `tree_sitter_language_pack` imports.
- `tree-sitting/tests/test_engine.py` — drop the obsolete bootstrap preamble that also imported the pack.
- `tree-sitting/SKILL.md` — updated Setup, version bump to 0.5.0, honest `Supported Languages` section with "Adding a grammar" escape hatch. CLI examples switched from `/home/claude/.venv/bin/python` to `python3`.
- `tree-sitting/README.md` — updated Dependencies and language claim (11 bundled, extensible).
- `tree-sitting/CHANGELOG.md` — 0.5.0 entry.