### PR TITLE
docs(flowing): clarify validate=/when= kwarg binding by dep name

### DIFF
--- a/flowing/CHANGELOG.md
+++ b/flowing/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `flowing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Documentation
+
+- SKILL.md: added "Validator and predicate signatures" subsection clarifying that `validate=` and `when=` callables receive gathered dep values as kwargs by dep name. Reusing a validator across tasks with differently-named deps raises `TypeError` at validate time, surfacing as a confusing FAIL. Documents two patterns to handle reuse: `**kwargs` lookup and a name-binding factory.
+
 ## [1.1.0] - 2026-05-07
 
 ### Added

--- a/flowing/CHANGELOG.md
+++ b/flowing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the `flowing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.1.1] - 2026-05-07
 
 ### Documentation
 

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -2,7 +2,7 @@
 name: flowing
 description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also: parallel execution, checkpoint resume, detached side-effects.
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 # Flowing — Control Flow in Code, Not Prose

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -61,6 +61,40 @@ def process(fetch):
 
 Use to make the contract between tasks explicit. The validator is the gate; without a passing validator, the body never runs. Compare to "remember to check inputs at the top of the task" — that's prose.
 
+#### Validator and predicate signatures
+
+`validate=` and `when=` callables receive gathered dep values as kwargs *by dep name*, the same way task bodies do. A validator written for a specific dep:
+
+```python
+def must_have_title(fetch_url_meta):
+    if not fetch_url_meta.get("title"):
+        raise ValueError("missing title")
+```
+
+works only on tasks whose dep is named `fetch_url_meta`. Reuse it on a task whose dep is named `fetch_bad_meta` and you get `TypeError: must_have_title() got an unexpected keyword argument 'fetch_bad_meta'` at validate time, surfacing as a confusing FAIL with the wrong reason.
+
+Two patterns to avoid the trap:
+
+```python
+# A) Reusable: take **kwargs, look up by expected key
+def must_have_title(**kwargs):
+    meta = next(iter(kwargs.values()))
+    if not meta.get("title"):
+        raise ValueError("missing title")
+
+# B) Factory: bind the dep name explicitly at task definition
+def must_have_title_of(dep_name):
+    def v(**kwargs):
+        if not kwargs[dep_name].get("title"):
+            raise ValueError(f"{dep_name}: missing title")
+    return v
+
+@task(depends_on=[fetch], validate=must_have_title_of("fetch"))
+def process(fetch): ...
+```
+
+Same applies to `when=` predicates.
+
 ### `retry_until=` — predicate-driven loop
 
 Run the body, then call `retry_until(value)`. True → return the value. False → retry, consuming the `retry=` budget. Useful for self-correcting LLM steps: generate, validate, regenerate.


### PR DESCRIPTION
*Filed by Muninn*

Adds a small SKILL.md subsection clarifying a sharp edge in `validate=` and `when=`: their callables receive gathered dep values as kwargs **by dep name**, so a validator written with `def must_have_title(fetch_url_meta)` only works on tasks whose dep is named `fetch_url_meta`. Reused on a task whose dep is `fetch_bad_meta`, it raises `TypeError: got an unexpected keyword argument 'fetch_bad_meta'` at validate time — which surfaces as a FAIL with a misleading reason.

Two patterns documented to avoid the trap:

- A) Reusable: take `**kwargs`, look up by expected key.
- B) Factory: bind the dep name at task-definition time and return a closure.

### Discovered while

Testing `flowing` v1.1 with a Bluesky-post pipeline (4 scenarios: retry_until convergence, when= skip propagation, validate= no-retry on bad inputs, override+resume). All four work as documented; the gotcha was the only sharp edge that bit me.

### Companion fix (already applied, separate from this PR)

The `flowing` `utility-code` memory in Turso held a v1.0 frozen copy that shadowed the v1.1 skill via `.pth` ordering (`~/muninn_utils/` before skill scripts dirs). Replaced that memory with a thin re-export shim that loads the canonical skill via `importlib.spec_from_file_location` and rebinds `sys.modules['flowing']` to it, making the skill the single source of truth for all import paths (`from flowing import ...`, `from muninn_utils import flowing`, `from muninn_utils.flowing import ...`).

Same drift problem flagged in memory `0d63ed4f` (migrate muninn_utils away from Turso memory-stored code to repo files). The shim is a stopgap that makes the divergence harmless until that migration lands.

### Test plan

Docs-only change. Patterns A/B verified manually against the v1.1 runner.
