### PR TITLE
fix(flowing): auto-discover detached tasks downstream of terminals (v1.2.0)

### DIFF
--- a/flowing/CHANGELOG.md
+++ b/flowing/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `flowing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2026-05-07
+
+### Fixed
+
+- **Detached tasks downstream of terminals are now auto-discovered.** In v1.1.1, `Flow(main)` would silently skip a `@task(detached=True, depends_on=[main])` defined elsewhere; the task had to be passed as an additional terminal (`Flow(main, side_effect)`). The SKILL.md said "Run in a final layer after the main DAG" which implied auto-discovery. Now matches the docs: any detached task in the module registry whose `depends_on` are all reachable from declared terminals joins the run automatically. Detached tasks with unreachable deps are still ignored (they belong to a different graph).
+- **Detached-on-detached chains now layer correctly.** Previously `_execute_detached` ran all detached tasks in one parallel layer, so `detachB(depends_on=[detachA], detached=True)` would be SKIPPED because `detachA` hadn't completed yet. Detached execution now uses topological layering inside the detached subset.
+
+### Added
+
+- Module-level `_TASK_REGISTRY` populated by the `@task` decorator. Used by `Flow._collect_tasks` to find detached candidates for auto-discovery.
+- Test class `TestDetachedAutoDiscovery` (5 tests): direct downstream auto-discovery, backward-compat with explicit terminal, detached-on-detached chains, isolation of unrelated detached tasks, failure-isolation preservation. Total suite now 20 tests.
+
 ## [1.1.1] - 2026-05-07
 
 ### Documentation

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -2,7 +2,7 @@
 name: flowing
 description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also: parallel execution, checkpoint resume, detached side-effects.
 metadata:
-  version: 1.1.1
+  version: 1.2.0
 ---
 
 # Flowing — Control Flow in Code, Not Prose
@@ -158,7 +158,23 @@ def store_memory(create_issue):
     remember(create_issue["url"], ...)
 ```
 
-Run in a final layer after the main DAG. Failures collected in `flow.detached_failures`, never trigger `fail_fast`. Dependencies must all be SUCCEEDED.
+Run in topologically-sorted layers after the main DAG. Failures collected in `flow.detached_failures`, never trigger `fail_fast`. Dependencies must all be SUCCEEDED for a detached task to run.
+
+#### Auto-discovery (v1.2.0)
+
+A detached task whose `depends_on` are all reachable from the declared terminals is **auto-discovered** — you don't need to pass it as a terminal:
+
+```python
+@task
+def main_step(): ...
+
+@task(depends_on=[main_step], detached=True)
+def store(main_step): ...
+
+Flow(main_step).run()   # `store` runs automatically after main_step succeeds
+```
+
+Detached tasks may depend on other detached tasks; the chain is layered and runs in dependency order. Detached tasks whose deps are NOT reachable from any terminal are ignored — they belong to a different graph and should be terminals of their own `Flow`.
 
 ## When to use
 

--- a/flowing/scripts/flowing.py
+++ b/flowing/scripts/flowing.py
@@ -90,6 +90,14 @@ class TaskDef:
         return self is other
 
 
+# Module-level registry of all TaskDefs created via the @task decorator.
+# Used by Flow._collect_tasks to auto-discover detached tasks whose dependencies
+# are reachable from declared terminals (v1.2.0). Without this, a detached task
+# downstream of a terminal would silently never run, since the dep walk only
+# traverses depends_on backward.
+_TASK_REGISTRY: list[TaskDef] = []
+
+
 # @lat: [[orchestration#DAG Workflow Runner]]
 def task(
     fn: Optional[Callable] = None,
@@ -119,6 +127,7 @@ def task(
             validate=validate,
             retry_until=retry_until,
         )
+        _TASK_REGISTRY.append(td)
         return td
 
     if fn is not None:
@@ -278,7 +287,14 @@ class Flow:
         self.detached_failures: list[StepResult] = []
 
     def _collect_tasks(self) -> tuple[set[TaskDef], set[TaskDef]]:
-        """Collect all tasks, separating main DAG from detached tasks."""
+        """Collect all tasks, separating main DAG from detached tasks.
+
+        v1.2.0: Auto-discovers detached tasks whose dependencies are all
+        reachable from declared terminals. Iterates to fixed point so that
+        chains of detached tasks (detachB -> detachA -> main) are picked up.
+        Detached tasks whose deps are NOT reachable are ignored — they belong
+        to a different graph.
+        """
         all_tasks: set[TaskDef] = set()
         stack = list(self.terminals)
         while stack:
@@ -286,6 +302,19 @@ class Flow:
             if t not in all_tasks:
                 all_tasks.add(t)
                 stack.extend(t.depends_on)
+
+        # Fixed-point pull-in of detached tasks from the module registry whose
+        # deps are all already reachable. Repeat until no new task is added so
+        # detached-on-detached chains resolve correctly.
+        while True:
+            added = False
+            for t in _TASK_REGISTRY:
+                if t.detached and t not in all_tasks:
+                    if t.depends_on and all(dep in all_tasks for dep in t.depends_on):
+                        all_tasks.add(t)
+                        added = True
+            if not added:
+                break
 
         main_tasks = {t for t in all_tasks if not t.detached}
         detached_tasks = {t for t in all_tasks if t.detached}
@@ -364,47 +393,56 @@ class Flow:
                     break
 
     def _execute_detached(self, detached_tasks: set[TaskDef]) -> None:
-        """Run detached tasks in one final parallel layer. Failures collected, not propagated."""
+        """Run detached tasks in topologically-sorted layers after the main DAG.
+        Failures collected in self.detached_failures, not propagated.
+
+        v1.2.0: Layered execution (was single-layer). A detached task may
+        depend on another detached task; layering ensures the dependency
+        runs first and its result is available.
+        """
         if not detached_tasks:
             return
 
-        # Only run detached tasks whose dependencies all succeeded
-        runnable = []
-        for t in detached_tasks:
-            deps_ok = all(
-                t_dep.name in self.results and
-                self.results[t_dep.name].state == StepState.SUCCEEDED
-                for t_dep in t.depends_on
-            )
-            if deps_ok:
-                runnable.append(t)
+        detached_layers = self._build_layers(detached_tasks)
+
+        for layer in detached_layers:
+            # Filter to tasks whose deps (main + earlier detached layers) all succeeded
+            runnable = []
+            for t in layer:
+                deps_ok = all(
+                    t_dep.name in self.results and
+                    self.results[t_dep.name].state == StepState.SUCCEEDED
+                    for t_dep in t.depends_on
+                )
+                if deps_ok:
+                    runnable.append(t)
+                else:
+                    skip_result = StepResult(
+                        name=t.name, state=StepState.SKIPPED, attempts=0)
+                    self.results[t.name] = skip_result
+
+            if not runnable:
+                continue
+
+            _log("DETACHED", tasks=",".join(t.name for t in runnable))
+
+            if len(runnable) > 1:
+                with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+                    futures = {
+                        pool.submit(_run_step, td, self.results): td
+                        for td in runnable
+                    }
+                    for future in as_completed(futures):
+                        result = future.result()
+                        self.results[result.name] = result
+                        if result.state == StepState.FAILED:
+                            self.detached_failures.append(result)
             else:
-                skip_result = StepResult(
-                    name=t.name, state=StepState.SKIPPED, attempts=0)
-                self.results[t.name] = skip_result
-
-        if not runnable:
-            return
-
-        _log("DETACHED", tasks=",".join(t.name for t in runnable))
-
-        if len(runnable) > 1:
-            with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
-                futures = {
-                    pool.submit(_run_step, td, self.results): td
-                    for td in runnable
-                }
-                for future in as_completed(futures):
-                    result = future.result()
+                for td in runnable:
+                    result = _run_step(td, self.results)
                     self.results[result.name] = result
                     if result.state == StepState.FAILED:
                         self.detached_failures.append(result)
-        else:
-            for td in runnable:
-                result = _run_step(td, self.results)
-                self.results[result.name] = result
-                if result.state == StepState.FAILED:
-                    self.detached_failures.append(result)
 
     def run(self) -> dict[str, StepResult]:
         """Execute the full DAG from scratch."""

--- a/flowing/tests/test_flowing.py
+++ b/flowing/tests/test_flowing.py
@@ -291,5 +291,127 @@ class TestComposition(unittest.TestCase):
         self.assertEqual(flow.value(converging)["n"], 2)
 
 
+
+class TestDetachedAutoDiscovery(unittest.TestCase):
+    """v1.2: detached tasks whose deps are reachable from declared terminals
+    should be auto-discovered and run, without needing to be passed as terminals.
+
+    Regression: in v1.1.1, `Flow(assemble)` with a `store_memory(detached=True,
+    depends_on=[assemble])` defined elsewhere would silently NOT run store_memory.
+    The user had to know to pass it: `Flow(assemble, store_memory)`. The SKILL.md
+    "Run in a final layer after the main DAG" implied auto-discovery.
+    """
+
+    def test_detached_downstream_of_terminal_auto_discovered(self):
+        """Detached task whose dep IS the terminal should run automatically."""
+        side_effects = []
+
+        @task
+        def main_step():
+            return "result"
+
+        @task(depends_on=[main_step], detached=True)
+        def store(main_step):
+            side_effects.append(("stored", main_step))
+            return "stored"
+
+        flow = Flow(main_step)  # NOTE: store NOT passed as terminal
+        results = flow.run()
+
+        self.assertEqual(results["main_step"].state, StepState.SUCCEEDED)
+        self.assertIn("store", results)
+        self.assertEqual(results["store"].state, StepState.SUCCEEDED)
+        self.assertEqual(side_effects, [("stored", "result")])
+
+    def test_detached_passed_as_terminal_still_works(self):
+        """Backward compat: explicitly passing detached as terminal still works."""
+        side_effects = []
+
+        @task
+        def main_step():
+            return "result"
+
+        @task(depends_on=[main_step], detached=True)
+        def store(main_step):
+            side_effects.append(main_step)
+
+        flow = Flow(main_step, store)
+        flow.run()
+        self.assertEqual(side_effects, ["result"])
+
+    def test_detached_chain_auto_discovered(self):
+        """Detached-on-detached: if detachB depends on detachA depends on main,
+        both should be auto-discovered when only main is the terminal."""
+        order = []
+
+        @task
+        def main_step():
+            order.append("main")
+            return 1
+
+        @task(depends_on=[main_step], detached=True)
+        def detach_a(main_step):
+            order.append("a")
+            return main_step + 1
+
+        @task(depends_on=[detach_a], detached=True)
+        def detach_b(detach_a):
+            order.append("b")
+            return detach_a + 1
+
+        flow = Flow(main_step)
+        results = flow.run()
+
+        self.assertEqual(results["main_step"].state, StepState.SUCCEEDED)
+        self.assertEqual(results["detach_a"].state, StepState.SUCCEEDED)
+        self.assertEqual(results["detach_b"].state, StepState.SUCCEEDED)
+        self.assertEqual(order, ["main", "a", "b"])
+
+    def test_unrelated_detached_not_picked_up(self):
+        """Detached tasks whose deps are NOT reachable from terminals should
+        NOT run — they belong to a different graph."""
+        side_effects = []
+
+        @task
+        def graph_a_step():
+            return "a"
+
+        @task
+        def graph_b_step():
+            return "b"
+
+        @task(depends_on=[graph_b_step], detached=True)
+        def graph_b_side(graph_b_step):
+            side_effects.append(graph_b_step)
+
+        flow = Flow(graph_a_step)  # only graph A
+        results = flow.run()
+
+        self.assertEqual(results["graph_a_step"].state, StepState.SUCCEEDED)
+        self.assertNotIn("graph_b_step", results)
+        self.assertNotIn("graph_b_side", results)
+        self.assertEqual(side_effects, [])
+
+    def test_detached_failure_still_isolated(self):
+        """Auto-discovered detached failure must still NOT trigger fail_fast
+        and must land in flow.detached_failures (existing detached semantics)."""
+
+        @task
+        def main_step():
+            return "ok"
+
+        @task(depends_on=[main_step], detached=True)
+        def flaky_side(main_step):
+            raise RuntimeError("side-effect blew up")
+
+        flow = Flow(main_step)
+        results = flow.run()
+
+        self.assertEqual(results["main_step"].state, StepState.SUCCEEDED)
+        self.assertEqual(results["flaky_side"].state, StepState.FAILED)
+        self.assertEqual(len(flow.detached_failures), 1)
+        self.assertEqual(flow.detached_failures[0].name, "flaky_side")
+
+
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main()


### PR DESCRIPTION
## What

v1.1.1 had an authoring trap I hit while testing flowing this session: `Flow(main)` would silently NOT run a `@task(detached=True, depends_on=[main])` defined elsewhere. The user had to know to pass it as an additional terminal: `Flow(main, side_effect)`. This contradicted the SKILL.md, which said "Run in a final layer after the main DAG."

Fix makes the runtime match the documented intent.

## Why

Detached tasks are *side-effects of the main DAG completing*. That semantic — implicit in the name and the docs — should be the default behavior. Requiring users to enumerate them as terminals is prose-imperative discipline ("remember to pass detached tasks too") that flowing's whole pitch is supposed to eliminate.

## How

- Module-level `_TASK_REGISTRY` populated by the `@task` decorator.
- `Flow._collect_tasks` scans the registry for detached tasks whose `depends_on` are all reachable from declared terminals. Iterates to fixed point so detached-on-detached chains resolve correctly.
- `_execute_detached` now layers the detached subset topologically (was single parallel layer). Chains run in dependency order; independent detached tasks within a layer still parallelize.
- Detached tasks with unreachable deps are *not* picked up — they belong to a different graph and should be terminals of their own `Flow`.

## Tests

New `TestDetachedAutoDiscovery` class, 5 cases:

1. Direct downstream auto-discovery (the regression).
2. Backward compat — passing detached as terminal still works.
3. Detached-on-detached chain layering.
4. Unrelated detached graph stays isolated (nothing pulled in).
5. Failure isolation preserved — auto-discovered detached failures still land in `detached_failures`, don't trigger `fail_fast`.

Total suite: 20 tests (was 15), all green.

## Discovery

Found while testing v1.1 features in a session today. Test artifact: a `fetch -> validate -> branch -> retry-until-valid -> assemble -> store_memory(detached)` pipeline. `Flow(assemble).run()` reported `detached=0` and `_stored["called"] == False` with no error. Took inspecting `_collect_tasks` to realize the backward dep walk doesn't reach downstream tasks. The SKILL.md's "Run in a final layer" wording made me expect auto-discovery; that expectation is now correct.

## Version

1.1.1 -> **1.2.0** (behavior change, not docs-only). CHANGELOG updated.