### PR TITLE
chore(remembering): bump SKILL.md frontmatter version to 5.7.1

### DIFF
--- a/remembering/SKILL.md
+++ b/remembering/SKILL.md
@@ -2,7 +2,7 @@
 name: remembering
 description: Advanced memory operations reference. Basic patterns (profile loading, simple recall/remember) are in project instructions. Consult this skill for background writes, memory versioning, complex queries, edge cases, session scoping, retention management, type-safe results, proactive memory hints, GitHub access detection, autonomous curation, episodic scoring, and decision traces.
 metadata:
-  version: 5.4.0
+  version: 5.7.1
 ---
 
 # Remembering - Advanced Operations


### PR DESCRIPTION
## What

Bumps `remembering/SKILL.md` frontmatter `metadata.version` from `5.4.0` → `5.7.1`.

## Why

Frontmatter version is the canonical skill version (per Oskar). It was three minor versions behind CHANGELOG:

- `5.5.0` (TF-IDF index, 2026-03-18) — frontmatter not bumped
- `5.7.0` (refs no auto-supersede, #583) — frontmatter not bumped
- `5.7.1` (boot tz/LOCAL_DATE fix, #584) — frontmatter not bumped

This single-line change catches the canonical version up to current state. Both #583 and #584 should have included this; flagging it now so the omission becomes visible.

## Out of scope

- Other skills with similar drift between frontmatter and CHANGELOG (if any). One skill at a time.
- Adding a CI check that frontmatter version matches CHANGELOG head. Worth doing eventually but separate PR.
