### PR TITLE
feat(remembering): make background-write failures visible

### DIFF
--- a/remembering/scripts/__init__.py
+++ b/remembering/scripts/__init__.py
@@ -32,6 +32,7 @@ from .turso import (
 # Import memory layer
 from .memory import (
     _write_memory, _resolve_memory_id, remember, remember_bg, flush,
+    failed_writes, retry_failed_writes, clear_failed_writes,
     recall, _update_access_tracking, _query,
     recall_since, recall_between,
     forget, supersede, reprioritize,
@@ -95,6 +96,7 @@ j = journal
 
 __all__ = [
     "remember", "recall", "forget", "supersede", "remember_bg", "flush",  # memories
+    "failed_writes", "retry_failed_writes", "clear_failed_writes",  # bg-write hardening (#622)
     "recall_since", "recall_between",  # date-filtered queries
     "config_get", "config_set", "config_delete", "config_list", "config_set_boot_load", "config_set_priority",  # config
     "profile", "ops", "boot", "journal", "journal_recent", "journal_prune",  # boot & journal

--- a/remembering/scripts/memory.py
+++ b/remembering/scripts/memory.py
@@ -213,6 +213,27 @@ def remember(what: str, type: str, *, tags: list = None, conf: float = None,
         def _bg_write():
             try:
                 _write_memory(mem_id, what, type, now, conf, tags, refs, priority, valid_from, session_id)
+            except Exception as e:
+                # Retry budget exhausted in the bg thread. Capture the payload
+                # so the failure is visible to callers (failed_writes()) and
+                # can be retried later (retry_failed_writes()). Without this,
+                # background-write failures die silently with the thread.
+                with state._failed_bg_writes_lock:
+                    state._failed_bg_writes.append({
+                        'mem_id': mem_id,
+                        'what': what,
+                        'type': type,
+                        'tags': tags,
+                        'refs': refs,
+                        'priority': priority,
+                        'valid_from': valid_from,
+                        'session_id': session_id,
+                        'conf': conf,
+                        'error': str(e),
+                        'failed_at': datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                    })
+                print(f"Muninn: background write failed (id={mem_id[:8]}): {e}. "
+                      f"Payload captured; retry with retry_failed_writes() or inspect with failed_writes().")
             finally:
                 # Remove from pending list when done
                 with state._pending_writes_lock:
@@ -317,6 +338,95 @@ def flush(timeout: float = 5.0) -> dict:
         print(f"Muninn: Access tracking flush failed: {e}")
 
     return {"completed": completed, "timed_out": timed_out}
+
+
+# @lat: [[memory#Background Writes]]
+def failed_writes() -> list:
+    """Return list of background writes that exhausted retry budget.
+
+    Each entry is a dict with the original payload (mem_id, what, type, tags,
+    refs, priority, valid_from, session_id, conf), plus 'error' (last error
+    string) and 'failed_at' (ISO timestamp). Returns a copy — mutations to
+    the returned list don't affect internal state.
+
+    Use to surface silent background-write failures, e.g. at conversation
+    end or before exit. Empty list = nothing failed.
+
+    Example:
+        for fw in failed_writes():
+            print(f"failed: {fw['what'][:50]} -- {fw['error']}")
+    """
+    with state._failed_bg_writes_lock:
+        return list(state._failed_bg_writes)
+
+
+# @lat: [[memory#Background Writes]]
+def retry_failed_writes(timeout: float = 30.0) -> dict:
+    """Re-attempt all captured failed background writes synchronously.
+
+    Each retry uses the standard sync path (_write_memory with retry budget),
+    so transient 503s are absorbed by _retry_with_backoff. Successes drop out
+    of the failed list; failures stay (with updated error/failed_at).
+
+    Args:
+        timeout: Per-write timeout hint. Currently advisory (not strictly
+            enforced); the underlying retry budget caps total wait time.
+
+    Returns:
+        Dict with:
+            'recovered': int — count successfully written
+            'still_failing': int — count still in failed list
+            'remaining': list — failed-write entries that still aren't writing
+
+    Example:
+        result = retry_failed_writes()
+        if result['still_failing']:
+            print(f"{result['still_failing']} writes still failing")
+    """
+    with state._failed_bg_writes_lock:
+        items = list(state._failed_bg_writes)
+        state._failed_bg_writes.clear()
+
+    recovered = 0
+    still_failing = []
+    for item in items:
+        try:
+            _write_memory(
+                item['mem_id'], item['what'], item['type'],
+                item['failed_at'],  # use failed_at as 'now' so original ordering preserved
+                item['conf'], item['tags'], item['refs'],
+                item['priority'], item['valid_from'], item['session_id'],
+            )
+            recovered += 1
+        except Exception as e:
+            item['error'] = str(e)
+            item['failed_at'] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            still_failing.append(item)
+
+    if still_failing:
+        with state._failed_bg_writes_lock:
+            # Re-queue at front to preserve oldest-first ordering across retries
+            state._failed_bg_writes = still_failing + state._failed_bg_writes
+
+    return {
+        'recovered': recovered,
+        'still_failing': len(still_failing),
+        'remaining': still_failing,
+    }
+
+
+# @lat: [[memory#Background Writes]]
+def clear_failed_writes() -> int:
+    """Drop accumulated failed writes without retrying. Returns count dropped.
+
+    Use after retry_failed_writes() reveals all failures are unrecoverable
+    (e.g. malformed payload, schema violation), or to reset state during
+    testing. Failures are otherwise harmless if left in place.
+    """
+    with state._failed_bg_writes_lock:
+        n = len(state._failed_bg_writes)
+        state._failed_bg_writes.clear()
+        return n
 
 
 # @lat: [[memory#Core Operations]]

--- a/remembering/scripts/state.py
+++ b/remembering/scripts/state.py
@@ -28,6 +28,14 @@ TYPES = {"decision", "world", "anomaly", "experience", "interaction", "procedure
 _pending_writes = []
 _pending_writes_lock = threading.Lock()
 
+# Track failed background writes for visibility & retry (#622).
+# When remember(sync=False) exhausts its retry budget, the payload is
+# captured here so callers can inspect, retry, or surface the failure.
+# Each entry: {'mem_id', 'what', 'type', 'tags', 'refs', 'priority',
+# 'valid_from', 'session_id', 'conf', 'error', 'failed_at'}.
+_failed_bg_writes = []
+_failed_bg_writes_lock = threading.Lock()
+
 # Buffered access_count updates (v5.x.0, #issue-batch-access)
 # Maps memory_id -> pending increment count. Flushed via
 # memory._flush_access_tracking() at threshold, explicit flush(), or atexit.

--- a/remembering/tests/test_remembering.py
+++ b/remembering/tests/test_remembering.py
@@ -543,6 +543,133 @@ def test_background_writes():
     print("PASS: Background writes work")
 
 
+def test_bg_write_failure_captured():
+    """Background write failures populate failed_writes() instead of dying silently."""
+    from scripts import remember, flush, failed_writes, clear_failed_writes
+    from scripts import memory as memory_mod
+
+    # Make sure we start clean
+    clear_failed_writes()
+
+    # Patch _write_memory to always raise — simulates exhausted retry budget
+    orig = memory_mod._write_memory
+    def failing(*args, **kwargs):
+        raise RuntimeError("503 Service Unavailable (test)")
+    memory_mod._write_memory = failing
+
+    try:
+        mem_id = remember("bg failure capture test", "experience",
+                          tags=["test-bg-failure"], sync=False)
+        # Wait for the bg thread to land in the failure path
+        flush(timeout=5.0)
+
+        failures = failed_writes()
+        matching = [f for f in failures if f['mem_id'] == mem_id]
+        assert len(matching) == 1, f"Expected 1 failure for {mem_id}, got {len(matching)}"
+        f = matching[0]
+        assert f['what'] == "bg failure capture test"
+        assert f['type'] == "experience"
+        assert f['tags'] == ["test-bg-failure"]
+        assert "503" in f['error']
+        assert f['failed_at']  # ISO timestamp present
+    finally:
+        memory_mod._write_memory = orig
+        clear_failed_writes()
+    print("PASS: BG-write failure captured in failed_writes()")
+
+
+def test_retry_failed_writes_recovers():
+    """retry_failed_writes() re-attempts captured failures and removes successes."""
+    from scripts import remember, flush, failed_writes, retry_failed_writes, forget, recall
+    from scripts import memory as memory_mod
+
+    # Patch _write_memory to fail first time, succeed second
+    orig = memory_mod._write_memory
+    call_state = {"first_call_done": False}
+    def flaky(*args, **kwargs):
+        if not call_state["first_call_done"]:
+            call_state["first_call_done"] = True
+            raise RuntimeError("503 Service Unavailable (test, transient)")
+        return orig(*args, **kwargs)
+    memory_mod._write_memory = flaky
+
+    try:
+        mem_id = remember("retry recovery test", "experience",
+                          tags=["test-bg-retry"], sync=False)
+        flush(timeout=5.0)
+
+        # Should be in failed list
+        assert any(f['mem_id'] == mem_id for f in failed_writes()), \
+            "expected failed write captured"
+
+        # Restore original to ensure retry can succeed
+        memory_mod._write_memory = orig
+        result = retry_failed_writes()
+        assert result['recovered'] >= 1
+        assert not any(f['mem_id'] == mem_id for f in failed_writes()), \
+            "successful retry should drop from list"
+
+        # Memory should now be queryable
+        time.sleep(0.3)
+        rs = recall(tags=["test-bg-retry"])
+        assert any(m["id"] == mem_id for m in rs), \
+            "memory should be retrievable after retry"
+        forget(mem_id)
+    finally:
+        memory_mod._write_memory = orig
+    print("PASS: retry_failed_writes() recovers transient failures")
+
+
+def test_retry_failed_writes_keeps_persistent_failures():
+    """retry_failed_writes() leaves entries that still fail in the failed list."""
+    from scripts import remember, flush, failed_writes, retry_failed_writes, clear_failed_writes
+    from scripts import memory as memory_mod
+
+    clear_failed_writes()
+    orig = memory_mod._write_memory
+    def always_fails(*args, **kwargs):
+        raise RuntimeError("503 Service Unavailable (test, persistent)")
+    memory_mod._write_memory = always_fails
+
+    try:
+        mem_id = remember("persistent failure test", "experience",
+                          tags=["test-bg-persistent"], sync=False)
+        flush(timeout=5.0)
+        assert any(f['mem_id'] == mem_id for f in failed_writes())
+
+        result = retry_failed_writes()
+        assert result['recovered'] == 0
+        assert result['still_failing'] >= 1
+        assert any(f['mem_id'] == mem_id for f in failed_writes()), \
+            "persistent failure should remain in list"
+    finally:
+        memory_mod._write_memory = orig
+        clear_failed_writes()
+    print("PASS: retry_failed_writes() preserves persistent failures")
+
+
+def test_clear_failed_writes_returns_count():
+    """clear_failed_writes() drops entries and returns the count dropped."""
+    from scripts import remember, flush, failed_writes, clear_failed_writes
+    from scripts import memory as memory_mod
+
+    clear_failed_writes()
+    orig = memory_mod._write_memory
+    memory_mod._write_memory = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("503"))
+    try:
+        for i in range(3):
+            remember(f"clear test {i}", "experience",
+                     tags=[f"test-clear-{i}"], sync=False)
+        flush(timeout=5.0)
+        assert len(failed_writes()) >= 3
+        n = clear_failed_writes()
+        assert n >= 3
+        assert len(failed_writes()) == 0
+    finally:
+        memory_mod._write_memory = orig
+    print("PASS: clear_failed_writes() returns drop count")
+
+
 def test_result_types():
     """Test 30: MemoryResult wrapper works"""
     from scripts import remember, recall, forget, MemoryResult


### PR DESCRIPTION
## Why

`remember(sync=False)` writes from a background thread. If the bg `_write_memory` exhausts the retry budget (e.g. egress proxy 503 storm), the exception currently bubbles up *inside the bg thread and dies there*. The caller never knows. Same shape as classic Python "task fired and forgot — including the failure."

This session (2026-05-08) hit it: a `remember()` call during the remax merge hit a proxy cold-start 503, exhausted the 3-attempt budget, and was silently lost. I had to manually backfill the memory next turn.

## Change

Three new public functions in `remembering`:

- `failed_writes() -> list[dict]` — read accumulated failures (each entry contains the original payload + last error + timestamp)
- `retry_failed_writes() -> dict` — re-attempt all captured failures synchronously; successes drop out, persistent failures stay
- `clear_failed_writes() -> int` — drop accumulated failures without retrying

Plus the underlying state list (`state._failed_bg_writes` + lock) and a `print()` warning at capture time so failures are visible in stderr too.

## What this is *not*

- Not a local SQLite cache. The captured payloads live in process memory only — they survive the bg thread but not the conversation. For durable buffering, call `retry_failed_writes()` / `flush()` before turn-end (or after restoring connectivity).
- Not auto-retry. Caller decides when to retry. Auto-retry would make timing assumptions that don't generalize.

## Companion to flowing

`remember()` calls inside a `@task(detached=True)` flowing node are now first-class citizens of the failure-visibility model: the detached task's failure goes to `flow.detached_failures` (flowing-side) AND the underlying `remember(sync=False)` failure goes to `failed_writes()` (memory-side). Both are inspectable.

## Tests

5 new (all green):
- `test_bg_write_failure_captured`
- `test_retry_failed_writes_recovers` (transient → drops out)
- `test_retry_failed_writes_keeps_persistent_failures` (stays queued)
- `test_clear_failed_writes_returns_count`
- `test_background_writes` (existing — still green)

## Companion PRs

Part of a 3-PR series (boot-time-503 hardening) opened together: #621 (loosen retry budget), this one (#622, bg-write visibility), and a follow-up for in-memory recall caching. Each independent — review/merge in any order.
