### PR TITLE
container-layer: stop leaking GH_TOKEN via TimeoutExpired

### DIFF
--- a/container-layer/scripts/layer_cache.py
+++ b/container-layer/scripts/layer_cache.py
@@ -125,19 +125,37 @@ def try_restore(repo: str, tag: str, token: str) -> bool:
     
     # Download the asset
     print("  Cache hit — downloading layer...")
-    
+
     tarball = "/tmp/_layer_restore.tar.gz"
-    
-    # Use curl for the download since it handles redirects well
-    cmd = (
-        f'curl -sL -H "Authorization: token {token}" '
-        f'-H "Accept: application/octet-stream" '
-        f'"{asset_url}" -o "{tarball}"'
-    )
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=120)
-    
-    if result.returncode != 0 or not os.path.exists(tarball):
-        print(f"  Download failed: {result.stderr.strip()}")
+
+    # Stream via urllib so the token stays in request headers, never in argv.
+    # The previous implementation shelled out to curl with the token interpolated
+    # into the command string; on TimeoutExpired, Python's exception __str__
+    # echoed the full cmd (including the token) into stderr/logs/transcripts.
+    # urllib keeps the secret in the Request object and out of any error message.
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/octet-stream",
+    }
+    req = urllib.request.Request(asset_url, headers=headers)
+
+    try:
+        # Per-read timeout, not wall-clock — multi-hundred-MB layers on slow
+        # links won't trip the old hardcoded 120s ceiling.
+        with urllib.request.urlopen(req, timeout=60) as resp, open(tarball, "wb") as out:
+            while True:
+                chunk = resp.read(1024 * 1024)
+                if not chunk:
+                    break
+                out.write(chunk)
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"  Download failed: {type(e).__name__}: {e}")
+        if os.path.exists(tarball):
+            os.remove(tarball)
+        return False
+
+    if not os.path.exists(tarball):
+        print("  Download failed: no file written")
         return False
     
     size_mb = os.path.getsize(tarball) / (1024 * 1024)


### PR DESCRIPTION
## Problem

`container-layer/scripts/layer_cache.py:try_restore` shelled out to curl with the token interpolated into the command string and `shell=True`:

\`\`\`python
cmd = (
    f'curl -sL -H "Authorization: token {token}" '
    f'-H "Accept: application/octet-stream" '
    f'"{asset_url}" -o "{tarball}"'
)
result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=120)
\`\`\`

When the 120s timeout fires, `subprocess.TimeoutExpired.__str__` interpolates the full `cmd` (including the token) into the exception message. That message ends up in stderr, on-disk logs, and downstream consumers (in our case Claude Code transcripts archived to GitHub Releases). Token rotation required every time.

## Fix

Switch the asset download to `urllib.request`, matching what the rest of the module already uses for API calls. The token stays in `Request.headers`; `URLError`/`TimeoutError` carry no headers, so no leak path exists.

Also bumps the timeout from 120s wall-clock to 60s per-read, since multi-hundred-MB layers on slow links were tripping the old ceiling even when the connection was healthy.

## Verification

- `urllib.error.HTTPError` on bad request → message contains URL only, no headers
- `TimeoutError` from `urllib.request.urlopen(req, timeout=1)` against a slow endpoint → `"The read operation timed out"`, no token
- Tested against `https://httpbin.org/delay/10` with a fake token; confirmed token does not appear in any exception representation

## Notes

`subprocess` is still imported and used for the tar extraction below — neither that call nor anything in `build_and_push` interpolates the token, so they're unaffected.