### PR TITLE
fix(remembering): refs in remember() is citation-only, not supersede

### DIFF
--- a/remembering/CHANGELOG.md
+++ b/remembering/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `remembering` skill (Muninn) are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5.7.0] - 2026-04-26
+
+### Fixed
+
+- **`refs` no longer auto-supersedes referenced memories** (#issue-refs-no-auto-supersede): `_write_memory` previously ran `UPDATE memories SET is_superseded = 1 WHERE id IN (refs...)` after every insert, conflating two distinct semantics:
+  - **Supersede edges** — "this memory replaces the referenced ones" (handled by `supersede()`)
+  - **Citation/provenance edges** — "this memory was derived from / cites the referenced ones" (used by Phase 3 syntheses, `boot.py` reflection clusters, manual provenance refs)
+
+  The auto-flag silently corrupted the second pattern. On 2026-04-26 it took out an entire batch of 6 living-reference syntheses (the L5a retrieval layer) plus 5 prototype-log analyses and 34 cited source memories — all flagged `is_superseded=1` within seconds of creation, by the prototype-log writes that immediately followed each synthesis. Total contaminated flags: ~45.
+
+  **Behavior change:** `remember(refs=[...])` is now a pure citation expression. The referenced rows are unaffected. Use `supersede(original_id, ...)` when you actually mean replacement — that path remains the single source of truth for the `is_superseded` flag.
+
+### Notes for callers
+
+- `consolidate()` previously relied on the auto-flag side effect to hide cluster source memories from default recall. Its explicit code only demotes sources to `priority=-1` (background). After this fix, source memories remain technically active (not superseded) but stay deprioritized via `priority=-1`. Recall callers that already filter by priority are unaffected; callers that relied on the supersede flag to hide consolidated sources will now see them in low-priority results. If hard supersede semantics are wanted in `consolidate()`, prefer making it explicit there.
+- `boot.py` reflection clustering uses `refs` as citations and was previously corrupting its own source memories. This fix is the intended behavior.
+
 ## [5.5.0] - 2026-03-18
 
 ### Added

--- a/remembering/scripts/memory.py
+++ b/remembering/scripts/memory.py
@@ -105,6 +105,12 @@ def _write_memory(mem_id: str, what: str, type: str, now: str, conf: float,
     v2.0.0: Simplified schema - removed entities, importance, salience, memory_class, embedding. Added priority field.
     v3.2.0: Re-enabled session_id tracking.
     v5.x.0 (#issue-superseded-col): Maintain is_superseded flag on referenced memories.
+    v5.7.0 (#issue-refs-no-auto-supersede): refs are citation/provenance edges, NOT supersede edges.
+        Removed the implicit UPDATE that flagged every referenced memory is_superseded=1
+        on insert. Two real-world callers (Phase 3 syntheses, boot.py reflection clusters)
+        used refs as provenance and were silently corrupting their citations. The supersede
+        flag now lives only on the explicit supersede() path; remember(refs=...) is
+        side-effect-free with respect to the referenced rows.
     """
     clean_refs = [r for r in (refs or []) if r is not None]
     _exec(
@@ -116,14 +122,12 @@ def _write_memory(mem_id: str, what: str, type: str, now: str, conf: float,
          priority, session_id, now, now, valid_from]
     )
 
-    # Mark any referenced memories as superseded. Indexed recall path relies on
-    # this flag instead of a runtime json_each(refs) subquery (#issue-superseded-col).
-    if clean_refs:
-        placeholders = ", ".join("?" * len(clean_refs))
-        _exec(
-            f"UPDATE memories SET is_superseded = 1 WHERE id IN ({placeholders})",
-            clean_refs,
-        )
+    # NOTE: previous versions auto-flagged referenced memories is_superseded=1 here.
+    # That conflated supersede semantics ("this replaces the referenced rows") with
+    # citation semantics ("this was derived from / cites the referenced rows"). Phase 3
+    # tag syntheses and reflection clustering used refs as citations and got their
+    # source memories silently flagged. Use supersede() when you want supersede
+    # semantics — it is the single explicit path that sets is_superseded=1.
 
 
 # @lat: [[memory#Core Operations]]
@@ -140,7 +144,9 @@ def remember(what: str, type: str, *, tags: list = None, conf: float = None,
         type: Memory type (decision, world, anomaly, experience)
         tags: Optional list of tags
         conf: Optional confidence score (0.0-1.0)
-        refs: Optional list of referenced memory IDs
+        refs: Optional list of referenced memory IDs. Citation/provenance only —
+            the referenced memories are NOT flagged superseded. Use supersede() if
+            you want to mark a memory as replaced. (v5.7.0 — see _write_memory.)
         priority: Priority level (-1=background, 0=normal, 1=important, 2=critical)
         valid_from: Optional timestamp when fact became true (defaults to creation time)
         sync: If True (default), block until write completes. If False, write in background.
@@ -163,6 +169,8 @@ def remember(what: str, type: str, *, tags: list = None, conf: float = None,
     v2.0.0: Simplified schema. Added priority. Removed entities, importance, memory_class.
     v3.2.0: Added session_id parameter for session scoping.
     v4.2.0: Added alternatives parameter for decision memories (#254).
+    v5.7.0 (#issue-refs-no-auto-supersede): refs is citation-only — referenced memories
+        are no longer auto-flagged is_superseded=1. Use supersede() for revision semantics.
     """
     if type not in TYPES:
         raise ValueError(f"Invalid type '{type}'. Must be one of: {', '.join(sorted(TYPES))}")


### PR DESCRIPTION
## Summary

`_write_memory` previously ran `UPDATE memories SET is_superseded = 1 WHERE id IN (refs...)` on every insert. The intent (added in #issue-superseded-col) was to keep the recall hot path index-prunable. The unintended effect: it conflated two distinct semantics that callers were already mixing:

- **Supersede edges** — "this memory replaces the referenced ones" (handled by `supersede()`)
- **Citation/provenance edges** — "this memory was derived from / cites the referenced ones"

Real callers using the second pattern were silently corrupting their own citations. Two found in this repo:

1. **Phase 3 tag-synthesis runs** — `remembering/scripts/therapy.py` and the `phase3_scaffold` utility. On 2026-04-26 a batch of 6 living-reference syntheses got flagged `is_superseded=1` within seconds of creation, by the prototype-log analyses written immediately after each synthesis (each log carried the synthesis ID in `refs` as a citation). Cascade also hit 5 prototype logs and 34 cited source memories. Total contaminated flags: ~45. The L5a retrieval layer went dark.
2. **`boot.py` reflection clustering** (line 1189) — stores a "reflection" memory with `refs=cluster["source_ids"]` as citation. Was incorrectly flagging source memories as superseded.

Diagnostic memory: `4aa224a3` (full root-cause + cascade trace).

## Fix

- `_write_memory` no longer auto-flags referenced memories. The supersede flag is now set only by the explicit `supersede()` path.
- `remember()` docstring updated: `refs` is citation/provenance, not supersede.
- CHANGELOG entry as v5.7.0 (5.6.0 reserved for in-flight MIA work — version markers in source already use 5.6.0 for that).

## Behavior change

`consolidate()` previously relied on the auto-flag side effect. Its explicit code only `reprioritize(mid, -1)`s sources. After this fix, sources remain technically active but stay deprioritized via priority=-1. Recall callers that already filter by priority are unaffected; callers that relied on `is_superseded=1` to hide consolidated sources will now see them in low-priority results. If consolidate() truly wants supersede semantics, it should call supersede() (or set the flag) explicitly — flagged for future cleanup, out of scope here.

## Test coverage

`test_supersede` (test_remembering.py:244) uses the explicit `supersede()` path and remains unchanged. No tests assert the auto-flag behavior, so removal is test-safe.

## Database remediation

Performed manually on Muninn's Turso DB after diagnosis: `UPDATE memories SET is_superseded = 0 WHERE id IN (<29 known contaminated IDs>)`. L5a layer restored to 6 active living-references. Verified in same session.

## Procedure remediation

`phase3-refs-discipline` ops entry stored in Muninn config. Codifies: Phase 3 storage uses empty `refs=[]`; provenance lives in synthesis prose with backtick-wrapped 8-char IDs (the `phase3_scaffold.audit` regex already extracts these for coverage analysis).

---

Closes the P1 thread from the 2026-04-26 Phase 3 handoff (memory `97749e67`).
