### PR TITLE
boot: persist Turso creds to ~/.muninn/.env for cross-shell reuse

### DIFF
--- a/remembering/scripts/boot.py
+++ b/remembering/scripts/boot.py
@@ -518,6 +518,61 @@ def _ensure_is_superseded_schema():
             pass  # Backfill best-effort; flag is self-healing on next supersede
 
 
+def _persist_env_fallback() -> bool:
+    """Persist live Turso credentials to ``~/.muninn/.env`` for cross-shell reuse.
+
+    Called from ``boot()`` after Turso has confirmed working credentials.
+    Writes ``TURSO_TOKEN`` and ``TURSO_URL`` to ``~/.muninn/.env`` — one of the
+    well-known fallback paths that ``turso._init()`` already searches (#263).
+
+    Why this exists
+    ---------------
+    Each Claude tool call is a fresh shell — env vars set in one ``bash_tool``
+    call do NOT survive to the next. When ``/mnt/project/turso.env`` is missing
+    or transiently unavailable (e.g. boot ran in a project where the file
+    wasn't mounted, or the user moved a conversation mid-stream and the
+    project mount was rehydrated late), every subsequent shell invocation has
+    to re-export credentials by hand or sourcing breaks. Persisting to the
+    home-dir fallback makes the next ``bash_tool`` call's ``python3 -c "from
+    scripts import remember; ..."`` Just Work without any explicit env
+    plumbing — the remembering library finds the file via its existing
+    well-known-paths search and loads the creds itself.
+
+    Idempotent: skips if the fallback file already exists. Never overwrites
+    user-managed creds. Silent on failure — this is a convenience side effect,
+    not a boot precondition.
+
+    Returns
+    -------
+    bool
+        True if a new fallback file was written, False otherwise (already
+        existed, no live creds available, or write failed).
+    """
+    try:
+        token = state._TOKEN
+        url = state._URL
+        if not token or not url:
+            return False
+        fallback_dir = Path.home() / ".muninn"
+        fallback_path = fallback_dir / ".env"
+        if fallback_path.exists():
+            return False  # Don't clobber user-managed creds
+        fallback_dir.mkdir(parents=True, exist_ok=True)
+        # 0600: token is a credential. mkdir doesn't take a mode reliably
+        # across umasks, so chmod after write.
+        fallback_path.write_text(
+            f"TURSO_TOKEN={token}\n"
+            f"TURSO_URL={url}\n"
+        )
+        try:
+            os.chmod(fallback_path, 0o600)
+        except OSError:
+            pass  # Best-effort permission tightening
+        return True
+    except Exception:
+        return False  # Side-effect only; never break boot
+
+
 def boot(mode: str = None, task: str = None, telemetry: bool = False) -> str:
     """Boot sequence: load profile + ops from Turso.
 
@@ -595,6 +650,12 @@ def boot(mode: str = None, task: str = None, telemetry: bool = False) -> str:
         else:
             return f"ERROR: Unable to load config (remote failed: {e}, no defaults available)"
     _mark("config_fetch")
+
+    # Persist working creds to ~/.muninn/.env so subsequent fresh shells in the
+    # same container can find them via remembering's existing fallback paths.
+    # Side-effect only, never breaks boot. See _persist_env_fallback() docstring.
+    _persist_env_fallback()
+    _mark("env_persist")
 
     if mode == "perch":
         return _boot_perch(profile_data, ops_data, task=task)

--- a/remembering/tests/test_hardening.py
+++ b/remembering/tests/test_hardening.py
@@ -471,6 +471,108 @@ def test_exec_batch_handles_non_json_response():
     print("PASS: _exec_batch handles non-JSON responses")
 
 
+# ── 8. Env fallback persistence (late-boot recovery) ──
+
+def test_persist_env_fallback_writes_when_missing():
+    """Writes ~/.muninn/.env from live state when no fallback file exists."""
+    from scripts import state
+    import importlib; boot_module = importlib.import_module("scripts.boot")
+    from pathlib import Path as RealPath
+
+    old_token, old_url = state._TOKEN, state._URL
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch("scripts.boot.Path.home", return_value=RealPath(tmp)):
+            try:
+                state._TOKEN = "test-token-xyz"
+                state._URL = "test.turso.io"
+                wrote = boot_module._persist_env_fallback()
+                assert wrote is True
+                env_file = RealPath(tmp) / ".muninn" / ".env"
+                assert env_file.exists()
+                content = env_file.read_text()
+                assert "TURSO_TOKEN=test-token-xyz" in content
+                assert "TURSO_URL=test.turso.io" in content
+                # Permissions should be 0600
+                mode = env_file.stat().st_mode & 0o777
+                assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+            finally:
+                state._TOKEN, state._URL = old_token, old_url
+
+    print("PASS: _persist_env_fallback writes ~/.muninn/.env when missing")
+
+
+def test_persist_env_fallback_skips_when_file_exists():
+    """Does not clobber an existing ~/.muninn/.env (user-managed creds)."""
+    from scripts import state
+    import importlib; boot_module = importlib.import_module("scripts.boot")
+    from pathlib import Path as RealPath
+
+    old_token, old_url = state._TOKEN, state._URL
+    with tempfile.TemporaryDirectory() as tmp:
+        home = RealPath(tmp)
+        muninn_dir = home / ".muninn"
+        muninn_dir.mkdir()
+        existing = muninn_dir / ".env"
+        existing.write_text("TURSO_TOKEN=existing-do-not-touch\n")
+
+        with patch("scripts.boot.Path.home", return_value=home):
+            try:
+                state._TOKEN = "new-different-token"
+                state._URL = "different.turso.io"
+                wrote = boot_module._persist_env_fallback()
+                assert wrote is False
+                # File contents must be unchanged
+                assert existing.read_text() == "TURSO_TOKEN=existing-do-not-touch\n"
+            finally:
+                state._TOKEN, state._URL = old_token, old_url
+
+    print("PASS: _persist_env_fallback preserves existing ~/.muninn/.env")
+
+
+def test_persist_env_fallback_silent_when_no_creds():
+    """Returns False without raising when state has no live creds."""
+    from scripts import state
+    import importlib; boot_module = importlib.import_module("scripts.boot")
+
+    old_token, old_url = state._TOKEN, state._URL
+    try:
+        state._TOKEN = None
+        state._URL = None
+        wrote = boot_module._persist_env_fallback()
+        assert wrote is False
+    finally:
+        state._TOKEN, state._URL = old_token, old_url
+
+    print("PASS: _persist_env_fallback returns False when no creds")
+
+
+def test_persist_env_fallback_never_raises():
+    """Side-effect helper must swallow all errors; boot must not break on it."""
+    from scripts import state
+    import importlib; boot_module = importlib.import_module("scripts.boot")
+    from pathlib import Path as RealPath
+
+    old_token, old_url = state._TOKEN, state._URL
+    with tempfile.TemporaryDirectory() as tmp:
+        # Create a regular file at the path where ".muninn" should be a dir.
+        # mkdir(parents=True, exist_ok=True) will raise FileExistsError because
+        # the path exists but isn't a directory. This works regardless of UID.
+        home = RealPath(tmp)
+        bogus_muninn = home / ".muninn"
+        bogus_muninn.write_text("not a directory")
+
+        try:
+            with patch("scripts.boot.Path.home", return_value=home):
+                state._TOKEN = "t"
+                state._URL = "u"
+                wrote = boot_module._persist_env_fallback()
+                assert wrote is False  # Returned cleanly, no exception
+        finally:
+            state._TOKEN, state._URL = old_token, old_url
+
+    print("PASS: _persist_env_fallback never raises")
+
+
 # ── Run all tests ──
 
 if __name__ == "__main__":
@@ -503,6 +605,11 @@ if __name__ == "__main__":
         # 7. JSON decode
         test_exec_handles_non_json_response,
         test_exec_batch_handles_non_json_response,
+        # 8. Env fallback persistence
+        test_persist_env_fallback_writes_when_missing,
+        test_persist_env_fallback_skips_when_file_exists,
+        test_persist_env_fallback_silent_when_no_creds,
+        test_persist_env_fallback_never_raises,
     ]
 
     passed = 0


### PR DESCRIPTION
## Problem

Each Claude tool call is a fresh shell — env vars set in one `bash_tool` call do **not** survive to the next. When `/mnt/project/turso.env` is missing or transiently unavailable, every subsequent shell has to re-export credentials by hand or sourcing fails.

Concrete failure mode (this session): user moved a conversation mid-stream into the Muninn project. The env files appeared in my context (top-of-prompt documents block) but `/mnt/project/` as a filesystem path was empty. Boot's `set -a; . /mnt/project/turso.env 2>/dev/null; set +a` masked the missing file silently, then `set -e` bailed with no message — five round-trips of forensics later I had to reconstruct the env from my own context into `/root/.muninn/.env` by hand.

The remembering library *already* supports `~/.muninn/.env` as a well-known fallback path ([`turso.py:33`](https://github.com/oaustegard/claude-skills/blob/main/remembering/scripts/turso.py#L33)) — there just was no automatic writer.

## Fix

After `boot()` confirms working credentials via Turso, write `~/.muninn/.env` from `state._TOKEN` and `state._URL`. Future fresh shells in the same container automatically pick up creds via the library's existing search path. No client-side change required.

```python
def _persist_env_fallback() -> bool:
    """Persist live Turso credentials to ~/.muninn/.env for cross-shell reuse."""
    ...
```

Properties:
- **Idempotent**: skips if `~/.muninn/.env` already exists — never clobbers user-managed creds
- **Silent**: returns `False` on any failure rather than raising; side effect, not precondition
- **Secure**: `0600` permissions (token is a credential)
- **Conditional**: only runs after Turso config-fetch succeeded with valid creds, never persists garbage

## Tests (4 new in `test_hardening.py`)

- writes when missing (verifies content + `0600` mode)
- skips when file exists (verifies preservation of user-managed creds)
- returns `False` when state has no creds
- never raises even on filesystem errors

```
Results: 25 passed, 0 failed out of 25
```

## End-to-end verification

Fresh shell, no `/mnt/project/`, no env vars set, only `~/.muninn/.env` present:

```python
from scripts.memory import recall
results = recall(tags=['preference'], n=2)
# → recalled 2 items via fallback file alone ✓
```

Solves the "late boot" failure mode where `/mnt/project/` was empty at boot time. Makes Muninn self-healing for this class of mount issue without changing the project-instructions boot script.
