### PR TITLE
fix: config_set preserves boot_load on update

### DIFF
--- a/remembering/CHANGELOG.md
+++ b/remembering/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `remembering` skill (Muninn) are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- `config_set` now preserves `boot_load` on update. Previously, every update silently re-promoted reference-only entries to boot-loaded because `INSERT OR REPLACE` omitted the `boot_load` column. This was particularly painful for auto-maintained keys like `recall-triggers` (rewritten on every `remember()` call).
+
 ## [5.7.1] - 2026-04-27
 
 ### Added

--- a/remembering/scripts/config.py
+++ b/remembering/scripts/config.py
@@ -25,7 +25,8 @@ def config_get(key: str) -> str | None:
 
 # @lat: [[memory#Config System]]
 def config_set(key: str, value: str, category: str, *,
-               char_limit: int = None, read_only: bool = False) -> None:
+               char_limit: int = None, read_only: bool = False,
+               boot_load: bool = None) -> None:
     """Set a config value with optional constraints.
 
     Args:
@@ -34,6 +35,9 @@ def config_set(key: str, value: str, category: str, *,
         category: Must be 'profile', 'ops', or 'journal'
         char_limit: Optional character limit for value (enforced on writes)
         read_only: Mark as read-only (advisory - not enforced by this function)
+        boot_load: Whether the entry loads at boot. If None (default), existing
+            entries preserve their current boot_load and new entries default to
+            True. Pass True/False to set explicitly.
 
     Raises:
         ValueError: If category invalid or value exceeds char_limit
@@ -41,14 +45,27 @@ def config_set(key: str, value: str, category: str, *,
     if category not in ("profile", "ops", "journal"):
         raise ValueError(f"Invalid category '{category}'. Must be 'profile', 'ops', or 'journal'")
 
-    # Check existing entry for read_only flag
+    # Check existing entry for read_only flag and current boot_load.
     # Note: Turso returns boolean fields as strings ('0' or '1'), so we need explicit checks
-    existing = _exec("SELECT read_only FROM config WHERE key = ?", [key])
+    existing = _exec("SELECT read_only, boot_load FROM config WHERE key = ?", [key])
     if existing:
         is_readonly = existing[0].get("read_only")
         # Check for truthy values that indicate read-only (handle both int and string types)
         if is_readonly not in (None, 0, '0', False, 'false', 'False'):
             raise ValueError(f"Config key '{key}' is marked read-only and cannot be modified")
+        # Preserve existing boot_load on update unless caller explicitly specified one.
+        # Without this, INSERT OR REPLACE would silently reset boot_load to the column
+        # default (1), re-promoting reference-only entries to boot-loaded on every update.
+        # This is critical for auto-maintained keys like 'recall-triggers' that are written
+        # on every remember() call.
+        if boot_load is None:
+            existing_bl = existing[0].get("boot_load")
+            boot_load_val = 0 if existing_bl in (0, '0', False, 'false', 'False') else 1
+        else:
+            boot_load_val = 1 if boot_load else 0
+    else:
+        # New entry: default to boot_load=1 (matches schema default), or use explicit value.
+        boot_load_val = 1 if (boot_load is None or boot_load) else 0
 
     # Enforce character limit if specified
     if char_limit and len(value) > char_limit:
@@ -59,9 +76,9 @@ def config_set(key: str, value: str, category: str, *,
 
     now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     _exec(
-        """INSERT OR REPLACE INTO config (key, value, category, updated_at, char_limit, read_only)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        [key, value, category, now, char_limit, 1 if read_only else 0]
+        """INSERT OR REPLACE INTO config (key, value, category, updated_at, char_limit, read_only, boot_load)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [key, value, category, now, char_limit, 1 if read_only else 0, boot_load_val]
     )
 
 

--- a/remembering/tests/test_remembering.py
+++ b/remembering/tests/test_remembering.py
@@ -288,6 +288,52 @@ def test_config_crud():
     print("PASS: Config CRUD works")
 
 
+def test_config_set_preserves_boot_load():
+    """Test 16b: config_set preserves boot_load on update (regression test for #N).
+
+    Previously, INSERT OR REPLACE in config_set omitted boot_load, causing every
+    update to silently reset boot_load to the column default (1). This re-promoted
+    reference-only entries on every update — particularly painful for auto-maintained
+    keys like 'recall-triggers' that are rewritten on every remember() call.
+    """
+    from scripts import config_set, config_delete, config_set_boot_load
+    from scripts.turso import _exec
+
+    KEY = "test-boot-load-preservation"
+    try:
+        # New entry defaults to boot_load=1
+        config_set(KEY, "v1", "ops")
+        rows = _exec("SELECT boot_load FROM config WHERE key=?", [KEY])
+        assert rows[0]["boot_load"] in (1, "1"), \
+            f"new entry should default to boot_load=1, got {rows[0]['boot_load']}"
+
+        # Demote
+        config_set_boot_load(KEY, False)
+        rows = _exec("SELECT boot_load FROM config WHERE key=?", [KEY])
+        assert rows[0]["boot_load"] in (0, "0")
+
+        # Update value via config_set — boot_load must persist (the bug)
+        config_set(KEY, "v2", "ops")
+        rows = _exec("SELECT boot_load, value FROM config WHERE key=?", [KEY])
+        assert rows[0]["boot_load"] in (0, "0"), \
+            f"config_set must preserve boot_load=0 on update, got {rows[0]['boot_load']}"
+        assert rows[0]["value"] == "v2"
+
+        # Explicit boot_load=True overrides
+        config_set(KEY, "v3", "ops", boot_load=True)
+        rows = _exec("SELECT boot_load FROM config WHERE key=?", [KEY])
+        assert rows[0]["boot_load"] in (1, "1")
+
+        # Explicit boot_load=False overrides
+        config_set(KEY, "v4", "ops", boot_load=False)
+        rows = _exec("SELECT boot_load FROM config WHERE key=?", [KEY])
+        assert rows[0]["boot_load"] in (0, "0")
+
+        print("PASS: config_set preserves boot_load on update")
+    finally:
+        config_delete(KEY)
+
+
 def test_boot_returns_string():
     """Test 17: Boot function returns expected format"""
     from scripts import boot


### PR DESCRIPTION
## Bug

`config_set` uses `INSERT OR REPLACE` without including `boot_load` in the column list. Since `boot_load` defaults to `1`, every update of an existing key silently re-promotes it from `boot_load=0` back to `1`.

## Impact

`recall-triggers` is auto-maintained — every `remember()` call appends novel tags via `config_set("recall-triggers", json.dumps(sorted(trigger_set)), "ops")` (memory.py L246, L1017, L1538). Each of those resets `boot_load` to 1, undoing any demote.

Caught in a Muninn boot-output cleanup session: demoted `recall-triggers` via `config_set_boot_load(False)`, boot dropped 84KB → 35KB. Several `remember()` calls later, `recall-triggers` was silently re-promoted and boot grew back to 76KB.

Other auto-updated keys (`spoke-registry`, `ops-topics`) are vulnerable to the same pattern, but they update less frequently so the bug is less obvious there.

## Fix

`config_set` now:
- When the key exists and `boot_load` is not specified: preserves the existing `boot_load`
- When the key is new and `boot_load` is not specified: defaults to `True` (matches schema default, preserves existing behavior)
- When `boot_load` is explicitly passed: uses that value

Adds `boot_load: bool = None` parameter so callers can override when needed.

## Test

New regression test `test_config_set_preserves_boot_load` covers:
1. New entry defaults to `boot_load=1`
2. `config_set_boot_load(False)` demotes
3. **`config_set` update preserves `boot_load=0`** (the bug)
4. Explicit `boot_load=True` promotes
5. Explicit `boot_load=False` demotes

Verified locally against the live Turso instance.

## Behavior Compatibility

- Existing callers unaffected — `boot_load` is keyword-only with default `None`
- New entries still default to boot-loaded (matches schema default and prior behavior)
- The only behavior change is the bug fix itself: updates no longer silently re-promote demoted entries