### PR TITLE
fix(turso): loosen retry budget for egress-proxy cold start

### DIFF
--- a/remembering/scripts/turso.py
+++ b/remembering/scripts/turso.py
@@ -14,6 +14,7 @@ import importlib
 import importlib.util
 import json
 import os
+import random
 import re
 import threading
 import time
@@ -173,13 +174,21 @@ def _sanitize_error(e: Exception) -> str:
     return msg
 
 
-def _retry_with_backoff(fn, max_retries=3, base_delay=1.0):
+def _retry_with_backoff(fn, max_retries=5, base_delay=0.5, jitter=True):
     """Retry a function with exponential backoff on transient errors.
+
+    Default budget: 5 attempts at 0.5, 1, 2, 4 seconds (~7.5s no-jitter,
+    ~7.5-11s with jitter) — tuned for egress-proxy cold-start (which can
+    take 5-10s to recover from 'DNS cache overflow' 503s). Old defaults
+    (3 attempts @ 1s, ~3s total) were too tight; cold starts routinely
+    exhausted them.
 
     Args:
         fn: Callable that may raise exceptions
-        max_retries: Maximum number of retry attempts (default 3)
-        base_delay: Initial delay in seconds (default 1.0)
+        max_retries: Maximum number of retry attempts (default 5)
+        base_delay: Initial delay in seconds (default 0.5)
+        jitter: If True, multiply each delay by a random factor in [1.0, 1.5)
+            to prevent thundering-herd retries from concurrent callers.
 
     Returns:
         Result of fn() if successful
@@ -211,7 +220,9 @@ def _retry_with_backoff(fn, max_retries=3, base_delay=1.0):
             )
             if is_retriable:
                 delay = base_delay * (2 ** attempt)
-                print(f"Warning: API request failed (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {_sanitize_error(e)}")
+                if jitter:
+                    delay *= random.uniform(1.0, 1.5)
+                print(f"Warning: API request failed (attempt {attempt + 1}/{max_retries}), retrying in {delay:.2f}s: {_sanitize_error(e)}")
                 time.sleep(delay)
             else:
                 # Non-retriable error, fail immediately

--- a/remembering/tests/test_remembering.py
+++ b/remembering/tests/test_remembering.py
@@ -436,6 +436,75 @@ def test_retry_exhaustion():
     print("PASS: Retry exhaustion raises last error")
 
 
+def test_retry_default_budget_is_five_attempts():
+    """Defaults bumped 3->5 attempts to handle egress-proxy cold start (~5-10s)."""
+    from scripts.turso import _retry_with_backoff
+    import time
+
+    call_count = 0
+
+    def always_fails():
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("503 Service Unavailable")
+
+    # Patch sleep so the test stays fast; we only care about attempt count.
+    orig_sleep = time.sleep
+    time.sleep = lambda _: None
+    try:
+        try:
+            _retry_with_backoff(always_fails, jitter=False)  # use new defaults
+            assert False, "should have raised"
+        except RuntimeError:
+            pass
+    finally:
+        time.sleep = orig_sleep
+
+    assert call_count == 5, f"Default budget should be 5 attempts, got {call_count}"
+    print("PASS: Default retry budget is 5 attempts")
+
+
+def test_retry_jitter_perturbs_delay():
+    """Jitter is on by default and multiplies each delay by [1.0, 1.5)."""
+    from scripts.turso import _retry_with_backoff
+    import time
+
+    delays = []
+    orig_sleep = time.sleep
+    time.sleep = lambda d: delays.append(d)
+    try:
+        try:
+            _retry_with_backoff(
+                lambda: (_ for _ in ()).throw(RuntimeError("503 Service Unavailable")),
+                max_retries=4, base_delay=1.0, jitter=True,
+            )
+        except RuntimeError:
+            pass
+    finally:
+        time.sleep = orig_sleep
+
+    # 4 attempts -> 3 retries -> 3 sleeps; each in [base*2^i, base*2^i*1.5)
+    assert len(delays) == 3
+    for i, d in enumerate(delays):
+        base = 1.0 * (2 ** i)
+        assert base <= d < base * 1.5, f"delay[{i}]={d} not in [{base}, {base*1.5})"
+    # And jitter=False produces exact powers of two
+    delays.clear()
+    time.sleep = lambda d: delays.append(d)
+    try:
+        try:
+            _retry_with_backoff(
+                lambda: (_ for _ in ()).throw(RuntimeError("503")),
+                max_retries=4, base_delay=1.0, jitter=False,
+            )
+        except RuntimeError:
+            pass
+    finally:
+        time.sleep = orig_sleep
+    assert delays == [1.0, 2.0, 4.0], f"jitter=False should give exact: got {delays}"
+    print("PASS: Jitter perturbs delays in [1.0x, 1.5x)")
+
+
 def test_recall_fts5_fallback_to_like():
     """Test 23: recall() falls back to LIKE query if FTS5 table missing"""
     from scripts import remember, recall, forget


### PR DESCRIPTION
## Why

Egress-proxy 503s ('DNS cache overflow') on cold start routinely take 5-10s to recover. The old retry budget — 3 attempts @ 1s base, ~3s total — exhausts before the proxy stabilizes, so cold-start `remember()` / `config_set()` calls fail with a noisy 503 even though the next call will succeed immediately. Documented as ops `proxy-503-retry-pattern`; this PR fixes the underlying retry path instead of asking callers to wrap each call in their own retry.

## Change

`_retry_with_backoff` defaults:
- `max_retries`: 3 → 5
- `base_delay`: 1.0 → 0.5  (sequence 0.5, 1, 2, 4 = 7.5s budget)
- New `jitter=True` (default): each delay multiplied by `[1.0, 1.5)` to prevent thundering-herd retries when several callers (e.g. boot's parallel memory ops) hit a cold proxy at once

## Tests

- 5 existing retry tests pass unchanged (they all pass `max_retries` explicitly, so default change doesn't affect them)
- 2 new: `test_retry_default_budget_is_five_attempts`, `test_retry_jitter_perturbs_delay`
- 25 hardening tests still green

## Companion work

Part of a 3-PR series triggered by Oskar asking whether we need a local SQLite cache. This is the cheapest of the three — a tighter retry budget probably resolves ~80% of what we observe. Follow-ups: hardened background writes (sync=False failure visibility) and an in-memory recall cache.
