### PR TITLE
tree-sitting: pin language-pack <1.6.3 in fallback install hint

### DIFF
--- a/tree-sitting/SKILL.md
+++ b/tree-sitting/SKILL.md
@@ -126,7 +126,7 @@ Three-tier extraction for bundled languages:
 
 Files with unsupported extensions are silently skipped (they show as `SKIP (no parser)` with `--stats`). To add a grammar, drop a compiled `libtree_sitter_<lang>.so` into `parsers/` — the engine picks it up automatically on the next run. Build from the grammar's repo (each `tree-sitter/tree-sitter-<lang>` repo has a `src/` directory you can compile with `cc -shared -fPIC -I src src/parser.c src/scanner.c -o libtree_sitter_<lang>.so`, or use `tree-sitter build`).
 
-If you need a language urgently and can't build the `.so`, you can try installing `tree-sitter-language-pack` as a fallback (`uv pip install --system --break-system-packages tree-sitter-language-pack`) — but note its 1.6.x wheels have a broken install layout in some containers and try to download grammars at runtime from a domain that may not be in your network allowlist. Bundling the `.so` is the reliable path.
+If you need a language urgently and can't build the `.so`, you can try installing `tree-sitter-language-pack` as a fallback (`uv pip install --system --break-system-packages 'tree-sitter-language-pack<1.6.3'`) — but note 1.6.3 ships a broken wheel (only `_native/`, missing the `tree_sitter_language_pack/` python module → `ModuleNotFoundError` despite pip showing it installed); 1.6.2 and earlier work, hence the `<1.6.3` pin and try to download grammars at runtime from a domain that may not be in your network allowlist. Bundling the `.so` is the reliable path.
 
 ## What It Extracts
 


### PR DESCRIPTION
Pins `tree-sitter-language-pack<1.6.3` in the fallback install command in `tree-sitting/SKILL.md`.

## Why

1.6.3 (current pip default) ships a broken wheel — only `_native/` is included, the `tree_sitter_language_pack/` python module is missing. Result: `ModuleNotFoundError: No module named 'tree_sitter_language_pack'` despite pip showing it installed. 1.6.2 and earlier work correctly.

Without the pin, every fresh container that hits the fallback path catches the broken wheel.

## Scope

This only changes the **fallback** install hint at the bottom of the skill. The primary install (`uv pip install --system --break-system-packages tree-sitter`) is unaffected — that's just core tree-sitter, which the bundled `parsers/*.so` files use.

## Note on the broader pattern

Verified empirically: tree-sitting works perfectly with just `tree-sitter` core (no language-pack) for the 11 bundled languages. The language-pack is genuinely fallback-only. Worth a separate look at whether `exploring-codebases` step 0 should be installing the language-pack at all — it currently does, unnecessarily, and is the original source of this thrash. But that's a follow-up; this PR is just the pin.