### PR TITLE
fix(remembering): boot _time_anchor robust to multi-line tz config + write /tmp/LOCAL_DATE

### DIFF
--- a/remembering/CHANGELOG.md
+++ b/remembering/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `remembering` skill (Muninn) are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5.7.1] - 2026-04-26
+
+### Fixed
+
+- **`_time_anchor()` falls back to UTC silently when `timezone` profile value contains trailing instructional text** (#boot-tz-multiline): The `timezone` profile config sometimes carries date-grounding instructions appended after the IANA name (e.g. `"America/New_York\n\nDATE GROUNDING (added 2026-04-13)..."`). `ZoneInfo()` rejects the multi-line string and the existing exception handler silently falls back to UTC — so the boot header reads `UTC | DST: inactive` even when the user is in EDT, which is exactly the failure mode the time anchor was added to prevent. Boot now extracts the first non-empty line of the timezone value before passing it to `ZoneInfo`, so multi-line profile entries work as long as the IANA name comes first.
+
+### Added
+
+- **`/tmp/LOCAL_DATE` written at boot**: `_time_anchor()` now writes today's local date (`YYYY-MM-DD`) to `/tmp/LOCAL_DATE` as a side effect, matching the contract that several ops entries and skills already document (e.g. "cat /tmp/LOCAL_DATE for date grounding"). Best-effort — write failure does not break boot.
+
 ## [5.7.0] - 2026-04-26
 
 ### Fixed

--- a/remembering/scripts/boot.py
+++ b/remembering/scripts/boot.py
@@ -797,17 +797,34 @@ def _time_anchor() -> str:
     Emits local time (from profile 'timezone' config), UTC, offset, and DST status.
     Prevents timezone math errors when interpreting UTC memory timestamps.
 
+    Side effect: writes today's local YYYY-MM-DD to /tmp/LOCAL_DATE so
+    downstream tooling can `cat /tmp/LOCAL_DATE` for date grounding without
+    reimplementing the timezone math.
+
     v5.5.0: Added for temporal grounding (#time-anchor).
+    v5.7.x: Robust to multi-line `timezone` values (instructions appended to
+            the IANA name) by parsing only the first non-empty line. Also
+            writes /tmp/LOCAL_DATE.
     """
     from zoneinfo import ZoneInfo
+    from pathlib import Path
 
     now_utc = datetime.now(UTC)
 
-    # Load timezone from profile config, fall back to UTC
+    # Load timezone from profile config, fall back to UTC.
+    # The `timezone` profile entry sometimes carries instructional text after
+    # the IANA name (e.g. "America/New_York\n\nDATE GROUNDING..."). ZoneInfo
+    # rejects the multi-line string, so extract just the first non-empty line.
     tz_name = None
     try:
         from .config import config_get
-        tz_name = config_get('timezone')
+        raw = config_get('timezone')
+        if raw:
+            for line in raw.splitlines():
+                line = line.strip()
+                if line:
+                    tz_name = line
+                    break
     except Exception:
         pass
 
@@ -825,6 +842,12 @@ def _time_anchor() -> str:
     offset_fmt = f"{offset[:3]}:{offset[3:]}"  # e.g., '-05:00'
     tz_abbrev = now_local.strftime('%Z')  # e.g., 'EST' or 'EDT'
     dst_active = bool(now_local.dst())
+
+    # Write /tmp/LOCAL_DATE for shell tooling. Best-effort; never fail boot.
+    try:
+        Path('/tmp/LOCAL_DATE').write_text(now_local.strftime('%Y-%m-%d') + '\n')
+    except Exception:
+        pass
 
     return (
         f"⏰ {now_local.strftime('%Y-%m-%d %H:%M')} {tz_abbrev} "


### PR DESCRIPTION
## What

Two related boot-time date-grounding bugs:

1. **`_time_anchor()` silently falls back to UTC when the `timezone` profile value is multi-line.** The live `timezone` config entry carries date-grounding instructions appended after the IANA name (`"America/New_York

DATE GROUNDING (added 2026-04-13)..."`). `ZoneInfo()` rejects the multi-line string, the existing `except Exception` swallows it, and the boot header reads `UTC | DST: inactive` instead of local time — exactly the failure the time anchor was added to prevent. Now extracts the first non-empty line as the IANA name.

2. **`/tmp/LOCAL_DATE` was documented in ops as "written at boot" but no code wrote it.** Skills and ops entries advise `cat /tmp/LOCAL_DATE` for date grounding; until now that returned nothing. `_time_anchor()` now writes it as a best-effort side effect.

## Why

Diagnosed live tonight (2026-04-26): boot header showed `UTC | DST: inactive` despite `timezone: America/New_York` in the profile, and I lost the day-of-week as a result (called Sunday "Saturday" in conversation). Root cause turned out to be downstream of the visible symptom — fixing both layers in one PR rather than splitting hairs.

## Verified locally

```
⏰ 2026-04-26 22:13 EDT (UTC-04:00) | DST: active
/tmp/LOCAL_DATE: 2026-04-26
```

DST flag now correctly reads `active` (it IS active in late April in `America/New_York`), and the local date file matches.

## Out of scope

- Profile content cleanup (moving the date-grounding instructions out of the `timezone` value into a separate ops entry). Worth doing eventually, but the code should be robust to it regardless — that's what this PR delivers.
- VERSION file. Not introducing one in this PR; CHANGELOG header is the source of truth.

## CHANGELOG

`v5.7.1` (follows `v5.7.0` from #583).