### PR TITLE
llm-as-computer: program specialization via partial evaluation (#576)

### DIFF
--- a/llm-as-computer/CHANGELOG.md
+++ b/llm-as-computer/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `llm-as-computer` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.0] - 2026-04-24
+
+### Added
+
+- `specialize.py`: Percepta-style partial-evaluation pass. Bakes a compiled
+  program into `2N` ReGLU step-function neurons + per-field coefficient
+  tables; fetched `(op, arg)` at any cursor is reconstructed from
+  `c0 + Σᵢ (cᵢ − cᵢ₋₁)·𝟙[cursor ≥ i]`, no program prefix required.
+- `runner.execute(..., specialize=True)` / `runner.run(..., specialize=True)`:
+  runs the specialized executor; traces match the universal interpreter
+  step-for-step (verified across countdown, fibonacci, factorial,
+  sum_1_to_n, power_of_2 and all 10 `ALL_TESTS` regression programs).
+- `programs.make_countdown(n)`: canonical specialization demo target.
+- `format_trace` now reports FFN neuron count and
+  `universal → specialized` prompt-token savings when `specialize=True`.
+
+### Notes
+
+- `executor.mojo` intentionally untouched: its fetch path is already direct
+  `List[Int]` indexing, so specialization offers no Mojo-runtime speedup.
+  The demonstration is architectural (programs-as-weights) and
+  prompt-size (#576).
+
 ## [1.0.1] - 2026-03-25
 
 ### Other

--- a/llm-as-computer/SKILL.md
+++ b/llm-as-computer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: llm-as-computer
-description: Execute programs on a compiled transformer stack machine where every instruction fetch and memory read is a parabolic attention head. Demonstrates that transformer attention + FF layers can implement a working computer. Use when user mentions "llm-as-computer", "lac", "stack machine", "compiled transformer", "percepta", "parabolic attention", "execute program", or asks to run/trace programs on the transformer executor.
+description: Execute programs on a compiled transformer stack machine where every instruction fetch and memory read is a parabolic attention head. Demonstrates that transformer attention + FF layers can implement a working computer, including Percepta-style program specialization that bakes compiled programs into FFN coefficient tables. Use when user mentions "llm-as-computer", "lac", "stack machine", "compiled transformer", "percepta", "parabolic attention", "specialization", "partial evaluation", "execute program", or asks to run/trace programs on the transformer executor.
 metadata:
-  version: 1.0.1
+  version: 1.1.0
   repo: oaustegard/llm-as-computer
 ---
 
@@ -65,6 +65,7 @@ From `programs.py` — all return `(program, expected_result)`:
 | `make_compare_binary(op,a,b)` | eq/ne/lt_s/gt_s/le_s/ge_s | |
 | `make_bitwise_binary(op,a,b)` | and/or/xor/shl/shr_u/rotl/rotr | |
 | `make_select(a,b,c)` | Conditional select | |
+| `make_countdown(n)` | Simplest loop; decrements counter to 0 | specialization demo target |
 
 ## Writing Custom Programs
 
@@ -114,6 +115,38 @@ sharply at a target position. Same encoding addresses program memory, stack, loc
 and heap without interference. Each attention head is a compiled `W_Q @ state → query`,
 `W_K @ memory → keys`, `scores = K @ q`, `output = V[argmax(scores)]`.
 
+## Program Specialization (Partial Evaluation)
+
+Mirrors Percepta's partial-evaluation pass
+([blog](https://www.percepta.ai/blog/constructing-llm-computer)): for a program of N
+instructions, bake the program table into `2N` ReGLU step-function neurons plus
+per-field coefficient vectors. At deployment the prompt shrinks from
+`(program || input)` to `(input)` alone; fetched opcode/arg become a linear
+combination of the `1[cursor ≥ i]` indicators.
+
+```python
+from specialize import specialize, verify_fetch_parity
+from programs import make_countdown
+from runner import run
+
+prog, _ = make_countdown(5)
+
+# Partial-evaluate. 2N ReGLU neurons + coefficient tables per field.
+sp = specialize(prog)
+print(sp.n, sp.coefficients['op'], sp.token_savings())
+
+# Bit-exact with direct prefix indexing at every cursor position
+verify_fetch_parity(prog)
+
+# Run the specialized executor -- step-count and trace parity with universal
+print(run(prog, specialize=True))
+```
+
+`executor.mojo` already fetches instructions via direct `List[Int]` indexing, so
+specialization buys no Mojo-runtime speedup — its value here is architectural:
+the `2N` ReGLU neurons plus coefficient tables are what "programs live in
+weights" looks like concretely.
+
 ## Updating from Repo
 
 To pull latest source from the repository:
@@ -125,7 +158,7 @@ for f in executor.mojo; do
   curl -sL -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3.raw" \
     "https://api.github.com/repos/oaustegard/llm-as-computer/contents/src/$f?ref=main" > $f
 done
-for f in isa_lite.py programs.py runner.py; do
+for f in isa_lite.py programs.py runner.py specialize.py; do
   curl -sL -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3.raw" \
     "https://api.github.com/repos/oaustegard/llm-as-computer/contents/skill/src/$f?ref=main" > $f
 done

--- a/llm-as-computer/src/programs.py
+++ b/llm-as-computer/src/programs.py
@@ -146,6 +146,23 @@ def make_fibonacci(n):
     return prog, fib(n)
 
 
+def make_countdown(n):
+    """Simplest possible loop: decrement a counter from n to 0. Terminates at 0.
+
+    Canonical specialization demo target -- small, clearly deterministic,
+    traces are easy to eyeball. Final stack top is always 0.
+    """
+    prog = [
+        Instruction(OP_PUSH, n),   # 0: counter = n
+        Instruction(OP_PUSH, 1),   # 1: decrement
+        Instruction(OP_SUB),       # 2: counter - 1
+        Instruction(OP_DUP),       # 3: copy for JNZ test
+        Instruction(OP_JNZ, 1),    # 4: loop if non-zero
+        Instruction(OP_HALT),      # 5: done
+    ]
+    return prog, 0
+
+
 def make_power_of_2(n):
     """Generate a program that computes 2^n via repeated doubling."""
     if n == 0:

--- a/llm-as-computer/src/runner.py
+++ b/llm-as-computer/src/runner.py
@@ -125,20 +125,37 @@ def _run_mojo(prog, max_steps=5000000, repeat=0):
 
 
 def _run_python(prog, max_steps=5000000):
-    """Pure Python fallback executor (no deps beyond stdlib)."""
-    # Minimal stack machine - same semantics as Mojo executor
+    """Pure Python fallback executor (no deps beyond stdlib).
+
+    Uses direct prefix indexing for the universal-interpreter path.
+    """
+    from specialize import fetch_fn_from_program
+    return _run_python_core(len(prog), fetch_fn_from_program(prog), max_steps)
+
+
+def _run_python_specialized(specialized, max_steps=5000000):
+    """Specialized executor: fetches via FFN coefficient tables, no prefix.
+
+    Trace format and step semantics are identical to _run_python, so the
+    caller can assert step-count / trace parity.
+    """
+    return _run_python_core(specialized.n, specialized.fetch, max_steps)
+
+
+def _run_python_core(n_instrs, fetch, max_steps=5000000):
+    """Shared Python executor loop. `fetch(ip) -> (op, arg)` decouples the
+    prefix-indexed universal path from the FFN-specialized path."""
     from isa_lite import MASK32
-    
+
     stack = {}
     sp = 0
     ip = 0
     lines = []
-    
+
     for _step in range(max_steps):
-        if ip >= len(prog):
+        if ip >= n_instrs:
             break
-        instr = prog[ip]
-        op, arg = instr.op, instr.arg
+        op, arg = fetch(ip)
         next_ip = ip + 1
         top = 0
         
@@ -186,18 +203,38 @@ def _run_python(prog, max_steps=5000000):
     return lines, stack.get(sp, 0) if sp > 0 else 0
 
 
-def execute(prog, max_steps=5000000, verbose=True, benchmark_repeat=0):
+def execute(prog, max_steps=5000000, verbose=True, benchmark_repeat=0, specialize=False):
     """Execute a program. Returns (result, trace_lines, backend, timing_info).
-    
+
     Args:
         prog: List[Instruction] or (List[Instruction], expected) tuple
         max_steps: execution limit
         verbose: whether to collect trace
         benchmark_repeat: if >0, run N times and report median timing
+        specialize: if True, bake the program into FFN coefficient tables
+            (Percepta-style partial evaluation) and fetch from them instead
+            of a program prefix. Forces the Python backend; the Mojo executor
+            already uses direct prefix indexing, so specialization offers no
+            runtime speedup there -- the benefit is prompt-size, demonstrated
+            via SpecializedProgram.token_savings().
     """
     prog = _unpack(prog)
+
+    if specialize:
+        from specialize import specialize as _specialize
+        sp = _specialize(prog)
+        t0 = time.perf_counter_ns()
+        lines, result = _run_python_specialized(sp, max_steps)
+        elapsed = time.perf_counter_ns() - t0
+        savings = sp.token_savings()
+        return result, lines, "python-specialized", {
+            "wall_ns": elapsed,
+            "token_savings": savings,
+            "ffn_neurons": 2 * sp.n,
+        }
+
     backend = "mojo" if os.path.exists(MOJO_BIN) else "python"
-    
+
     if backend == "mojo":
         if benchmark_repeat > 0:
             lines, wall_ns = _run_mojo(prog, max_steps, repeat=benchmark_repeat)
@@ -279,7 +316,18 @@ def format_trace(prog, trace_lines, result, backend, timing):
     
     if "wall_ns" in timing:
         out.append(f"  Wall time: {timing['wall_ns']/1e6:.1f} ms")
-    
+
+    if "token_savings" in timing:
+        ts = timing["token_savings"]
+        out.append(
+            f"\nSpecialization: {timing['ffn_neurons']} ReGLU neurons baked "
+            f"({ts['program_tokens_saved']} program tokens -> FFN weights)"
+        )
+        out.append(
+            f"  Prompt tokens: {ts['universal_prompt_tokens']} (universal) "
+            f"-> {ts['specialized_prompt_tokens']} (specialized)"
+        )
+
     return "\n".join(out)
 
 
@@ -301,20 +349,25 @@ def _unpack(prog):
     return prog
 
 
-def run(prog, benchmark=False, repeat=200):
+def run(prog, benchmark=False, repeat=200, specialize=False):
     """Execute and format a program. Returns formatted string.
-    
+
     Args:
         prog: List[Instruction], or (List[Instruction], expected) tuple
         benchmark: if True, run timing benchmark
         repeat: number of benchmark iterations
+        specialize: if True, partial-evaluate the program into FFN
+            coefficient tables and run the specialized executor. Matches
+            the universal interpreter trace step-for-step; see specialize.py.
     """
     prog = _unpack(prog)
-    if benchmark:
+    if specialize:
+        result, lines, backend, timing = execute(prog, specialize=True)
+    elif benchmark:
         result, lines, backend, timing = execute(prog, benchmark_repeat=repeat)
     else:
         result, lines, backend, timing = execute(prog)
-    
+
     return format_trace(prog, lines, result, backend, timing)
 
 

--- a/llm-as-computer/src/specialize.py
+++ b/llm-as-computer/src/specialize.py
@@ -1,0 +1,153 @@
+"""Program specialization via partial evaluation.
+
+Bakes the compiled stack machine's program table into FFN-style coefficient
+tables, so the fetched opcode/arg at each cursor position is computed from
+a fixed set of step-function neurons rather than from attention over a
+program prefix.
+
+For a program of N instructions, specialization emits:
+
+  - 2N ReGLU step-function neurons realising  1[cursor >= i]  for i in 0..N-1
+    (each indicator needs a gate + up half-neuron under the ReGLU product
+    formulation).
+  - Per fetched field f, a coefficient vector  c = [c0, c1-c0, ..., c_{N-1}-c_{N-2}]
+    such that  f(cursor) = sum_{i=0..N-1} c[i] * 1[cursor >= i].
+
+The sum telescopes to f(prog[cursor]) whenever 0 <= cursor < N, so the
+specialized representation is bit-exact with direct indexing into the
+program table.
+
+Based on the partial-evaluation pass described in
+https://www.percepta.ai/blog/constructing-llm-computer (2026-03-25).
+
+In this repo the "FFN" is ordinary arithmetic -- we are not training weights.
+The demonstration is that at deployment time the prompt shrinks from
+(program || input) to (input), because the fetched fields are now a function
+of the cursor alone.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Tuple
+
+from isa_lite import Instruction
+
+
+# Fields baked into FFN coefficients. Matches the (op, arg) shape used by
+# every other layer of the executor.
+FIELDS: Tuple[str, ...] = ("op", "arg")
+
+
+@dataclass
+class SpecializedProgram:
+    """A program represented as FFN coefficient tables instead of a prefix.
+
+    Attributes:
+        n:
+            Number of instructions (and number of step-function neurons).
+        coefficients:
+            Per field, a list of length n where coefficients[f][0] = c0 and
+            coefficients[f][i] = c_i - c_{i-1} for i >= 1. The fetched value
+            at cursor t is sum(coefficients[f][i] * 1[t >= i] for i in 0..n-1).
+        originals:
+            The input instruction list. Retained only so the verification
+            helpers can assert specialized-vs-direct parity; fetch() never
+            consults it.
+    """
+
+    n: int
+    coefficients: Dict[str, List[int]]
+    originals: List[Instruction] = field(default_factory=list)
+
+    def step_neurons(self, cursor: int) -> List[int]:
+        """Return the n step-function activations 1[cursor >= i] for i in 0..n-1."""
+        return [1 if cursor >= i else 0 for i in range(self.n)]
+
+    def fetch(self, cursor: int) -> Tuple[int, int]:
+        """Reconstruct (op, arg) at `cursor` using only the coefficient tables.
+
+        Implements the Percepta expansion
+            f(cursor) = c0 + sum_{i=1..n-1} (c_i - c_{i-1}) * 1[cursor >= i]
+        which telescopes to c_cursor for 0 <= cursor < n. Out-of-range cursors
+        saturate at c_{n-1}, matching WASM's trap-on-overrun semantics when
+        the executor has already halted.
+        """
+        if cursor < 0:
+            return (0, 0)
+        ind = self.step_neurons(cursor)
+        op = sum(c * s for c, s in zip(self.coefficients["op"], ind))
+        arg = sum(c * s for c, s in zip(self.coefficients["arg"], ind))
+        return int(op), int(arg)
+
+    def ffn_rows(self) -> List[Tuple[str, int]]:
+        """Describe the 2N ReGLU neurons emitted for this program.
+
+        Each instruction i contributes a (gate, up) pair; their product
+        realises 1[cursor >= i] (the gate saturates at 1, the up saturates
+        at 1, ReGLU multiplies them).
+        """
+        rows: List[Tuple[str, int]] = []
+        for i in range(self.n):
+            rows.append(("gate", i))
+            rows.append(("up", i))
+        return rows
+
+    def token_savings(self, input_tokens: int = 0) -> Dict[str, int]:
+        """Compare prompt sizes: universal (program || input) vs specialized (input)."""
+        program_tokens = 2 * self.n  # op + arg per instruction
+        return {
+            "universal_prompt_tokens": program_tokens + input_tokens,
+            "specialized_prompt_tokens": input_tokens,
+            "program_tokens_saved": program_tokens,
+        }
+
+
+def specialize(prog: List[Instruction]) -> SpecializedProgram:
+    """Partial-evaluate a program into FFN coefficient tables.
+
+    For each field f, computes:
+        c[0] = f(prog[0])
+        c[i] = f(prog[i]) - f(prog[i-1])    for i > 0
+    so that sum_{i=0..cursor} c[i] = f(prog[cursor]).
+    """
+    # Unpack (prog, expected) tuples returned by programs.make_*
+    if isinstance(prog, tuple) and len(prog) == 2 and isinstance(prog[0], list):
+        prog = prog[0]
+
+    n = len(prog)
+    if n == 0:
+        raise ValueError("Cannot specialize an empty program.")
+
+    coefficients: Dict[str, List[int]] = {}
+    for name in FIELDS:
+        seq = [int(getattr(instr, name)) for instr in prog]
+        row = [seq[0]]
+        for i in range(1, n):
+            row.append(seq[i] - seq[i - 1])
+        coefficients[name] = row
+
+    return SpecializedProgram(n=n, coefficients=coefficients, originals=list(prog))
+
+
+def fetch_fn_from_program(prog: List[Instruction]) -> Callable[[int], Tuple[int, int]]:
+    """Universal-interpreter fetch: direct indexing into the program prefix."""
+
+    def fetch(ip: int) -> Tuple[int, int]:
+        if ip < 0 or ip >= len(prog):
+            return (0, 0)
+        instr = prog[ip]
+        return int(instr.op), int(instr.arg)
+
+    return fetch
+
+
+def verify_fetch_parity(prog: List[Instruction]) -> bool:
+    """Assert specialized.fetch(i) == (prog[i].op, prog[i].arg) for every i."""
+    sp = specialize(prog)
+    direct = fetch_fn_from_program(prog)
+    for i in range(len(prog)):
+        if sp.fetch(i) != direct(i):
+            raise AssertionError(
+                f"specialization mismatch at cursor={i}: "
+                f"specialized={sp.fetch(i)} direct={direct(i)}"
+            )
+    return True


### PR DESCRIPTION
Closes oaustegard/llm-as-computer#113.

## What

Ports Percepta's partial-evaluation pass ([blog](https://www.percepta.ai/blog/constructing-llm-computer), 2026-03-25) into the skill. For a program of `N` instructions, emits:

- `2N` ReGLU step-function neurons realising `1[cursor >= i]` for `i` in `0..N-1`
- Per-field coefficient vectors so that `f(cursor) = c0 + Σᵢ (cᵢ − cᵢ₋₁)·1[cursor >= i]` telescopes to `f(prog[cursor])`

At deployment the prompt shrinks from `(program || input)` to `(input)` — fetched opcode/arg are now a function of the cursor alone.

## Files

- `src/specialize.py` (new) — `SpecializedProgram`, `specialize(prog)`, `verify_fetch_parity()`, `token_savings()`, `ffn_rows()`
- `src/runner.py` — factored the Python executor to take a `fetch(ip)` callable; added `specialize=True` on `execute()` / `run()`; trace format shows FFN neuron count and prompt-token savings in specialized mode
- `src/programs.py` — `make_countdown(n)` as the canonical demo target
- `SKILL.md` / `CHANGELOG.md` — documented; bumped version to `1.1.0`

## Acceptance (#576)

- [x] Pick one existing test program — `countdown(5)` / `countdown(20)`
- [x] Specialize it; verify weights match the non-specialized executor's behavior — `verify_fetch_parity()` checks all cursors bit-exact
- [x] Step-count parity with universal interpreter — 17/17 programs produce identical traces (countdown, fibonacci, factorial, sum_1_to_n, power_of_2, multiply + all 10 `ALL_TESTS` regressions)
- [x] Benchmark: token count drop — `token_savings()` reports `2N` program tokens saved (e.g. countdown → 12 → 0, fibonacci(10) → 38 → 0)
- [x] No regression on the universal-interpreter path — default `run(prog)` unchanged

## executor.mojo untouched (on purpose)

The issue flagged this as a maybe — verified and left alone. The Mojo executor's fetch path is already direct `List[Int]` indexing (see `executor.mojo:426-427`), not attention-over-prefix, so specialization buys no Mojo-runtime speedup. The value here is architectural (programs-as-weights) and prompt-size, which is a Python-level artifact.

https://claude.ai/code/session_01MYEgU6Jq5PQaQWvoB5XPY7