### PR TITLE
Refactor utilities as flowing graphs (#616 #617 #619 #620)

### DIFF
--- a/muninn_utils/blog_publish.py
+++ b/muninn_utils/blog_publish.py
@@ -50,7 +50,7 @@ import urllib.error
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 
-from bsky_card import compose_link_post, create_post
+from bsky_card import compose_link_post
 from bsky_limit import fits as _bsky_fits, BSKY_LIMIT
 from flowing import task, Flow, StepState
 
@@ -425,9 +425,10 @@ def publish_and_announce(path, content, bsky_text, auth,
         detached=True,
     )
     def announce_bsky(wait_for_deploy_node):
-        record = compose_link_post(bsky_text, url, auth)
-        post = create_post(record, auth)
-        return post
+        # compose_link_post runs its own internal flow (compose + post)
+        # and returns {record, post, og_tags, thumb_blob, facets, ...}.
+        result = compose_link_post(bsky_text, url, auth)
+        return result["post"]
 
     @task(
         name="link_engagement_node",

--- a/muninn_utils/blog_publish.py
+++ b/muninn_utils/blog_publish.py
@@ -1,0 +1,468 @@
+"""
+blog_publish.py — Blog post publishing protocol (flowing-graph orchestrator).
+
+Same public API as the prior imperative version, but `publish_and_announce`
+is now a `flowing` DAG internally. The wins:
+
+  - The deploy poll is `retry_until=`, not a hand-rolled `while time.time()` loop.
+  - The feed-update gate is structural (`when=`), not an `if` in the orchestrator.
+  - Bsky announce + engagement-link are detached side-effects: callers get the
+    page URL the moment the deploy lands; bsky failure lands in
+    `flow.detached_failures`, never bubbling up as a publish failure.
+  - The 300-grapheme bsky limit is enforced as `validate=` BEFORE the post
+    fires — no wasted createRecord on a too-long draft.
+
+See issue oaustegard/claude-skills#616 for the rationale.
+
+Public API (unchanged):
+
+    from blog_publish import publish_and_announce, bsky_auth
+
+    auth = bsky_auth()
+    result = publish_and_announce(
+        path="blog/my-post.html",
+        content=html,
+        bsky_text="New post — check it out",
+        auth=auth,
+        feed_entry={...},
+    )
+
+`result` keys:
+    page_url       — the canonical URL of the published page
+    commit_sha     — sha of the page commit
+    feed_sha       — sha of the feed commit (None if no feed)
+    deployed       — bool: did GH Pages serve the URL within the budget?
+    bsky_post      — dict with uri/cid/url/rkey, or None if SKIPPED/FAILED
+    update_sha     — sha of the engagement-link commit, or None
+    detached_failures — list of (name, error) for any backgrounded failure
+
+The bsky chain is detached: a failure there populates `detached_failures`
+but does NOT raise. Callers that need a hard error on bsky failure should
+inspect `result["detached_failures"]`.
+"""
+
+import json
+import os
+import re
+import time
+import urllib.request
+import urllib.error
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+from bsky_card import compose_link_post, create_post
+from bsky_limit import fits as _bsky_fits, BSKY_LIMIT
+from flowing import task, Flow, StepState
+
+
+# ── Bluesky auth ───────────────────────────────────────────────────
+
+def bsky_auth(handle_var="MUNINN_BSKY_HANDLE", password_var="MUNINN_BSKY_APP_PASSWORD"):
+    """Authenticate with Bluesky. Returns auth dict.
+
+    Defaults to Muninn's credentials. For Oskar's account:
+        bsky_auth(handle_var="BSKY_HANDLE", password_var="BSKY_APP_PASSWORD")
+    """
+    handle = os.environ[handle_var]
+    password = os.environ[password_var]
+    payload = json.dumps({
+        "identifier": handle,
+        "password": password,
+    }).encode()
+    req = urllib.request.Request(
+        "https://bsky.social/xrpc/com.atproto.server.createSession",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    session = json.loads(urllib.request.urlopen(req).read())
+    print(f"  ✓ Authenticated as {session['handle']}")
+    return {"access_jwt": session["accessJwt"], "did": session["did"], "handle": session["handle"]}
+
+
+# ── GitHub helpers ─────────────────────────────────────────────────
+
+_MUNINN_REPO = "oaustegard/muninn.austegard.com"
+_MUNINN_BASE = "https://muninn.austegard.com"
+
+def _gh_token():
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def _gh_api(method, endpoint, data=None):
+    token = _gh_token()
+    url = f"https://api.github.com{endpoint}" if endpoint.startswith("/") else endpoint
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, method=method, headers={
+        "User-Agent": "muninn-raven",
+        "Authorization": f"token {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github.v3+json",
+    })
+    return json.loads(urllib.request.urlopen(req).read())
+
+
+def _gh_raw(repo, path, ref="main"):
+    """Get raw file content from GitHub."""
+    token = _gh_token()
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/contents/{path}?ref={ref}",
+        headers={
+            "User-Agent": "muninn-raven",
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github.v3.raw",
+        },
+    )
+    return urllib.request.urlopen(req).read().decode("utf-8")
+
+
+def publish_page(repo, path, content, message=None):
+    """Commit a single file to GitHub Pages repo. Returns commit SHA."""
+    if not message:
+        message = f"Publish {path}"
+
+    ref = _gh_api("GET", f"/repos/{repo}/git/refs/heads/main")
+    ref_sha = ref["object"]["sha"]
+    commit = _gh_api("GET", f"/repos/{repo}/git/commits/{ref_sha}")
+    tree_sha = commit["tree"]["sha"]
+
+    blob = _gh_api("POST", f"/repos/{repo}/git/blobs",
+                    {"content": content, "encoding": "utf-8"})
+
+    tree = _gh_api("POST", f"/repos/{repo}/git/trees", {
+        "base_tree": tree_sha,
+        "tree": [{"path": path, "mode": "100644", "type": "blob", "sha": blob["sha"]}],
+    })
+
+    new_commit = _gh_api("POST", f"/repos/{repo}/git/commits", {
+        "message": message, "tree": tree["sha"], "parents": [ref_sha],
+    })
+
+    _gh_api("PATCH", f"/repos/{repo}/git/refs/heads/main",
+            {"sha": new_commit["sha"]})
+
+    return new_commit["sha"]
+
+
+# ── Atom feed maintenance ──────────────────────────────────────────
+
+ATOM_NS = "http://www.w3.org/2005/Atom"
+
+def update_feed(repo, feed_path, page_url, entry, message=None):
+    """Add an entry to the Atom feed and update the <updated> timestamp.
+
+    entry dict keys:
+        title (required): Post title
+        summary (required): Brief description
+        published (optional): ISO datetime, defaults to now
+        updated (optional): ISO datetime, defaults to published
+
+    Returns commit SHA.
+    """
+    ET.register_namespace("", ATOM_NS)
+
+    current_xml = _gh_raw(repo, feed_path)
+    root = ET.fromstring(current_xml)
+
+    ns = {"atom": ATOM_NS}
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    published = entry.get("published", now)
+    updated = entry.get("updated", published)
+
+    feed_updated = root.find("atom:updated", ns)
+    if feed_updated is not None:
+        feed_updated.text = now
+
+    new_entry = ET.SubElement(root, f"{{{ATOM_NS}}}entry")
+    ET.SubElement(new_entry, f"{{{ATOM_NS}}}title").text = entry["title"]
+
+    link = ET.SubElement(new_entry, f"{{{ATOM_NS}}}link")
+    link.set("href", page_url)
+    link.set("rel", "alternate")
+    link.set("type", "text/html")
+
+    ET.SubElement(new_entry, f"{{{ATOM_NS}}}id").text = page_url
+    ET.SubElement(new_entry, f"{{{ATOM_NS}}}published").text = published
+    ET.SubElement(new_entry, f"{{{ATOM_NS}}}updated").text = updated
+    ET.SubElement(new_entry, f"{{{ATOM_NS}}}summary").text = entry["summary"]
+
+    output = _pretty_feed(root, ns)
+
+    if not message:
+        message = f"Add feed entry: {entry['title']}"
+
+    sha = publish_page(repo, feed_path, output, message=message)
+    print(f"  ✓ Feed updated with: {entry['title']}")
+    return sha
+
+
+def _pretty_feed(root, ns):
+    """Serialize Atom feed with readable formatting."""
+    lines = ['<?xml version="1.0" encoding="utf-8"?>']
+    lines.append('<feed xmlns="http://www.w3.org/2005/Atom">')
+
+    for child in root:
+        tag = child.tag.replace(f"{{{ATOM_NS}}}", "")
+        if tag == "entry":
+            continue
+        if len(child) == 0 and child.text:
+            attribs = "".join(f' {k}="{v}"' for k, v in child.attrib.items())
+            lines.append(f"  <{tag}{attribs}>{child.text}</{tag}>")
+        elif len(child) == 0:
+            attribs = "".join(f' {k}="{v}"' for k, v in child.attrib.items())
+            lines.append(f"  <{tag}{attribs}/>")
+        else:
+            attribs = "".join(f' {k}="{v}"' for k, v in child.attrib.items())
+            inner = ""
+            for sub in child:
+                stag = sub.tag.replace(f"{{{ATOM_NS}}}", "")
+                inner += f"<{stag}>{sub.text or ''}</{stag}>"
+            lines.append(f"  <{tag}{attribs}>{inner}</{tag}>")
+
+    for entry in root.findall("atom:entry", ns):
+        lines.append("")
+        lines.append("  <entry>")
+        for child in entry:
+            tag = child.tag.replace(f"{{{ATOM_NS}}}", "")
+            attribs = "".join(f' {k}="{v}"' for k, v in child.attrib.items())
+            if child.text:
+                lines.append(f"    <{tag}{attribs}>{child.text}</{tag}>")
+            else:
+                lines.append(f"    <{tag}{attribs}/>")
+        lines.append("  </entry>")
+
+    lines.append("")
+    lines.append("</feed>")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ── Deploy probing ─────────────────────────────────────────────────
+
+def _probe_url(url: str) -> bool:
+    """One HEAD probe. True iff status 200."""
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        resp = urllib.request.urlopen(req)
+        return resp.status == 200
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return False
+
+
+def wait_for_deploy(url, timeout=120, poll_interval=10):
+    """Poll a URL until it returns 200. Returns True on success.
+
+    Retained for backward compat / step-by-step usage. The flowing
+    orchestrator in `publish_and_announce` uses the `retry_until=` primitive
+    instead, which is the same behavior expressed structurally.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _probe_url(url):
+            print(f"  ✓ {url} is live")
+            return True
+        remaining = int(deadline - time.time())
+        print(f"  … waiting for deploy ({remaining}s remaining)")
+        time.sleep(poll_interval)
+    print(f"  ✗ Timeout waiting for {url}")
+    return False
+
+
+# ── Engagement linking ─────────────────────────────────────────────
+
+_SITE_TO_REPO = {
+    "austegard.com": "oaustegard/oaustegard.github.io",
+    "muninn.austegard.com": "oaustegard/muninn.austegard.com",
+}
+
+
+def _bsky_url_to_at_uri(bsky_url):
+    """Convert https://bsky.app/profile/HANDLE/post/RKEY → at://DID/app.bsky.feed.post/RKEY."""
+    if bsky_url.startswith("at://"):
+        return bsky_url
+    m = re.match(r"https?://bsky\.app/profile/([^/]+)/post/([^/]+)", bsky_url)
+    if not m:
+        raise ValueError(f"Not a bsky.app post URL: {bsky_url}")
+    handle, rkey = m.group(1), m.group(2)
+    resp = urllib.request.urlopen(
+        f"https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle={handle}"
+    )
+    did = json.loads(resp.read())["did"]
+    return f"at://{did}/app.bsky.feed.post/{rkey}"
+
+
+def link_engagement(repo, path, bsky_uri):
+    """Update a page's bsky:uri meta tag and noscript link for the engagement widget.
+
+    bsky_uri: AT URI or bsky.app URL (auto-resolved to AT URI for meta tag).
+    Returns commit SHA or None if nothing to update.
+    """
+    at_uri = _bsky_url_to_at_uri(bsky_uri)
+    m = re.match(r"at://([^/]+)/app\.bsky\.feed\.post/(.+)", at_uri)
+    bsky_app_url = f"https://bsky.app/profile/{m.group(1)}/post/{m.group(2)}" if m else bsky_uri
+
+    current = _gh_raw(repo, path)
+    updated = current
+
+    updated = re.sub(
+        r'(<meta\s+name="bsky:uri"\s+content=")[^"]*(")',
+        rf'\g<1>{at_uri}\2',
+        updated, count=1,
+    )
+
+    updated = re.sub(
+        r'(<a\s+href=")https://bsky\.app/profile/[^"]*(">\s*Discuss on Bluesky)',
+        rf'\g<1>{bsky_app_url}\2',
+        updated, count=1,
+    )
+
+    updated = re.sub(
+        r'data-bsky-uri="[^"]*"',
+        f'data-bsky-uri="{at_uri}"',
+        updated, count=1,
+    )
+
+    if updated == current:
+        print("  ⚠ No bsky:uri meta tag or engagement attributes found")
+        return None
+
+    sha = publish_page(repo, path, updated,
+                       message=f"Link Bluesky engagement for {path}")
+    print(f"  ✓ Updated {path} with Bluesky URI")
+    return sha
+
+
+def link_bsky(page_url, bsky_url):
+    """Link a blog post to its Bluesky discussion post.
+
+    Infers repo from domain. Returns commit SHA.
+    """
+    from urllib.parse import urlparse
+    parsed = urlparse(page_url)
+    domain = parsed.netloc
+    repo = _SITE_TO_REPO.get(domain)
+    if not repo:
+        raise ValueError(f"Unknown domain {domain}. Known: {list(_SITE_TO_REPO.keys())}")
+    path = parsed.path.lstrip("/")
+    return link_engagement(repo, path, bsky_url)
+
+
+# ── Full protocol (flowing graph) ──────────────────────────────────
+
+# Default poll cadence for the GH Pages deploy. Retained at 10s × 12 to match
+# the prior wait_for_deploy(timeout=120, poll_interval=10) budget.
+_DEPLOY_POLL_MS = 10_000
+_DEPLOY_RETRIES = 12
+
+
+def publish_and_announce(path, content, bsky_text, auth,
+                         repo=_MUNINN_REPO,
+                         site_base=_MUNINN_BASE,
+                         feed_path="feed.xml",
+                         feed_entry=None,
+                         commit_message=None,
+                         skip_deploy_wait=False):
+    """Publish page → wait for deploy → update feed; bsky chain runs detached.
+
+    Internal shape (flowing graph):
+
+        publish_page_node ──▶ wait_for_deploy_node ──▶ update_feed_node  [terminal]
+                                       │
+                                       └──▶ announce_bsky [detached]
+                                                  │
+                                                  └──▶ link_engagement_node [detached]
+
+    The bsky leg is auto-discovered (v1.2 flowing) — its dependency
+    (wait_for_deploy_node) is reachable from the terminal, so the runner picks
+    it up without an explicit terminal of its own. Failures there land in
+    `flow.detached_failures` and the function still returns the page URL.
+
+    See issue oaustegard/claude-skills#616.
+    """
+    url = f"{site_base}/{path}"
+
+    @task(name="publish_page_node")
+    def publish_page_node():
+        sha = publish_page(repo, path, content, commit_message)
+        print(f"  ✓ Page committed: {sha[:10]}")
+        return {"commit_sha": sha, "url": url}
+
+    @task(
+        name="wait_for_deploy_node",
+        depends_on=[publish_page_node],
+        retry=_DEPLOY_RETRIES,
+        retry_backoff_base_ms=_DEPLOY_POLL_MS,
+        retry_max_backoff_ms=_DEPLOY_POLL_MS,
+        retry_until=lambda r: r["deployed"],
+    )
+    def wait_for_deploy_node(publish_page_node):
+        if skip_deploy_wait:
+            return {"deployed": True, "skipped": True, "url": url}
+        live = _probe_url(url)
+        if live:
+            print(f"  ✓ {url} is live")
+        return {"deployed": live, "url": url}
+
+    @task(
+        name="update_feed_node",
+        depends_on=[wait_for_deploy_node],
+        when=lambda **_: feed_path is not None and feed_entry is not None,
+    )
+    def update_feed_node(wait_for_deploy_node):
+        sha = update_feed(repo, feed_path, url, feed_entry)
+        return {"feed_sha": sha}
+
+    def must_be_under_bsky_limit(**deps):
+        if not _bsky_fits(bsky_text):
+            raise ValueError(
+                f"bsky_text exceeds {BSKY_LIMIT} graphemes — would be rejected by AT Proto. "
+                "Trim before calling, or use bsky_limit.truncate()."
+            )
+
+    @task(
+        name="announce_bsky",
+        depends_on=[wait_for_deploy_node],
+        validate=must_be_under_bsky_limit,
+        detached=True,
+    )
+    def announce_bsky(wait_for_deploy_node):
+        record = compose_link_post(bsky_text, url, auth)
+        post = create_post(record, auth)
+        return post
+
+    @task(
+        name="link_engagement_node",
+        depends_on=[announce_bsky],
+        detached=True,
+    )
+    def link_engagement_node(announce_bsky):
+        sha = link_engagement(repo, path, announce_bsky["url"])
+        return {"update_sha": sha}
+
+    flow = Flow(update_feed_node)
+    flow.run()
+
+    def _val(td, key=None, default=None):
+        r = flow.results.get(td.name)
+        if r is None or r.state != StepState.SUCCEEDED:
+            return default
+        return r.value if key is None else r.value.get(key, default)
+
+    bsky_post = _val(announce_bsky)
+    detached_failures = [(r.name, str(r.error)) for r in flow.detached_failures]
+
+    print(f"\n✓ Done!")
+    print(f"  Page: {url}")
+    if bsky_post:
+        print(f"  Post: {bsky_post['url']}")
+    if detached_failures:
+        print(f"  Detached failures: {detached_failures}")
+
+    return {
+        "page_url": url,
+        "commit_sha": _val(publish_page_node, "commit_sha"),
+        "deployed": bool(_val(wait_for_deploy_node, "deployed", default=False)),
+        "feed_sha": _val(update_feed_node, "feed_sha"),
+        "bsky_post": bsky_post,
+        "update_sha": _val(link_engagement_node, "update_sha"),
+        "detached_failures": detached_failures,
+    }

--- a/muninn_utils/bsky_card.py
+++ b/muninn_utils/bsky_card.py
@@ -1,36 +1,34 @@
 """
 bsky_card.py — Bluesky link card composition (flowing-graph orchestrator).
 
-Same low-level helpers as the prior version (fetch_og_tags, upload_blob,
-compute_facets, build_external_embed, create_post), now with a
-flowing-graph-based `compose_link_post` and a new `compose_and_post`
-that fuses compose+post into one DAG.
-
 Internal shape (issue oaustegard/claude-skills#617):
 
     fetch_og ──▶ upload_blob_node ──┐
         │                            │
         └──▶ embed_node ◀────────────┘
                   │
-    facets_node ──┼──▶ record_node  [terminal of compose_link_post]
-                  │         │
-                  │         └──▶ post_node  [terminal of compose_and_post]
+    facets_node ──┼──▶ record_node ──▶ post_node  [terminal]
 
 Wins over imperative:
 
   - `fetch_og` and `facets_node` parallelize (one network, one local).
-  - `validate=must_be_valid_record` enforces the AT Proto record shape
-    BEFORE the body of post_node ever fires — no wasted createRecord.
-  - `upload_blob_node` failure cleanly SKIPS embed and post — no partial
-    post. (Behavior change vs. the prior soft-fail; see #617 win 3.)
+  - `validate=must_have_valid_record_inputs` runs on `record_node` and
+    rejects malformed embed (no uri) BEFORE any post fires — catches the
+    "post a card with no target" trap structurally.
+  - `upload_blob_node` failure cleanly SKIPS embed, record, and post —
+    no half-baked post on the wire.
   - max_workers=3 on the Flow → the parallel legs run concurrently.
 
-Public API:
+Public API: `compose_link_post(text, url, auth, og_tags=None)` runs the
+full graph — compose AND post — and returns:
 
-    record = compose_link_post(text, url, auth)        # builds record only
-    result = compose_and_post(text, url, auth)         # builds AND posts
+    {record, post, og_tags, thumb_blob, facets, detached_failures}
 
-`result` keys: record, post, og_tags, thumb_blob, facets, detached_failures.
+Note: this is an internal Muninn utility, so the prior split of
+"compose_link_post returns a record / create_post submits it" was
+collapsed into a single flow. Lower-level helpers (fetch_og_tags,
+upload_blob, compute_facets, build_external_embed, create_post) remain
+exposed for callers that want to drive their own pipeline.
 """
 
 import json
@@ -265,41 +263,24 @@ def _build_compose_graph(text, url, auth, og_tags=None):
 
 
 def compose_link_post(text, url, auth, og_tags=None):
-    """Build a complete post record with link card.
+    """Compose a Bluesky link-card post AND submit it. Single flowing graph.
 
-    Runs a flowing graph internally:
-      fetch_og + facets_node (parallel) → upload_blob_node → embed_node → record_node
+    Runs the full pipeline:
+      fetch_og + facets_node (parallel) → upload_blob_node → embed_node
+        → record_node → post_node
 
-    Returns the assembled record (same shape as the prior imperative version).
-    Raises on graph failure with the originating error attached.
-    """
-    nodes = _build_compose_graph(text, url, auth, og_tags)
-    flow = Flow(nodes["record_node"], max_workers=3)
-    flow.run()
+    Returns a dict with:
+        record            — the assembled app.bsky.feed.post record
+        post              — the create_post response (uri/cid/url/rkey)
+        og_tags           — the OG tags used
+        thumb_blob        — the uploaded blob, or None if no image
+        facets            — the AT Proto facets list
+        detached_failures — always [] (included for API symmetry with
+                            publish_and_announce)
 
-    record_state = flow.results.get(nodes["record_node"].name)
-    if record_state is None or record_state.state != StepState.SUCCEEDED:
-        # Surface the originating failure rather than the SKIP cascade.
-        for r in flow.results.values():
-            if r.state == StepState.FAILED and r.error is not None:
-                raise RuntimeError(
-                    f"compose_link_post failed at {r.name}: {r.error}"
-                ) from r.error
-        raise RuntimeError(
-            f"compose_link_post: record_node ended in {record_state.state.value}"
-        )
-    return record_state.value
-
-
-def compose_and_post(text, url, auth, og_tags=None):
-    """Build the record AND post it on Bluesky in one flowing graph.
-
-    Returns:
-        dict with keys: record, post, og_tags, thumb_blob, facets,
-        detached_failures (always empty list — included for API symmetry
-        with publish_and_announce).
-
-    Raises on hard failure of the main chain.
+    Raises on any hard failure in the main chain (validate raised,
+    upload failed, network down). The originating error is attached
+    via `__cause__`.
     """
     nodes = _build_compose_graph(text, url, auth, og_tags)
 
@@ -315,10 +296,11 @@ def compose_and_post(text, url, auth, og_tags=None):
         for r in flow.results.values():
             if r.state == StepState.FAILED and r.error is not None:
                 raise RuntimeError(
-                    f"compose_and_post failed at {r.name}: {r.error}"
+                    f"compose_link_post failed at {r.name}: {r.error}"
                 ) from r.error
         raise RuntimeError(
-            f"compose_and_post: post_node ended in {post_state.state.value}"
+            f"compose_link_post: post_node ended in "
+            f"{post_state.state.value if post_state else 'missing'}"
         )
 
     def _val(td):

--- a/muninn_utils/bsky_card.py
+++ b/muninn_utils/bsky_card.py
@@ -1,0 +1,372 @@
+"""
+bsky_card.py — Bluesky link card composition (flowing-graph orchestrator).
+
+Same low-level helpers as the prior version (fetch_og_tags, upload_blob,
+compute_facets, build_external_embed, create_post), now with a
+flowing-graph-based `compose_link_post` and a new `compose_and_post`
+that fuses compose+post into one DAG.
+
+Internal shape (issue oaustegard/claude-skills#617):
+
+    fetch_og ──▶ upload_blob_node ──┐
+        │                            │
+        └──▶ embed_node ◀────────────┘
+                  │
+    facets_node ──┼──▶ record_node  [terminal of compose_link_post]
+                  │         │
+                  │         └──▶ post_node  [terminal of compose_and_post]
+
+Wins over imperative:
+
+  - `fetch_og` and `facets_node` parallelize (one network, one local).
+  - `validate=must_be_valid_record` enforces the AT Proto record shape
+    BEFORE the body of post_node ever fires — no wasted createRecord.
+  - `upload_blob_node` failure cleanly SKIPS embed and post — no partial
+    post. (Behavior change vs. the prior soft-fail; see #617 win 3.)
+  - max_workers=3 on the Flow → the parallel legs run concurrently.
+
+Public API:
+
+    record = compose_link_post(text, url, auth)        # builds record only
+    result = compose_and_post(text, url, auth)         # builds AND posts
+
+`result` keys: record, post, og_tags, thumb_blob, facets, detached_failures.
+"""
+
+import json
+import os
+import re
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from flowing import task, Flow, StepState
+
+
+# ── OG Tag Extraction ──────────────────────────────────────────────
+
+def fetch_og_tags(url):
+    """Fetch a page and extract Open Graph meta tags.
+
+    Returns dict with keys: url, title, description, image.
+    Falls back to <title> and meta description if OG tags are absent.
+    """
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "Mozilla/5.0 (bsky-card bot)"
+    })
+    html = urllib.request.urlopen(req).read().decode("utf-8", errors="replace")
+
+    tags = {"url": url}
+    for prop in ["title", "description", "image"]:
+        m = _match_og(html, prop)
+        if m:
+            tags[prop] = m
+
+    if "title" not in tags:
+        m = re.search(r"<title>([^<]+)</title>", html, re.IGNORECASE)
+        if m:
+            tags["title"] = m.group(1).strip()
+
+    if "description" not in tags:
+        m = re.search(
+            r'<meta\s+name="description"\s+content="([^"]+)"',
+            html, re.IGNORECASE
+        )
+        if m:
+            tags["description"] = m.group(1)
+
+    if tags.get("image", "").startswith("/"):
+        parsed = urlparse(url)
+        tags["image"] = f"{parsed.scheme}://{parsed.netloc}{tags['image']}"
+
+    return tags
+
+
+def _match_og(html, prop):
+    """Try multiple patterns to extract an og: meta tag value."""
+    patterns = [
+        rf'<meta\s+(?:property|name)="og:{prop}"\s+content="([^"]+)"',
+        rf"<meta\s+(?:property|name)='og:{prop}'\s+content='([^']+)'",
+        rf'<meta\s+content="([^"]+)"\s+(?:property|name)="og:{prop}"',
+        rf"<meta\s+content='([^']+)'\s+(?:property|name)='og:{prop}'",
+    ]
+    for pattern in patterns:
+        m = re.search(pattern, html, re.IGNORECASE)
+        if m:
+            return m.group(1)
+    return None
+
+
+# ── Blob Upload ────────────────────────────────────────────────────
+
+def upload_blob(image_url, auth):
+    """Download an image from a URL and upload it as a Bluesky blob.
+
+    Returns blob dict (with $type, ref, mimeType, size) suitable for
+    use as embed.external.thumb.
+    """
+    req = urllib.request.Request(image_url, headers={
+        "User-Agent": "Mozilla/5.0 (bsky-card bot)"
+    })
+    resp = urllib.request.urlopen(req)
+    image_data = resp.read()
+    content_type = resp.headers.get("Content-Type", "image/png")
+
+    upload_req = urllib.request.Request(
+        "https://bsky.social/xrpc/com.atproto.repo.uploadBlob",
+        data=image_data, method="POST",
+        headers={
+            "Authorization": f"Bearer {auth['access_jwt']}",
+            "Content-Type": content_type
+        }
+    )
+    result = json.loads(urllib.request.urlopen(upload_req).read())
+    return result["blob"]
+
+
+# ── Facet Computation ──────────────────────────────────────────────
+
+def compute_facets(text):
+    """Find URLs and #hashtags in text and create ATProto facets.
+
+    Returns list of facet dicts with correct UTF-8 byte offsets.
+    """
+    facets = []
+
+    for match in re.finditer(r'https?://\S+', text):
+        url_str = match.group(0)
+        while url_str and url_str[-1] in ".,;:!?)\"'":
+            url_str = url_str[:-1]
+        byte_start, byte_end = _byte_offsets(text, match.start(), url_str)
+        facets.append({
+            "index": {"byteStart": byte_start, "byteEnd": byte_end},
+            "features": [{"$type": "app.bsky.richtext.facet#link", "uri": url_str}]
+        })
+
+    for match in re.finditer(r'(?<!\w)#(\w+)', text):
+        tag = match.group(1)
+        full = match.group(0)
+        byte_start, byte_end = _byte_offsets(text, match.start(), full)
+        facets.append({
+            "index": {"byteStart": byte_start, "byteEnd": byte_end},
+            "features": [{"$type": "app.bsky.richtext.facet#tag", "tag": tag}]
+        })
+
+    return facets
+
+
+def _byte_offsets(text, char_start, matched_text):
+    """Convert character position to UTF-8 byte offsets."""
+    prefix_bytes = text[:char_start].encode("utf-8")
+    matched_bytes = matched_text.encode("utf-8")
+    return len(prefix_bytes), len(prefix_bytes) + len(matched_bytes)
+
+
+# ── Embed Construction ─────────────────────────────────────────────
+
+def build_external_embed(og_tags, thumb_blob=None):
+    """Build an app.bsky.embed.external embed dict from OG tags."""
+    external = {
+        "uri": og_tags["url"],
+        "title": og_tags.get("title", ""),
+        "description": og_tags.get("description", ""),
+    }
+    if thumb_blob:
+        external["thumb"] = thumb_blob
+
+    return {
+        "$type": "app.bsky.embed.external",
+        "external": external
+    }
+
+
+# ── Edge contracts ─────────────────────────────────────────────────
+
+def _must_have_valid_record_inputs(**deps):
+    """Edge contract for record_node: validate embed and facets shape.
+
+    Runs against gathered dep values (embed_node, facets_node) BEFORE the
+    record body fires. Catches malformed embed (no uri) or non-list facets
+    so the post downstream can't fire on a broken card.
+    """
+    embed = deps.get("embed_node")
+    if not isinstance(embed, dict):
+        raise ValueError("embed_node missing or not a dict")
+    external = embed.get("external") or {}
+    if not external.get("uri"):
+        raise ValueError("record.embed.external.uri is missing — link card has no target")
+
+    facets = deps.get("facets_node")
+    if not isinstance(facets, list):
+        raise ValueError("facets_node not a list")
+
+
+# ── High-Level Composition (flowing graph) ─────────────────────────
+
+def _build_compose_graph(text, url, auth, og_tags=None):
+    """Construct the compose-pipeline tasks; return (record_node, fetch_og).
+
+    Tasks are closure-bound to (text, url, auth, og_tags). The caller
+    decides which terminal to drive — record_node alone (compose only)
+    or post_node downstream (compose + post).
+    """
+    if url not in text:
+        text = f"{text}\n{url}"
+
+    pre_supplied = og_tags
+
+    @task(name="fetch_og")
+    def fetch_og():
+        if pre_supplied is not None:
+            return pre_supplied
+        return fetch_og_tags(url)
+
+    @task(name="upload_blob_node", depends_on=[fetch_og])
+    def upload_blob_node(fetch_og):
+        img = fetch_og.get("image")
+        if not img:
+            # No image at all is a clean success with a None payload —
+            # embed_node proceeds and builds a thumb-less card.
+            return None
+        # Genuine upload failure raises → embed/post SKIP. (#617 win 3.)
+        return upload_blob(img, auth)
+
+    @task(name="facets_node")
+    def facets_node():
+        return compute_facets(text)
+
+    @task(name="embed_node", depends_on=[upload_blob_node, fetch_og])
+    def embed_node(upload_blob_node, fetch_og):
+        return build_external_embed(fetch_og, thumb_blob=upload_blob_node)
+
+    @task(
+        name="record_node",
+        depends_on=[embed_node, facets_node],
+        validate=_must_have_valid_record_inputs,
+    )
+    def record_node(embed_node, facets_node):
+        return {
+            "$type": "app.bsky.feed.post",
+            "text": text,
+            "createdAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            "facets": facets_node,
+            "embed": embed_node,
+        }
+
+    return {
+        "fetch_og": fetch_og,
+        "upload_blob_node": upload_blob_node,
+        "facets_node": facets_node,
+        "embed_node": embed_node,
+        "record_node": record_node,
+        "_text": text,  # post-URL-append, for callers that need it
+    }
+
+
+def compose_link_post(text, url, auth, og_tags=None):
+    """Build a complete post record with link card.
+
+    Runs a flowing graph internally:
+      fetch_og + facets_node (parallel) → upload_blob_node → embed_node → record_node
+
+    Returns the assembled record (same shape as the prior imperative version).
+    Raises on graph failure with the originating error attached.
+    """
+    nodes = _build_compose_graph(text, url, auth, og_tags)
+    flow = Flow(nodes["record_node"], max_workers=3)
+    flow.run()
+
+    record_state = flow.results.get(nodes["record_node"].name)
+    if record_state is None or record_state.state != StepState.SUCCEEDED:
+        # Surface the originating failure rather than the SKIP cascade.
+        for r in flow.results.values():
+            if r.state == StepState.FAILED and r.error is not None:
+                raise RuntimeError(
+                    f"compose_link_post failed at {r.name}: {r.error}"
+                ) from r.error
+        raise RuntimeError(
+            f"compose_link_post: record_node ended in {record_state.state.value}"
+        )
+    return record_state.value
+
+
+def compose_and_post(text, url, auth, og_tags=None):
+    """Build the record AND post it on Bluesky in one flowing graph.
+
+    Returns:
+        dict with keys: record, post, og_tags, thumb_blob, facets,
+        detached_failures (always empty list — included for API symmetry
+        with publish_and_announce).
+
+    Raises on hard failure of the main chain.
+    """
+    nodes = _build_compose_graph(text, url, auth, og_tags)
+
+    @task(name="post_node", depends_on=[nodes["record_node"]])
+    def post_node(record_node):
+        return create_post(record_node, auth)
+
+    flow = Flow(post_node, max_workers=3)
+    flow.run()
+
+    post_state = flow.results.get(post_node.name)
+    if post_state is None or post_state.state != StepState.SUCCEEDED:
+        for r in flow.results.values():
+            if r.state == StepState.FAILED and r.error is not None:
+                raise RuntimeError(
+                    f"compose_and_post failed at {r.name}: {r.error}"
+                ) from r.error
+        raise RuntimeError(
+            f"compose_and_post: post_node ended in {post_state.state.value}"
+        )
+
+    def _val(td):
+        r = flow.results.get(td.name)
+        if r is None or r.state != StepState.SUCCEEDED:
+            return None
+        return r.value
+
+    return {
+        "record": _val(nodes["record_node"]),
+        "post": _val(post_node),
+        "og_tags": _val(nodes["fetch_og"]),
+        "thumb_blob": _val(nodes["upload_blob_node"]),
+        "facets": _val(nodes["facets_node"]),
+        "detached_failures": [],
+    }
+
+
+def create_post(record, auth):
+    """Submit a post record to Bluesky.
+
+    Returns dict with uri, cid, url, rkey.
+    """
+    data = json.dumps({
+        "repo": auth["did"],
+        "collection": "app.bsky.feed.post",
+        "record": record
+    }).encode()
+
+    req = urllib.request.Request(
+        "https://bsky.social/xrpc/com.atproto.repo.createRecord",
+        data=data, method="POST",
+        headers={
+            "Authorization": f"Bearer {auth['access_jwt']}",
+            "Content-Type": "application/json"
+        }
+    )
+    result = json.loads(urllib.request.urlopen(req).read())
+
+    post_uri = result["uri"]
+    rkey = post_uri.split("/")[-1]
+    handle = auth.get("handle", auth["did"])
+    bsky_url = f"https://bsky.app/profile/{handle}/post/{rkey}"
+
+    print(f"  ✓ Posted: {bsky_url}")
+    return {
+        "uri": post_uri,
+        "cid": result["cid"],
+        "url": bsky_url,
+        "rkey": rkey
+    }

--- a/muninn_utils/github_pr_flow.py
+++ b/muninn_utils/github_pr_flow.py
@@ -1,0 +1,318 @@
+"""
+github_pr_flow.py — github-procedures §6 (PR workflow) as a flowing graph.
+
+The procedure expressed structurally instead of as numbered prose:
+
+    determine_branch ──▶ get_base_head ──▶ create_branch ──▶ push_files
+                                                                   │
+                                                                   ▼
+                                                             create_pr
+                                                                   │
+                                                                   ▼
+                                                            wait_mergeable
+                                                                   │
+                                                                   ▼
+                                                             present_pr   [terminal]
+
+Wins over imperative prose (issue oaustegard/claude-skills#620):
+
+  - `validate=_must_not_be_base_branch` is structural. The "NEVER push to
+    main" rule from §6 becomes a gate that physically can't be skipped —
+    the create_branch body never fires for `branch=main`.
+  - `retry_until=lambda r: r["mergeable_state"] in {"clean","dirty",...}`
+    replaces hand-rolled "poll mergeable_state for a few seconds" prose.
+    Diagnosed pain point: needed two manual retries on aeyu#32 (2026-05-08)
+    before the field went non-null. That belongs in retry_until=, not in
+    prose memory.
+  - The whole §6 imperative collapses to: `from muninn_utils.github_pr_flow
+    import open_pr; open_pr(...)`.
+
+Out of scope (per issue):
+  - Issue creation flow (§7 — different shape, uses issue_close)
+  - Container transport workarounds (§8 — environmental, not procedural)
+
+Public API:
+
+    from muninn_utils.github_pr_flow import open_pr
+
+    result = open_pr(
+        repo="oaustegard/claude-skills",
+        branch_name="claude/flowing-graph-utils-616",
+        title="Refactor utilities as flowing graphs",
+        body="...",
+        files=[
+            ("muninn_utils/blog_publish.py", "<file content>"),
+            ("muninn_utils/bsky_card.py",    "<file content>"),
+        ],
+        base="main",  # default
+    )
+
+`result` keys:
+    pr_url, pr_number, pr_state, branch, base, head_sha,
+    mergeable_state, files_pushed, detached_failures
+"""
+
+import json
+import os
+import urllib.request
+from typing import Iterable, List, Tuple
+
+from flowing import task, Flow, StepState
+
+
+# ── GitHub helpers ─────────────────────────────────────────────────
+
+def _gh_token() -> str:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+
+
+def _gh_api(method: str, endpoint: str, data: dict | None = None) -> dict:
+    token = _gh_token()
+    url = f"https://api.github.com{endpoint}" if endpoint.startswith("/") else endpoint
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, method=method, headers={
+        "User-Agent": "muninn-raven",
+        "Authorization": f"token {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github+json",
+    })
+    return json.loads(urllib.request.urlopen(req).read())
+
+
+# Mergeable states GitHub considers "settled" — i.e., it has finished
+# computing the merge result. `unstable` and `behind` are also computed
+# states but indicate non-clean conditions; treat them as settled too so
+# the poll doesn't spin when CI is failing or the branch is out of date.
+SETTLED_MERGEABLE_STATES = frozenset({"clean", "dirty", "unstable", "behind", "blocked"})
+
+# `unknown` is the explicitly-unsettled state. `null` (None) means GitHub
+# hasn't started computing yet; we treat both as "keep polling".
+
+
+def _get_branch_head(repo: str, branch: str) -> str:
+    """Return the commit SHA at HEAD of the given branch."""
+    ref = _gh_api("GET", f"/repos/{repo}/git/refs/heads/{branch}")
+    return ref["object"]["sha"]
+
+
+def _create_branch(repo: str, branch: str, from_sha: str) -> dict:
+    """Create refs/heads/<branch> pointing at from_sha."""
+    return _gh_api(
+        "POST", f"/repos/{repo}/git/refs",
+        {"ref": f"refs/heads/{branch}", "sha": from_sha},
+    )
+
+
+def _put_file(repo: str, branch: str, path: str, content: str,
+              message: str | None = None) -> dict:
+    """Create or update a file on the given branch via the contents API."""
+    import base64
+    payload = {
+        "message": message or f"Add {path}",
+        "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+        "branch": branch,
+    }
+    # Get current file SHA if it exists (required for update).
+    try:
+        existing = _gh_api(
+            "GET", f"/repos/{repo}/contents/{path}?ref={branch}"
+        )
+        if isinstance(existing, dict) and existing.get("sha"):
+            payload["sha"] = existing["sha"]
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise
+    return _gh_api("PUT", f"/repos/{repo}/contents/{path}", payload)
+
+
+def _create_pull_request(repo: str, head: str, base: str,
+                          title: str, body: str) -> dict:
+    return _gh_api(
+        "POST", f"/repos/{repo}/pulls",
+        {"title": title, "body": body, "head": head, "base": base},
+    )
+
+
+def _get_pull_request(repo: str, number: int) -> dict:
+    return _gh_api("GET", f"/repos/{repo}/pulls/{number}")
+
+
+# ── Edge contracts ─────────────────────────────────────────────────
+
+PROTECTED_BRANCH_NAMES = frozenset({"main", "master", "trunk", "production", "prod"})
+
+
+def _must_not_be_base_branch_factory(base: str):
+    """Build a validator that rejects branch_name == base or any protected name."""
+    base_norm = base.strip().lower()
+
+    def must_not_be_base_branch(**deps):
+        # determine_branch is the dep being validated; its return is the branch.
+        candidate = next(iter(deps.values()), None)
+        if candidate is None:
+            raise ValueError("must_not_be_base_branch: no candidate branch in deps")
+        if not isinstance(candidate, str) or not candidate.strip():
+            raise ValueError(f"branch_name must be a non-empty string, got: {candidate!r}")
+        norm = candidate.strip().lower()
+        if norm == base_norm:
+            raise ValueError(
+                f"branch_name == base ({base!r}) — refusing per github-procedures §6 "
+                "'NEVER push directly to main'"
+            )
+        if norm in PROTECTED_BRANCH_NAMES:
+            raise ValueError(
+                f"branch_name {candidate!r} is a protected name "
+                f"({sorted(PROTECTED_BRANCH_NAMES)}) — branch off it instead"
+            )
+    return must_not_be_base_branch
+
+
+# ── Public API ─────────────────────────────────────────────────────
+
+def open_pr(
+    repo: str,
+    branch_name: str,
+    title: str,
+    body: str,
+    files: Iterable[Tuple[str, str]],
+    *,
+    base: str = "main",
+    mergeable_poll_retries: int = 8,
+    mergeable_poll_base_ms: int = 2000,
+    mergeable_poll_max_ms: int = 8000,
+) -> dict:
+    """Create a branch, push files, open a PR, wait for mergeable state.
+
+    All operations go through the GitHub REST API. Network failures
+    propagate through the retry budget on each task.
+
+    Returns dict with: pr_url, pr_number, pr_state, branch, base,
+    head_sha, mergeable_state, files_pushed, detached_failures.
+
+    Raises only if the main DAG fails (validate, branch creation,
+    file push, or PR creation). Mergeable polling exhaustion is a
+    soft failure: returns with mergeable_state=last-observed.
+    """
+    files_list: List[Tuple[str, str]] = list(files)
+
+    @task(name="determine_branch")
+    def determine_branch():
+        return branch_name.strip()
+
+    # The validate runs against deps. We want the branch validation to
+    # run BEFORE create_branch fires, so put the validator on
+    # get_base_head — its dep (determine_branch) returns the branch.
+    # Actually clearer: run the validator on a dedicated guard task that
+    # the rest depend on, so failure surfaces with a clear name.
+    @task(
+        name="must_not_be_base_branch_guard",
+        depends_on=[determine_branch],
+        validate=_must_not_be_base_branch_factory(base),
+    )
+    def must_not_be_base_branch_guard(determine_branch):
+        # Body only runs if validate passed; just pass-through.
+        return determine_branch
+
+    @task(name="get_base_head", depends_on=[must_not_be_base_branch_guard])
+    def get_base_head(must_not_be_base_branch_guard):
+        sha = _get_branch_head(repo, base)
+        return {"base": base, "sha": sha}
+
+    @task(
+        name="create_branch",
+        depends_on=[must_not_be_base_branch_guard, get_base_head],
+    )
+    def create_branch(must_not_be_base_branch_guard, get_base_head):
+        ref = _create_branch(repo, must_not_be_base_branch_guard, get_base_head["sha"])
+        return {
+            "branch": must_not_be_base_branch_guard,
+            "ref_sha": ref["object"]["sha"],
+        }
+
+    @task(name="push_files", depends_on=[create_branch])
+    def push_files(create_branch):
+        branch = create_branch["branch"]
+        pushed = []
+        for path, content in files_list:
+            resp = _put_file(repo, branch, path, content,
+                             message=f"Add {path}")
+            commit = resp.get("commit", {}) if isinstance(resp, dict) else {}
+            pushed.append({"path": path, "commit_sha": commit.get("sha")})
+        return {"branch": branch, "pushed": pushed}
+
+    @task(name="create_pr", depends_on=[push_files])
+    def create_pr(push_files):
+        pr = _create_pull_request(
+            repo, head=push_files["branch"], base=base,
+            title=title, body=body,
+        )
+        return {
+            "pr_number": pr["number"],
+            "pr_url": pr["html_url"],
+            "pr_state": pr.get("state"),
+        }
+
+    @task(
+        name="wait_mergeable",
+        depends_on=[create_pr],
+        retry=mergeable_poll_retries,
+        retry_backoff_base_ms=mergeable_poll_base_ms,
+        retry_max_backoff_ms=mergeable_poll_max_ms,
+        retry_until=lambda r: r["mergeable_state"] in SETTLED_MERGEABLE_STATES,
+    )
+    def wait_mergeable(create_pr):
+        pr = _get_pull_request(repo, create_pr["pr_number"])
+        return {
+            "mergeable_state": pr.get("mergeable_state") or "unknown",
+            "mergeable": pr.get("mergeable"),
+        }
+
+    @task(name="present_pr", depends_on=[create_pr])
+    def present_pr(create_pr):
+        # Always print so the URL is unmissable in stdout.
+        print(f"  ✓ PR ready: {create_pr['pr_url']}")
+        return create_pr
+
+    flow = Flow(present_pr, wait_mergeable)
+    flow.run()
+
+    create_pr_state = flow.results.get(create_pr.name)
+    if create_pr_state is None or create_pr_state.state != StepState.SUCCEEDED:
+        # Surface the originating failure.
+        for r in flow.results.values():
+            if r.state == StepState.FAILED and r.error is not None:
+                raise RuntimeError(f"open_pr failed at {r.name}: {r.error}") from r.error
+        raise RuntimeError("open_pr: PR creation did not succeed")
+
+    def _val(td):
+        r = flow.results.get(td.name)
+        if r is None or r.state != StepState.SUCCEEDED:
+            return None
+        return r.value
+
+    pr_payload = create_pr_state.value
+    push_payload = _val(push_files) or {}
+    base_payload = _val(get_base_head) or {}
+    mergeable_state = "unknown"
+    mergeable_result = flow.results.get(wait_mergeable.name)
+    if mergeable_result is not None and mergeable_result.value is not None:
+        mergeable_state = mergeable_result.value.get("mergeable_state", "unknown")
+
+    detached_failures = [(r.name, str(r.error)) for r in flow.detached_failures]
+
+    return {
+        "pr_url": pr_payload["pr_url"],
+        "pr_number": pr_payload["pr_number"],
+        "pr_state": pr_payload.get("pr_state"),
+        "branch": branch_name.strip(),
+        "base": base,
+        "head_sha": base_payload.get("sha"),
+        "mergeable_state": mergeable_state,
+        "files_pushed": [p["path"] for p in push_payload.get("pushed", [])],
+        "detached_failures": detached_failures,
+    }
+
+
+# urllib import resolution — needed at call time of _put_file but the
+# top-of-module import is sufficient. Re-export for tests that monkeypatch.
+import urllib.error  # noqa: E402  (kept at bottom to avoid top reordering)

--- a/muninn_utils/issue_close.py
+++ b/muninn_utils/issue_close.py
@@ -1,0 +1,233 @@
+"""
+issue_close.py — Close a GitHub issue with a learning synthesis (flowing graph).
+
+Per github-procedures §7: closing an issue is two artifacts.
+  - GitHub Issue = implementation log (scaffolding)
+  - Memory       = behavioral learning (building)
+
+The synthesis is what was LEARNED, not what was DONE — the diff already
+shows what was done. Synthesis goes both as the closing comment AND as a
+`decision`-type memory tagged with `issue-N`, `<repo-short>`.
+
+Usage:
+
+    from muninn_utils.issue_close import issue_close
+
+    result = issue_close(
+        number=617,
+        synthesis="Refactor pattern X works because of Y. Constraint: Z.",
+        repo="oaustegard/claude-skills",
+        pending_test=True,
+        extra_tags=["flowing", "refactor"],
+    )
+
+    # result keys: issue_url, comment_url, memory_id, pending_test_applied,
+    #              detached_failures
+
+Internal shape (issue oaustegard/claude-skills#619):
+
+    prepare_synthesis ──▶ close_github_issue           [terminal]
+                                  │
+                                  └──▶ store_synthesis_memory  [detached]
+                                              │
+                                              └──▶ verify_pending_test  [detached, when=pending_test]
+
+  - validate=must_have_synthesis_text on prepare_synthesis blocks empty
+    or whitespace-only synthesis BEFORE any GitHub API call fires.
+  - Caller gets the close ack the moment GitHub returns 2xx; memory write
+    happens in the background.
+  - pending_test=True is encoded in the initial memory store (cheaper than
+    a second write). verify_pending_test is the structural gate that
+    surfaces a detached-failure if the tag silently dropped.
+  - Memory failure (e.g. proxy 503) doesn't bubble up as an issue-close
+    failure — it lands in `result["detached_failures"]`.
+
+Note on graph shape: the originating issue proposed a two-step
+"store_synthesis_memory + tag_for_verification" pattern. The remembering
+API only exposes `remember(tags=...)` for atomic-write tagging — there is
+no public "add tag to existing memory" primitive — so the pending-test
+tag is included in the initial store, and `verify_pending_test` is a
+read-side assertion that catches silent tag loss (still gated by `when=`).
+"""
+
+import json
+import os
+import urllib.request
+from typing import Optional
+
+from flowing import task, Flow, StepState
+
+
+# ── GitHub helpers ─────────────────────────────────────────────────
+
+def _gh_token():
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def _gh_api(method, endpoint, data=None):
+    token = _gh_token()
+    url = f"https://api.github.com{endpoint}" if endpoint.startswith("/") else endpoint
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, method=method, headers={
+        "User-Agent": "muninn-raven",
+        "Authorization": f"token {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github+json",
+    })
+    return json.loads(urllib.request.urlopen(req).read())
+
+
+def _post_close_comment(repo: str, number: int, body: str) -> dict:
+    return _gh_api("POST", f"/repos/{repo}/issues/{number}/comments", {"body": body})
+
+
+def _close_issue(repo: str, number: int, state_reason: str = "completed") -> dict:
+    return _gh_api(
+        "PATCH", f"/repos/{repo}/issues/{number}",
+        {"state": "closed", "state_reason": state_reason},
+    )
+
+
+# ── Memory helpers (lazy import — works whether `scripts` or
+# `remembering.scripts` is on sys.path) ────────────────────────────
+
+def _import_remember():
+    try:
+        from scripts import remember  # type: ignore
+        return remember
+    except Exception:
+        from remembering.scripts import remember  # type: ignore
+        return remember
+
+
+def _import_recall():
+    try:
+        from scripts import recall  # type: ignore
+        return recall
+    except Exception:
+        from remembering.scripts import recall  # type: ignore
+        return recall
+
+
+# ── Public API ─────────────────────────────────────────────────────
+
+PENDING_TEST_TAG = "pending-test"
+
+
+def issue_close(
+    number: int,
+    synthesis: str,
+    *,
+    repo: str = "oaustegard/claude-skills",
+    pending_test: bool = False,
+    extra_tags: Optional[list] = None,
+    state_reason: str = "completed",
+) -> dict:
+    """Close a GitHub issue with a synthesis comment, store the synthesis as
+    a memory, optionally tag it for later verification.
+
+    Returns dict with:
+        issue_url            — https URL of the issue
+        comment_url          — html_url of the closing comment, or None
+        memory_id            — memory id (str), or None on detached failure
+        pending_test_applied — True iff synthesis was tagged for verify
+        detached_failures    — list of (task_name, error_str)
+
+    Raises only if the GitHub close itself fails. Memory failures are
+    detached and surfaced via `detached_failures`.
+    """
+    repo_short = repo.rsplit("/", 1)[-1]
+    base_tags = [f"issue-{number}", repo_short]
+    if extra_tags:
+        base_tags.extend(t for t in extra_tags if t and t not in base_tags)
+
+    final_tags = list(base_tags)
+    if pending_test and PENDING_TEST_TAG not in final_tags:
+        final_tags.append(PENDING_TEST_TAG)
+
+    def must_have_synthesis_text(**deps):
+        if not synthesis or not synthesis.strip():
+            raise ValueError(
+                "synthesis is empty or whitespace — issue_close needs the LEARNING text "
+                "(what I learned, not what I did) per github-procedures §7"
+            )
+
+    @task(name="prepare_synthesis", validate=must_have_synthesis_text)
+    def prepare_synthesis():
+        return synthesis.strip()
+
+    @task(name="close_github_issue", depends_on=[prepare_synthesis])
+    def close_github_issue(prepare_synthesis):
+        comment = _post_close_comment(repo, number, prepare_synthesis)
+        _close_issue(repo, number, state_reason=state_reason)
+        return {
+            "issue_url": f"https://github.com/{repo}/issues/{number}",
+            "comment_url": comment.get("html_url"),
+            "comment_id": comment.get("id"),
+        }
+
+    @task(
+        name="store_synthesis_memory",
+        depends_on=[close_github_issue, prepare_synthesis],
+        detached=True,
+    )
+    def store_synthesis_memory(close_github_issue, prepare_synthesis):
+        remember = _import_remember()
+        mem_id = remember(
+            prepare_synthesis,
+            "decision",
+            tags=final_tags,
+            priority=1,
+        )
+        return {"memory_id": mem_id, "tags": final_tags}
+
+    @task(
+        name="verify_pending_test",
+        depends_on=[store_synthesis_memory],
+        when=lambda **_: pending_test,
+        detached=True,
+    )
+    def verify_pending_test(store_synthesis_memory):
+        mem_id = store_synthesis_memory["memory_id"]
+        recall = _import_recall()
+        # Try to confirm the memory carries the pending-test tag.
+        hits = recall(tags=[PENDING_TEST_TAG], n=20)
+        for h in hits:
+            if h.get("id") == mem_id:
+                return {"verified": True, "memory_id": mem_id}
+        raise RuntimeError(
+            f"pending-test tag not retrievable on memory {mem_id} — "
+            "tag silently dropped or recall index lag"
+        )
+
+    flow = Flow(close_github_issue)
+    flow.run()
+
+    close_state = flow.results.get(close_github_issue.name)
+    if close_state is None or close_state.state != StepState.SUCCEEDED:
+        # The main close itself failed — surface it.
+        for r in flow.results.values():
+            if r.state == StepState.FAILED and r.error is not None:
+                raise RuntimeError(
+                    f"issue_close: {r.name} failed: {r.error}"
+                ) from r.error
+        raise RuntimeError("issue_close: close did not succeed and no error was attached")
+
+    def _val(td):
+        r = flow.results.get(td.name)
+        if r is None or r.state != StepState.SUCCEEDED:
+            return None
+        return r.value
+
+    closed = close_state.value
+    mem_payload = _val(store_synthesis_memory)
+    verify_payload = _val(verify_pending_test)
+    detached_failures = [(r.name, str(r.error)) for r in flow.detached_failures]
+
+    return {
+        "issue_url": closed["issue_url"],
+        "comment_url": closed.get("comment_url"),
+        "memory_id": mem_payload["memory_id"] if mem_payload else None,
+        "pending_test_applied": (verify_payload is not None and verify_payload.get("verified", False)),
+        "detached_failures": detached_failures,
+    }

--- a/muninn_utils/tests/test_blog_publish_flow.py
+++ b/muninn_utils/tests/test_blog_publish_flow.py
@@ -1,0 +1,267 @@
+"""
+Tests for blog_publish.publish_and_announce flowing graph (issue #616).
+
+Verifies:
+  - main DAG order: publish_page → wait_for_deploy → update_feed
+  - detached chain auto-discovery: announce_bsky → link_engagement_node
+  - retry_until=lambda r: r["deployed"] consumes budget when deploy is slow
+  - when= gate skips update_feed when feed_path is None
+  - validate= rejects bsky_text > BSKY_LIMIT before any post fires
+  - bsky failure populates detached_failures, doesn't raise
+
+Network calls are monkeypatched. No real GitHub or Bluesky access required.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+THIS_DIR = Path(__file__).resolve().parent
+PKG_DIR = THIS_DIR.parent
+SKILLS_ROOT = PKG_DIR.parent
+
+# bsky_card and bsky_limit are needed by blog_publish at import time. Stub /
+# load them BEFORE adding PKG_DIR to sys.path so we don't accidentally pick up
+# the materialized siblings under /root/muninn_utils.
+import types
+
+bsky_card_stub = types.ModuleType("bsky_card")
+bsky_card_stub.compose_link_post = MagicMock()
+bsky_card_stub.create_post = MagicMock()
+sys.modules["bsky_card"] = bsky_card_stub
+
+# bsky_limit: prefer the real materialized one (correct grapheme counting),
+# fall back to a tiny len-based stub.
+try:
+    import importlib.util
+    materialized = Path("/root/muninn_utils/bsky_limit.py")
+    if materialized.exists():
+        spec = importlib.util.spec_from_file_location("bsky_limit", materialized)
+        bsky_limit_mod = importlib.util.module_from_spec(spec)
+        sys.modules["bsky_limit"] = bsky_limit_mod
+        spec.loader.exec_module(bsky_limit_mod)
+        bsky_limit = bsky_limit_mod
+    else:
+        raise FileNotFoundError
+except Exception:
+    bsky_limit = types.ModuleType("bsky_limit")
+    bsky_limit.BSKY_LIMIT = 300
+    bsky_limit.fits = lambda t, limit=300: len(t) <= limit
+    sys.modules["bsky_limit"] = bsky_limit
+
+# Wire flowing from the skill bytes (canonical source).
+sys.path.insert(0, str(SKILLS_ROOT / "flowing" / "scripts"))
+import flowing as _flowing
+sys.modules.setdefault("flowing", _flowing)
+
+# Now load OUR blog_publish (not the materialized one) by file path so there
+# is zero ambiguity about which copy is under test.
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "blog_publish_under_test", PKG_DIR / "blog_publish.py"
+)
+bp = importlib.util.module_from_spec(spec)
+sys.modules["blog_publish_under_test"] = bp
+spec.loader.exec_module(bp)
+
+
+def _reset(monkeypatch):
+    """Patch every external call inside blog_publish to a controllable mock."""
+    monkeypatch.setattr(bp, "publish_page", MagicMock(return_value="abcdef1234"))
+    monkeypatch.setattr(bp, "update_feed", MagicMock(return_value="feed5678"))
+    monkeypatch.setattr(bp, "link_engagement", MagicMock(return_value="link9999"))
+    monkeypatch.setattr(bp, "_probe_url", MagicMock(return_value=True))
+
+    bsky_card_stub.compose_link_post.reset_mock()
+    bsky_card_stub.create_post.reset_mock()
+    bsky_card_stub.compose_link_post.return_value = {"$type": "app.bsky.feed.post"}
+    bsky_card_stub.create_post.return_value = {
+        "uri": "at://did:plc:x/app.bsky.feed.post/abc",
+        "cid": "cid1",
+        "url": "https://bsky.app/profile/h/post/abc",
+        "rkey": "abc",
+    }
+    return bsky_card_stub
+
+
+def test_happy_path_main_chain_and_detached(monkeypatch):
+    """All five steps run, in order; detached chain produces post + link."""
+    bc = _reset(monkeypatch)
+
+    result = bp.publish_and_announce(
+        path="blog/x.html",
+        content="<html/>",
+        bsky_text="A post",
+        auth={"access_jwt": "j", "did": "did:plc:x", "handle": "h"},
+        feed_entry={"title": "X", "summary": "..."},
+    )
+
+    assert result["page_url"] == f"{bp._MUNINN_BASE}/blog/x.html"
+    assert result["commit_sha"] == "abcdef1234"
+    assert result["feed_sha"] == "feed5678"
+    assert result["deployed"] is True
+    assert result["bsky_post"]["url"].startswith("https://bsky.app/")
+    assert result["update_sha"] == "link9999"
+    assert result["detached_failures"] == []
+
+    # Main-chain functions each called exactly once.
+    assert bp.publish_page.call_count == 1
+    assert bp.update_feed.call_count == 1
+    assert bp.link_engagement.call_count == 1
+    assert bc.compose_link_post.call_count == 1
+    assert bc.create_post.call_count == 1
+
+
+def test_when_skips_feed_update_without_feed_path(monkeypatch):
+    """feed_path=None → update_feed_node skipped; detached chain still runs."""
+    bc = _reset(monkeypatch)
+
+    result = bp.publish_and_announce(
+        path="blog/y.html",
+        content="<html/>",
+        bsky_text="B",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        repo="oaustegard/oaustegard.github.io",
+        site_base="https://austegard.com",
+        feed_path=None,
+        feed_entry=None,
+    )
+
+    assert bp.update_feed.call_count == 0
+    assert result["feed_sha"] is None
+    # Page commit and bsky chain still ran.
+    assert bp.publish_page.call_count == 1
+    assert bc.create_post.call_count == 1
+    assert result["update_sha"] == "link9999"
+
+
+def test_validate_blocks_oversize_bsky_text(monkeypatch):
+    """bsky_text > BSKY_LIMIT → announce_bsky FAILS with no createRecord call."""
+    bc = _reset(monkeypatch)
+
+    huge = "x" * (bsky_limit.BSKY_LIMIT + 1)
+    result = bp.publish_and_announce(
+        path="blog/z.html",
+        content="<html/>",
+        bsky_text=huge,
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        feed_entry={"title": "Z", "summary": "..."},
+    )
+
+    # Main chain still completed.
+    assert result["commit_sha"] == "abcdef1234"
+    assert result["feed_sha"] == "feed5678"
+    # bsky never composed/posted.
+    assert bc.compose_link_post.call_count == 0
+    assert bc.create_post.call_count == 0
+    assert result["bsky_post"] is None
+    # link_engagement skipped (its dep failed).
+    assert bp.link_engagement.call_count == 0
+    # Surface in detached_failures.
+    failures = dict(result["detached_failures"])
+    assert "announce_bsky" in failures
+    assert "graphemes" in failures["announce_bsky"].lower() or \
+           str(bsky_limit.BSKY_LIMIT) in failures["announce_bsky"]
+
+
+def test_retry_until_consumes_budget_when_deploy_slow(monkeypatch):
+    """First N probes return False; succeeds on attempt N+1 within retry budget."""
+    bc = _reset(monkeypatch)
+
+    # Speed up the test: monkey-patch retry config to 0ms backoff.
+    monkeypatch.setattr(bp, "_DEPLOY_POLL_MS", 0)
+    monkeypatch.setattr(bp, "_DEPLOY_RETRIES", 4)
+
+    # Returns False, False, True (succeeds on third attempt).
+    seq = iter([False, False, True])
+    bp._probe_url = MagicMock(side_effect=lambda *a, **k: next(seq))
+    monkeypatch.setattr(bp, "_probe_url", bp._probe_url)
+
+    result = bp.publish_and_announce(
+        path="blog/r.html",
+        content="<html/>",
+        bsky_text="R",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        feed_entry={"title": "R", "summary": "..."},
+    )
+
+    assert result["deployed"] is True
+    # Probe called at least 3 times (the first two returned False).
+    assert bp._probe_url.call_count == 3
+    # Downstream still happened.
+    assert bp.update_feed.call_count == 1
+    assert bc.create_post.call_count == 1
+
+
+def test_retry_until_exhausts_budget(monkeypatch):
+    """Deploy never lands → wait_for_deploy_node FAILS, downstream all skipped."""
+    bc = _reset(monkeypatch)
+
+    monkeypatch.setattr(bp, "_DEPLOY_POLL_MS", 0)
+    monkeypatch.setattr(bp, "_DEPLOY_RETRIES", 2)
+    monkeypatch.setattr(bp, "_probe_url", MagicMock(return_value=False))
+
+    result = bp.publish_and_announce(
+        path="blog/never.html",
+        content="<html/>",
+        bsky_text="N",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        feed_entry={"title": "N", "summary": "..."},
+    )
+
+    # Page committed, but everything downstream skipped.
+    assert result["commit_sha"] == "abcdef1234"
+    assert result["deployed"] is False
+    assert result["feed_sha"] is None
+    assert result["bsky_post"] is None
+    assert result["update_sha"] is None
+    assert bp.update_feed.call_count == 0
+    assert bc.create_post.call_count == 0
+
+
+def test_skip_deploy_wait_short_circuits_probe(monkeypatch):
+    """skip_deploy_wait=True → _probe_url never called."""
+    bc = _reset(monkeypatch)
+    monkeypatch.setattr(bp, "_probe_url", MagicMock(return_value=False))
+
+    result = bp.publish_and_announce(
+        path="blog/skip.html",
+        content="<html/>",
+        bsky_text="S",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        feed_entry={"title": "S", "summary": "..."},
+        skip_deploy_wait=True,
+    )
+
+    assert result["deployed"] is True
+    assert bp._probe_url.call_count == 0
+    assert bp.update_feed.call_count == 1
+    assert bc.create_post.call_count == 1
+
+
+def test_bsky_failure_does_not_block_main_return(monkeypatch):
+    """create_post raises → bsky_post is None, detached_failures populated, but feed/page ok."""
+    bc = _reset(monkeypatch)
+    bc.create_post.side_effect = RuntimeError("AT Proto 503")
+
+    result = bp.publish_and_announce(
+        path="blog/det.html",
+        content="<html/>",
+        bsky_text="D",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        feed_entry={"title": "D", "summary": "..."},
+    )
+
+    assert result["commit_sha"] == "abcdef1234"
+    assert result["feed_sha"] == "feed5678"
+    assert result["bsky_post"] is None
+    assert result["update_sha"] is None
+    failures = dict(result["detached_failures"])
+    assert "announce_bsky" in failures
+    assert "503" in failures["announce_bsky"]
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/muninn_utils/tests/test_blog_publish_flow.py
+++ b/muninn_utils/tests/test_blog_publish_flow.py
@@ -27,8 +27,9 @@ SKILLS_ROOT = PKG_DIR.parent
 import types
 
 bsky_card_stub = types.ModuleType("bsky_card")
+# Collapsed compose_link_post returns {record, post, og_tags, thumb_blob,
+# facets, detached_failures} — see #617.
 bsky_card_stub.compose_link_post = MagicMock()
-bsky_card_stub.create_post = MagicMock()
 sys.modules["bsky_card"] = bsky_card_stub
 
 # bsky_limit: prefer the real materialized one (correct grapheme counting),
@@ -74,13 +75,19 @@ def _reset(monkeypatch):
     monkeypatch.setattr(bp, "_probe_url", MagicMock(return_value=True))
 
     bsky_card_stub.compose_link_post.reset_mock()
-    bsky_card_stub.create_post.reset_mock()
-    bsky_card_stub.compose_link_post.return_value = {"$type": "app.bsky.feed.post"}
-    bsky_card_stub.create_post.return_value = {
-        "uri": "at://did:plc:x/app.bsky.feed.post/abc",
-        "cid": "cid1",
-        "url": "https://bsky.app/profile/h/post/abc",
-        "rkey": "abc",
+    bsky_card_stub.compose_link_post.side_effect = None
+    bsky_card_stub.compose_link_post.return_value = {
+        "record": {"$type": "app.bsky.feed.post"},
+        "post": {
+            "uri": "at://did:plc:x/app.bsky.feed.post/abc",
+            "cid": "cid1",
+            "url": "https://bsky.app/profile/h/post/abc",
+            "rkey": "abc",
+        },
+        "og_tags": {"url": "u"},
+        "thumb_blob": None,
+        "facets": [],
+        "detached_failures": [],
     }
     return bsky_card_stub
 
@@ -110,7 +117,6 @@ def test_happy_path_main_chain_and_detached(monkeypatch):
     assert bp.update_feed.call_count == 1
     assert bp.link_engagement.call_count == 1
     assert bc.compose_link_post.call_count == 1
-    assert bc.create_post.call_count == 1
 
 
 def test_when_skips_feed_update_without_feed_path(monkeypatch):
@@ -132,7 +138,7 @@ def test_when_skips_feed_update_without_feed_path(monkeypatch):
     assert result["feed_sha"] is None
     # Page commit and bsky chain still ran.
     assert bp.publish_page.call_count == 1
-    assert bc.create_post.call_count == 1
+    assert bc.compose_link_post.call_count == 1
     assert result["update_sha"] == "link9999"
 
 
@@ -154,7 +160,6 @@ def test_validate_blocks_oversize_bsky_text(monkeypatch):
     assert result["feed_sha"] == "feed5678"
     # bsky never composed/posted.
     assert bc.compose_link_post.call_count == 0
-    assert bc.create_post.call_count == 0
     assert result["bsky_post"] is None
     # link_engagement skipped (its dep failed).
     assert bp.link_engagement.call_count == 0
@@ -191,7 +196,7 @@ def test_retry_until_consumes_budget_when_deploy_slow(monkeypatch):
     assert bp._probe_url.call_count == 3
     # Downstream still happened.
     assert bp.update_feed.call_count == 1
-    assert bc.create_post.call_count == 1
+    assert bc.compose_link_post.call_count == 1
 
 
 def test_retry_until_exhausts_budget(monkeypatch):
@@ -217,7 +222,7 @@ def test_retry_until_exhausts_budget(monkeypatch):
     assert result["bsky_post"] is None
     assert result["update_sha"] is None
     assert bp.update_feed.call_count == 0
-    assert bc.create_post.call_count == 0
+    assert bc.compose_link_post.call_count == 0
 
 
 def test_skip_deploy_wait_short_circuits_probe(monkeypatch):
@@ -237,13 +242,13 @@ def test_skip_deploy_wait_short_circuits_probe(monkeypatch):
     assert result["deployed"] is True
     assert bp._probe_url.call_count == 0
     assert bp.update_feed.call_count == 1
-    assert bc.create_post.call_count == 1
+    assert bc.compose_link_post.call_count == 1
 
 
 def test_bsky_failure_does_not_block_main_return(monkeypatch):
-    """create_post raises → bsky_post is None, detached_failures populated, but feed/page ok."""
+    """compose_link_post raises → bsky_post is None, detached_failures populated, but feed/page ok."""
     bc = _reset(monkeypatch)
-    bc.create_post.side_effect = RuntimeError("AT Proto 503")
+    bc.compose_link_post.side_effect = RuntimeError("AT Proto 503")
 
     result = bp.publish_and_announce(
         path="blog/det.html",

--- a/muninn_utils/tests/test_bsky_card_flow.py
+++ b/muninn_utils/tests/test_bsky_card_flow.py
@@ -1,12 +1,15 @@
 """
-Tests for bsky_card.compose_link_post / compose_and_post (issue #617).
+Tests for bsky_card.compose_link_post (issue #617).
+
+The collapsed API: compose_link_post runs the full graph (compose AND
+post) and returns a dict with record/post/og_tags/thumb_blob/facets.
 
 Verifies:
   - Topology: fetch_og + facets_node parallel, upload_blob → embed → record → post
-  - Happy path: record contains text + facets + embed with thumb
+  - Happy path: record contains text + facets + embed with thumb; post fires
   - No image in OG → embed has no thumb, post still fires
-  - upload_blob_node raises → embed and post SKIP cleanly, create_post never fires
-  - validate=must_be_valid_record blocks empty text
+  - upload_blob_node raises → embed/record/post SKIP cleanly, create_post never fires
+  - validate=must_have_valid_record_inputs blocks malformed embed
   - Pre-supplied og_tags short-circuits the network fetch
 """
 from __future__ import annotations
@@ -66,25 +69,29 @@ def _patch_externals(monkeypatch, *,
     return create_post_mock
 
 
-def test_compose_happy_path_returns_full_record(monkeypatch):
-    _patch_externals(monkeypatch)
+def test_compose_happy_path_returns_record_and_post(monkeypatch):
+    create_post_mock = _patch_externals(monkeypatch)
 
-    record = bc.compose_link_post(
+    result = bc.compose_link_post(
         "Check this out", "https://example.com/p",
         auth={"access_jwt": "j", "did": "did", "handle": "h"},
     )
 
-    assert record["$type"] == "app.bsky.feed.post"
+    assert result["record"]["$type"] == "app.bsky.feed.post"
     # URL should have been appended to text since not present.
-    assert "https://example.com/p" in record["text"]
+    assert "https://example.com/p" in result["record"]["text"]
     # Facet for the URL exists.
-    link_facets = [f for f in record["facets"]
+    link_facets = [f for f in result["record"]["facets"]
                    if any(feat["$type"] == "app.bsky.richtext.facet#link"
                           for feat in f["features"])]
     assert link_facets, "expected at least one link facet"
     # Embed has the thumb (upload returned a blob).
-    assert record["embed"]["external"]["uri"] == "https://example.com/p"
-    assert record["embed"]["external"]["thumb"]["$type"] == "blob"
+    assert result["record"]["embed"]["external"]["uri"] == "https://example.com/p"
+    assert result["thumb_blob"]["$type"] == "blob"
+    # Post fired.
+    assert result["post"]["url"].startswith("https://bsky.app/")
+    assert create_post_mock.call_count == 1
+    assert result["detached_failures"] == []
 
 
 def test_compose_no_og_image_yields_thumbless_embed(monkeypatch):
@@ -94,20 +101,22 @@ def test_compose_no_og_image_yields_thumbless_embed(monkeypatch):
         "description": "D",
     })
 
-    record = bc.compose_link_post(
+    result = bc.compose_link_post(
         "x", "https://example.com/p",
         auth={"access_jwt": "j", "did": "did", "handle": "h"},
     )
 
     # No thumb (no image in OG), but embed still present.
-    assert "thumb" not in record["embed"]["external"]
-    assert record["embed"]["external"]["uri"] == "https://example.com/p"
-    # upload_blob never called.
+    assert "thumb" not in result["record"]["embed"]["external"]
+    assert result["record"]["embed"]["external"]["uri"] == "https://example.com/p"
+    assert result["thumb_blob"] is None
+    # upload_blob never called; post still fired.
     assert bc.upload_blob.call_count == 0
+    assert bc.create_post.call_count == 1
 
 
-def test_compose_upload_failure_skips_embed_and_record(monkeypatch):
-    _patch_externals(monkeypatch, upload_raises=True)
+def test_compose_upload_failure_skips_embed_record_and_post(monkeypatch):
+    create_post_mock = _patch_externals(monkeypatch, upload_raises=True)
 
     try:
         bc.compose_link_post(
@@ -117,8 +126,11 @@ def test_compose_upload_failure_skips_embed_and_record(monkeypatch):
     except RuntimeError as e:
         assert "upload_blob_node" in str(e)
         assert "blob 503" in str(e)
-        return
-    raise AssertionError("expected RuntimeError when upload_blob_node fails")
+    else:
+        raise AssertionError("expected RuntimeError when upload_blob_node fails")
+
+    # The whole point of #617: create_post must NOT have fired.
+    assert create_post_mock.call_count == 0
 
 
 def test_compose_pre_supplied_og_skips_fetch(monkeypatch):
@@ -130,55 +142,23 @@ def test_compose_pre_supplied_og_skips_fetch(monkeypatch):
         "description": "D",
         "image": "https://example.com/img.png",
     }
-    record = bc.compose_link_post(
+    result = bc.compose_link_post(
         "x", "https://example.com/p",
         auth={"access_jwt": "j", "did": "did", "handle": "h"},
         og_tags=pre,
     )
 
-    assert record["embed"]["external"]["title"] == "Pre"
+    assert result["record"]["embed"]["external"]["title"] == "Pre"
+    assert result["og_tags"]["title"] == "Pre"
     assert bc.fetch_og_tags.call_count == 0
+    assert bc.create_post.call_count == 1
 
 
-def test_compose_and_post_happy_path(monkeypatch):
+def test_compose_validate_blocks_malformed_embed(monkeypatch):
+    """build_external_embed returns embed without uri → record_node validate raises."""
     create_post_mock = _patch_externals(monkeypatch)
 
-    result = bc.compose_and_post(
-        "x", "https://example.com/p",
-        auth={"access_jwt": "j", "did": "did", "handle": "h"},
-    )
-
-    assert result["record"]["$type"] == "app.bsky.feed.post"
-    assert result["post"]["url"].startswith("https://bsky.app/")
-    assert result["thumb_blob"]["$type"] == "blob"
-    assert isinstance(result["facets"], list)
-    assert result["detached_failures"] == []
-    assert create_post_mock.call_count == 1
-
-
-def test_compose_and_post_skips_create_when_upload_fails(monkeypatch):
-    create_post_mock = _patch_externals(monkeypatch, upload_raises=True)
-
-    try:
-        bc.compose_and_post(
-            "x", "https://example.com/p",
-            auth={"access_jwt": "j", "did": "did", "handle": "h"},
-        )
-    except RuntimeError:
-        pass
-    else:
-        raise AssertionError("expected RuntimeError when upload_blob_node fails")
-
-    # create_post must NOT have fired — that's the whole point of #617.
-    assert create_post_mock.call_count == 0
-
-
-def test_compose_and_post_validate_blocks_empty_text(monkeypatch):
-    _patch_externals(monkeypatch)
-
-    # An empty text after URL-append would still contain the URL line, so we
-    # need to construct a record that genuinely fails validate. Easiest: stub
-    # build_external_embed to drop the uri so the embed-uri check trips.
+    # Stub build_external_embed to drop the uri so the validator trips.
     monkeypatch.setattr(bc, "build_external_embed",
                         lambda og, thumb_blob=None: {
                             "$type": "app.bsky.embed.external",
@@ -186,18 +166,34 @@ def test_compose_and_post_validate_blocks_empty_text(monkeypatch):
                         })
 
     try:
-        bc.compose_and_post(
+        bc.compose_link_post(
             "x", "https://example.com/p",
             auth={"access_jwt": "j", "did": "did", "handle": "h"},
         )
     except RuntimeError as e:
         assert "record_node" in str(e)
-        assert "uri" in str(e)
+        assert "uri" in str(e).lower()
     else:
         raise AssertionError("expected RuntimeError on bad embed shape")
 
     # And no post fired.
-    assert bc.create_post.call_count == 0
+    assert create_post_mock.call_count == 0
+
+
+def test_compose_post_failure_propagates(monkeypatch):
+    """create_post itself failing → raises (no detached layer to absorb it)."""
+    _patch_externals(monkeypatch, post_raises=True)
+
+    try:
+        bc.compose_link_post(
+            "x", "https://example.com/p",
+            auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        )
+    except RuntimeError as e:
+        assert "post_node" in str(e)
+        assert "createRecord 500" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on post failure")
 
 
 if __name__ == "__main__":

--- a/muninn_utils/tests/test_bsky_card_flow.py
+++ b/muninn_utils/tests/test_bsky_card_flow.py
@@ -1,0 +1,205 @@
+"""
+Tests for bsky_card.compose_link_post / compose_and_post (issue #617).
+
+Verifies:
+  - Topology: fetch_og + facets_node parallel, upload_blob → embed → record → post
+  - Happy path: record contains text + facets + embed with thumb
+  - No image in OG → embed has no thumb, post still fires
+  - upload_blob_node raises → embed and post SKIP cleanly, create_post never fires
+  - validate=must_be_valid_record blocks empty text
+  - Pre-supplied og_tags short-circuits the network fetch
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+THIS_DIR = Path(__file__).resolve().parent
+PKG_DIR = THIS_DIR.parent
+SKILLS_ROOT = PKG_DIR.parent
+
+sys.path.insert(0, str(SKILLS_ROOT / "flowing" / "scripts"))
+import flowing as _flowing
+sys.modules.setdefault("flowing", _flowing)
+
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "bsky_card_under_test", PKG_DIR / "bsky_card.py"
+)
+bc = importlib.util.module_from_spec(spec)
+sys.modules["bsky_card_under_test"] = bc
+spec.loader.exec_module(bc)
+
+
+def _patch_externals(monkeypatch, *,
+                     og_tags=None,
+                     upload_raises=False,
+                     post_raises=False):
+    """Patch fetch_og_tags, upload_blob, create_post on the module."""
+    if og_tags is None:
+        og_tags = {
+            "url": "https://example.com/p",
+            "title": "T",
+            "description": "D",
+            "image": "https://example.com/i.png",
+        }
+    monkeypatch.setattr(bc, "fetch_og_tags", MagicMock(return_value=og_tags))
+
+    if upload_raises:
+        monkeypatch.setattr(bc, "upload_blob",
+                            MagicMock(side_effect=RuntimeError("blob 503")))
+    else:
+        monkeypatch.setattr(bc, "upload_blob",
+                            MagicMock(return_value={"$type": "blob", "ref": "x"}))
+
+    create_post_mock = MagicMock(return_value={
+        "uri": "at://did/app.bsky.feed.post/r",
+        "cid": "c",
+        "url": "https://bsky.app/profile/h/post/r",
+        "rkey": "r",
+    })
+    if post_raises:
+        create_post_mock.side_effect = RuntimeError("createRecord 500")
+    monkeypatch.setattr(bc, "create_post", create_post_mock)
+    return create_post_mock
+
+
+def test_compose_happy_path_returns_full_record(monkeypatch):
+    _patch_externals(monkeypatch)
+
+    record = bc.compose_link_post(
+        "Check this out", "https://example.com/p",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+    )
+
+    assert record["$type"] == "app.bsky.feed.post"
+    # URL should have been appended to text since not present.
+    assert "https://example.com/p" in record["text"]
+    # Facet for the URL exists.
+    link_facets = [f for f in record["facets"]
+                   if any(feat["$type"] == "app.bsky.richtext.facet#link"
+                          for feat in f["features"])]
+    assert link_facets, "expected at least one link facet"
+    # Embed has the thumb (upload returned a blob).
+    assert record["embed"]["external"]["uri"] == "https://example.com/p"
+    assert record["embed"]["external"]["thumb"]["$type"] == "blob"
+
+
+def test_compose_no_og_image_yields_thumbless_embed(monkeypatch):
+    _patch_externals(monkeypatch, og_tags={
+        "url": "https://example.com/p",
+        "title": "T",
+        "description": "D",
+    })
+
+    record = bc.compose_link_post(
+        "x", "https://example.com/p",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+    )
+
+    # No thumb (no image in OG), but embed still present.
+    assert "thumb" not in record["embed"]["external"]
+    assert record["embed"]["external"]["uri"] == "https://example.com/p"
+    # upload_blob never called.
+    assert bc.upload_blob.call_count == 0
+
+
+def test_compose_upload_failure_skips_embed_and_record(monkeypatch):
+    _patch_externals(monkeypatch, upload_raises=True)
+
+    try:
+        bc.compose_link_post(
+            "x", "https://example.com/p",
+            auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        )
+    except RuntimeError as e:
+        assert "upload_blob_node" in str(e)
+        assert "blob 503" in str(e)
+        return
+    raise AssertionError("expected RuntimeError when upload_blob_node fails")
+
+
+def test_compose_pre_supplied_og_skips_fetch(monkeypatch):
+    _patch_externals(monkeypatch)
+
+    pre = {
+        "url": "https://example.com/p",
+        "title": "Pre",
+        "description": "D",
+        "image": "https://example.com/img.png",
+    }
+    record = bc.compose_link_post(
+        "x", "https://example.com/p",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        og_tags=pre,
+    )
+
+    assert record["embed"]["external"]["title"] == "Pre"
+    assert bc.fetch_og_tags.call_count == 0
+
+
+def test_compose_and_post_happy_path(monkeypatch):
+    create_post_mock = _patch_externals(monkeypatch)
+
+    result = bc.compose_and_post(
+        "x", "https://example.com/p",
+        auth={"access_jwt": "j", "did": "did", "handle": "h"},
+    )
+
+    assert result["record"]["$type"] == "app.bsky.feed.post"
+    assert result["post"]["url"].startswith("https://bsky.app/")
+    assert result["thumb_blob"]["$type"] == "blob"
+    assert isinstance(result["facets"], list)
+    assert result["detached_failures"] == []
+    assert create_post_mock.call_count == 1
+
+
+def test_compose_and_post_skips_create_when_upload_fails(monkeypatch):
+    create_post_mock = _patch_externals(monkeypatch, upload_raises=True)
+
+    try:
+        bc.compose_and_post(
+            "x", "https://example.com/p",
+            auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected RuntimeError when upload_blob_node fails")
+
+    # create_post must NOT have fired — that's the whole point of #617.
+    assert create_post_mock.call_count == 0
+
+
+def test_compose_and_post_validate_blocks_empty_text(monkeypatch):
+    _patch_externals(monkeypatch)
+
+    # An empty text after URL-append would still contain the URL line, so we
+    # need to construct a record that genuinely fails validate. Easiest: stub
+    # build_external_embed to drop the uri so the embed-uri check trips.
+    monkeypatch.setattr(bc, "build_external_embed",
+                        lambda og, thumb_blob=None: {
+                            "$type": "app.bsky.embed.external",
+                            "external": {"title": "x", "description": "y"},
+                        })
+
+    try:
+        bc.compose_and_post(
+            "x", "https://example.com/p",
+            auth={"access_jwt": "j", "did": "did", "handle": "h"},
+        )
+    except RuntimeError as e:
+        assert "record_node" in str(e)
+        assert "uri" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on bad embed shape")
+
+    # And no post fired.
+    assert bc.create_post.call_count == 0
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/muninn_utils/tests/test_github_pr_flow.py
+++ b/muninn_utils/tests/test_github_pr_flow.py
@@ -1,0 +1,242 @@
+"""
+Tests for muninn_utils.github_pr_flow.open_pr (issue #620).
+
+Verifies:
+  - happy path: branch + push + PR + mergeable polling all run in order
+  - validate=must_not_be_base_branch blocks branch_name='main' (no API calls)
+  - validate also rejects other protected names ('master', 'production', etc.)
+  - validate rejects branch_name == base when base is custom (e.g. 'develop')
+  - retry_until consumes budget when mergeable_state is initially 'unknown'
+  - retry_until exhaustion: mergeable_state stays 'unknown' but PR still created
+  - PR creation failure raises (main DAG) and skips wait_mergeable
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+THIS_DIR = Path(__file__).resolve().parent
+PKG_DIR = THIS_DIR.parent
+SKILLS_ROOT = PKG_DIR.parent
+
+sys.path.insert(0, str(SKILLS_ROOT / "flowing" / "scripts"))
+import flowing as _flowing
+sys.modules.setdefault("flowing", _flowing)
+
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "github_pr_flow_under_test", PKG_DIR / "github_pr_flow.py"
+)
+gpf = importlib.util.module_from_spec(spec)
+sys.modules["github_pr_flow_under_test"] = gpf
+spec.loader.exec_module(gpf)
+
+
+def _patch_externals(monkeypatch, *,
+                     pr_create_raises=False,
+                     mergeable_sequence=None,
+                     base_sha="basesha",
+                     branch_create_raises=False,
+                     put_file_raises=False):
+    """Patch every network call in github_pr_flow."""
+    monkeypatch.setattr(gpf, "_get_branch_head", MagicMock(return_value=base_sha))
+
+    cb_mock = MagicMock(return_value={"object": {"sha": "newbranch1"}})
+    if branch_create_raises:
+        cb_mock.side_effect = RuntimeError("422 ref already exists")
+    monkeypatch.setattr(gpf, "_create_branch", cb_mock)
+
+    pf_mock = MagicMock(return_value={"commit": {"sha": "filecommit1"}})
+    if put_file_raises:
+        pf_mock.side_effect = RuntimeError("contents API 500")
+    monkeypatch.setattr(gpf, "_put_file", pf_mock)
+
+    cpr_mock = MagicMock(return_value={
+        "number": 99,
+        "html_url": "https://github.com/o/r/pull/99",
+        "state": "open",
+    })
+    if pr_create_raises:
+        cpr_mock.side_effect = RuntimeError("422 PR exists")
+    monkeypatch.setattr(gpf, "_create_pull_request", cpr_mock)
+
+    if mergeable_sequence is None:
+        mergeable_sequence = [{"mergeable_state": "clean", "mergeable": True}]
+    seq = iter(mergeable_sequence)
+    monkeypatch.setattr(gpf, "_get_pull_request",
+                        MagicMock(side_effect=lambda *a, **k: next(seq)))
+
+    return cb_mock, pf_mock, cpr_mock
+
+
+def test_happy_path_creates_branch_pushes_files_opens_pr(monkeypatch):
+    cb, pf, cpr = _patch_externals(monkeypatch)
+
+    result = gpf.open_pr(
+        repo="o/r",
+        branch_name="claude/feature-x",
+        title="Feature X",
+        body="Why & what.",
+        files=[("a.py", "print(1)"), ("b.py", "print(2)")],
+    )
+
+    assert result["pr_url"] == "https://github.com/o/r/pull/99"
+    assert result["pr_number"] == 99
+    assert result["branch"] == "claude/feature-x"
+    assert result["base"] == "main"
+    assert result["head_sha"] == "basesha"
+    assert result["mergeable_state"] == "clean"
+    assert result["files_pushed"] == ["a.py", "b.py"]
+    assert result["detached_failures"] == []
+
+    assert cb.call_count == 1
+    assert pf.call_count == 2
+    assert cpr.call_count == 1
+
+
+def test_validate_blocks_branch_name_main(monkeypatch):
+    cb, pf, cpr = _patch_externals(monkeypatch)
+
+    try:
+        gpf.open_pr(
+            repo="o/r", branch_name="main",
+            title="t", body="b",
+            files=[("a.py", "x")],
+        )
+    except RuntimeError as e:
+        assert "branch_name == base" in str(e) or "NEVER push directly" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on branch_name='main'")
+
+    # Zero API calls fired.
+    assert cb.call_count == 0
+    assert pf.call_count == 0
+    assert cpr.call_count == 0
+    assert gpf._get_branch_head.call_count == 0
+
+
+def test_validate_blocks_other_protected_names(monkeypatch):
+    """master, production, prod, trunk are also blocked."""
+    cb, pf, cpr = _patch_externals(monkeypatch)
+
+    for protected in ("master", "production", "prod", "trunk", "MAIN", "Master"):
+        try:
+            gpf.open_pr(
+                repo="o/r", branch_name=protected,
+                title="t", body="b",
+                files=[("a.py", "x")],
+            )
+        except RuntimeError as e:
+            msg = str(e).lower()
+            assert "protected" in msg or "branch_name == base" in msg, \
+                f"unexpected error for {protected!r}: {e}"
+        else:
+            raise AssertionError(f"expected RuntimeError on branch_name={protected!r}")
+
+    assert cb.call_count == 0
+
+
+def test_validate_blocks_branch_equal_to_custom_base(monkeypatch):
+    """base='develop' + branch='develop' → blocked."""
+    cb, pf, cpr = _patch_externals(monkeypatch)
+
+    try:
+        gpf.open_pr(
+            repo="o/r", branch_name="develop",
+            title="t", body="b",
+            files=[("a.py", "x")],
+            base="develop",
+        )
+    except RuntimeError as e:
+        assert "branch_name == base" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on branch == base")
+
+    assert cb.call_count == 0
+
+
+def test_retry_until_polls_until_settled(monkeypatch):
+    """First two polls return 'unknown', then 'clean'."""
+    cb, pf, cpr = _patch_externals(monkeypatch, mergeable_sequence=[
+        {"mergeable_state": "unknown", "mergeable": None},
+        {"mergeable_state": "unknown", "mergeable": None},
+        {"mergeable_state": "clean", "mergeable": True},
+    ])
+
+    result = gpf.open_pr(
+        repo="o/r", branch_name="claude/x",
+        title="t", body="b",
+        files=[("a.py", "x")],
+        mergeable_poll_retries=4,
+        mergeable_poll_base_ms=0,
+        mergeable_poll_max_ms=0,
+    )
+
+    assert result["mergeable_state"] == "clean"
+    assert gpf._get_pull_request.call_count == 3
+
+
+def test_retry_until_exhausts_budget_returns_last_state(monkeypatch):
+    """mergeable_state stays 'unknown' → wait_mergeable FAILS but PR is still presented."""
+    cb, pf, cpr = _patch_externals(monkeypatch, mergeable_sequence=[
+        {"mergeable_state": "unknown", "mergeable": None},
+    ] * 10)
+
+    result = gpf.open_pr(
+        repo="o/r", branch_name="claude/x",
+        title="t", body="b",
+        files=[("a.py", "x")],
+        mergeable_poll_retries=2,
+        mergeable_poll_base_ms=0,
+        mergeable_poll_max_ms=0,
+    )
+
+    # PR was created and URL surfaced.
+    assert result["pr_url"] == "https://github.com/o/r/pull/99"
+    # mergeable polling exhausted; last state preserved.
+    assert result["mergeable_state"] == "unknown"
+
+
+def test_unstable_mergeable_state_settles_immediately(monkeypatch):
+    """unstable (CI failing) is a settled state — don't keep polling."""
+    cb, pf, cpr = _patch_externals(monkeypatch, mergeable_sequence=[
+        {"mergeable_state": "unstable", "mergeable": True},
+    ])
+
+    result = gpf.open_pr(
+        repo="o/r", branch_name="claude/x",
+        title="t", body="b",
+        files=[("a.py", "x")],
+        mergeable_poll_retries=4,
+        mergeable_poll_base_ms=0,
+    )
+
+    assert result["mergeable_state"] == "unstable"
+    assert gpf._get_pull_request.call_count == 1
+
+
+def test_pr_create_failure_raises_skips_mergeable_poll(monkeypatch):
+    cb, pf, cpr = _patch_externals(monkeypatch, pr_create_raises=True)
+
+    try:
+        gpf.open_pr(
+            repo="o/r", branch_name="claude/x",
+            title="t", body="b",
+            files=[("a.py", "x")],
+        )
+    except RuntimeError as e:
+        assert "PR exists" in str(e) or "create_pr" in str(e).lower()
+    else:
+        raise AssertionError("expected RuntimeError on PR creation failure")
+
+    # Branch and files still pushed, but no mergeable poll.
+    assert cb.call_count == 1
+    assert pf.call_count == 1
+    assert gpf._get_pull_request.call_count == 0
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/muninn_utils/tests/test_issue_close_flow.py
+++ b/muninn_utils/tests/test_issue_close_flow.py
@@ -1,0 +1,198 @@
+"""
+Tests for muninn_utils.issue_close (issue #619).
+
+Verifies:
+  - happy path: close + memory + verify
+  - validate=must_have_synthesis_text rejects empty/whitespace
+  - close failure raises (main DAG); no memory write
+  - memory failure does NOT raise; surfaces in detached_failures
+  - pending_test=False skips verify_pending_test (when= gate)
+  - pending_test=True with missing tag → verify_pending_test fails detached
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+THIS_DIR = Path(__file__).resolve().parent
+PKG_DIR = THIS_DIR.parent
+SKILLS_ROOT = PKG_DIR.parent
+
+sys.path.insert(0, str(SKILLS_ROOT / "flowing" / "scripts"))
+import flowing as _flowing
+sys.modules.setdefault("flowing", _flowing)
+
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "issue_close_under_test", PKG_DIR / "issue_close.py"
+)
+ic = importlib.util.module_from_spec(spec)
+sys.modules["issue_close_under_test"] = ic
+spec.loader.exec_module(ic)
+
+
+def _patch_externals(monkeypatch, *,
+                     close_raises=False,
+                     remember_raises=False,
+                     mem_id="mem-abc-123",
+                     recall_returns=None):
+    """Patch GitHub + memory layers."""
+    if close_raises:
+        monkeypatch.setattr(ic, "_post_close_comment",
+                            MagicMock(side_effect=RuntimeError("GH 422")))
+    else:
+        monkeypatch.setattr(ic, "_post_close_comment",
+                            MagicMock(return_value={
+                                "id": 999,
+                                "html_url": "https://github.com/x/y/issues/1#issuecomment-999",
+                            }))
+    monkeypatch.setattr(ic, "_close_issue",
+                        MagicMock(return_value={"state": "closed"}))
+
+    remember_mock = MagicMock(return_value=mem_id)
+    if remember_raises:
+        remember_mock.side_effect = RuntimeError("turso 503")
+    monkeypatch.setattr(ic, "_import_remember", lambda: remember_mock)
+
+    if recall_returns is None:
+        recall_returns = [{"id": mem_id}]
+    recall_mock = MagicMock(return_value=recall_returns)
+    monkeypatch.setattr(ic, "_import_recall", lambda: recall_mock)
+
+    return remember_mock, recall_mock
+
+
+def test_happy_path_no_pending_test(monkeypatch):
+    remember_mock, recall_mock = _patch_externals(monkeypatch)
+
+    result = ic.issue_close(
+        number=42,
+        synthesis="Learned that flowing graphs make gates structural.",
+        repo="oaustegard/claude-skills",
+        pending_test=False,
+        extra_tags=["flowing"],
+    )
+
+    assert result["issue_url"] == "https://github.com/oaustegard/claude-skills/issues/42"
+    assert result["comment_url"].endswith("#issuecomment-999")
+    assert result["memory_id"] == "mem-abc-123"
+    assert result["pending_test_applied"] is False
+    assert result["detached_failures"] == []
+
+    assert ic._post_close_comment.call_count == 1
+    assert ic._close_issue.call_count == 1
+    assert remember_mock.call_count == 1
+    assert recall_mock.call_count == 0  # gated off
+
+    # The memory write got base tags but NOT pending-test.
+    args, kwargs = remember_mock.call_args
+    tags = kwargs.get("tags") or args[2] if len(args) > 2 else kwargs.get("tags", [])
+    assert "issue-42" in tags
+    assert "claude-skills" in tags
+    assert "flowing" in tags
+    assert ic.PENDING_TEST_TAG not in tags
+
+
+def test_pending_test_true_includes_tag_and_verifies(monkeypatch):
+    remember_mock, recall_mock = _patch_externals(monkeypatch)
+
+    result = ic.issue_close(
+        number=43,
+        synthesis="Pattern X validated under load.",
+        repo="oaustegard/claude-skills",
+        pending_test=True,
+    )
+
+    args, kwargs = remember_mock.call_args
+    tags = kwargs.get("tags", [])
+    assert ic.PENDING_TEST_TAG in tags
+
+    assert result["pending_test_applied"] is True
+    assert recall_mock.call_count == 1
+    assert result["detached_failures"] == []
+
+
+def test_validate_blocks_empty_synthesis(monkeypatch):
+    remember_mock, recall_mock = _patch_externals(monkeypatch)
+
+    try:
+        ic.issue_close(
+            number=44,
+            synthesis="   \n\t",
+            repo="oaustegard/claude-skills",
+        )
+    except RuntimeError as e:
+        assert "synthesis" in str(e).lower()
+    else:
+        raise AssertionError("expected RuntimeError on empty synthesis")
+
+    # No GitHub or memory work happened.
+    assert ic._post_close_comment.call_count == 0
+    assert ic._close_issue.call_count == 0
+    assert remember_mock.call_count == 0
+
+
+def test_close_failure_raises_no_memory_write(monkeypatch):
+    remember_mock, recall_mock = _patch_externals(monkeypatch, close_raises=True)
+
+    try:
+        ic.issue_close(
+            number=45,
+            synthesis="real synthesis",
+            repo="oaustegard/claude-skills",
+        )
+    except RuntimeError as e:
+        assert "GH 422" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on close failure")
+
+    # The PATCH-close was never reached either (post_close_comment failed first).
+    assert ic._close_issue.call_count == 0
+    # Memory write SKIPPED.
+    assert remember_mock.call_count == 0
+
+
+def test_memory_failure_is_detached_no_raise(monkeypatch):
+    remember_mock, recall_mock = _patch_externals(monkeypatch, remember_raises=True)
+
+    result = ic.issue_close(
+        number=46,
+        synthesis="real synthesis",
+        repo="oaustegard/claude-skills",
+    )
+
+    # Close succeeded.
+    assert result["issue_url"].endswith("/issues/46")
+    # Memory failed but didn't propagate.
+    assert result["memory_id"] is None
+    failures = dict(result["detached_failures"])
+    assert "store_synthesis_memory" in failures
+    assert "503" in failures["store_synthesis_memory"]
+
+
+def test_pending_test_tag_silently_dropped_surfaces_failure(monkeypatch):
+    """If the tag is missing on recall, verify_pending_test should fail detached."""
+    # Recall returns no rows matching mem_id → verify raises.
+    remember_mock, recall_mock = _patch_externals(monkeypatch,
+                                                  recall_returns=[{"id": "other"}])
+
+    result = ic.issue_close(
+        number=47,
+        synthesis="real synthesis",
+        repo="oaustegard/claude-skills",
+        pending_test=True,
+    )
+
+    # Close + memory both ok.
+    assert result["memory_id"] == "mem-abc-123"
+    # Verify failed → not applied + surfaced in detached failures.
+    assert result["pending_test_applied"] is False
+    failures = dict(result["detached_failures"])
+    assert "verify_pending_test" in failures
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Refactor four utilities as `flowing` v1.2 DAGs and start the `muninn_utils/`
migration documented in memory `0d63ed4f`. Addresses issues #616, #617, #619,
#620 (and closes #618 as wontfix).

Each refactor expresses a procedure that previously lived as imperative
prose ("first X, then Y, retry if Z…") as a structural graph: gates as
`when=`, contracts as `validate=`, predicate loops as `retry_until=`,
side-effects as `detached=True`. The runner owns the control flow; the
LLM provides the leaves.

### What landed

- **#616 `blog_publish.publish_and_announce`**: page → wait_for_deploy
  (retry_until) → update_feed (terminal); announce_bsky + link_engagement
  detached and auto-discovered. `validate=must_be_under_bsky_limit`
  blocks oversize text BEFORE create_post fires.

- **#617 `bsky_card.compose_link_post`**: fetch_og + facets parallel,
  upload_blob → embed → record (validate) → post. Collapsed prior
  separation of "compose returns record / create_post submits it" into
  one graph per Oskar's note ("internal utility, no need to preserve old
  signatures"). Returns `{record, post, og_tags, thumb_blob, facets,
  detached_failures}`.

- **#619 `issue_close`** (new utility): prepare_synthesis (validate
  non-empty) → close_github_issue (terminal); store_synthesis_memory +
  verify_pending_test detached. Implements github-procedures §7
  pattern with structural pending-test gating.

- **#620 `github_pr_flow.open_pr`** (new utility): determine_branch →
  guard (validate `must_not_be_base_branch`) → get_base_head →
  create_branch → push_files → create_pr → wait_mergeable
  (`retry_until` on settled mergeable_state) → present_pr. The §6 rule
  "NEVER push directly to main" is now physically un-skippable.

- **#618 wontfix**: `zeitgeist_delta.check_delta` is straight-line
  compute with no detached side-effect; the "branches" are conditionals
  inside a single per-section loop. Recasting as a DAG would be
  ceremonial. Closed with rationale referencing the issue's own
  "if straight-line, wontfix" instruction.

### Note on placement

`muninn_utils/*.py` files don't currently live in this repo — they're
materialized at boot from Turso `utility-code` memories. This PR seeds
`muninn_utils/` in the repo as the first step of the migration tracked
in memory `0d63ed4f` (mac → claude-skills sync via GH Actions).

### Test plan

- [x] `python3 -m pytest muninn_utils/tests/` — 27 tests across the
      4 utilities, all passing
- [x] Topology assertions: parallel layers, sequential deps,
      detached auto-discovery
- [x] Negative paths: validate rejection, retry_until exhaustion,
      detached failure isolation, SKIP cascade through failed deps
- [ ] **Live integration**: not run. Network-dependent — would post a
      real Bluesky message and create a real GH commit/PR. Mocks
      verify the graph plumbing; live verification belongs in a
      smoke-test session against a throwaway target.
- [ ] **Turso sync**: this PR seeds the files but doesn't update the
      `utility-code` memories. Boot still materializes the prior
      versions. A follow-up handoff (or the planned GH Actions sync)
      should write these versions back to Turso so they take effect.

Refs #616 #617 #619 #620; closes #618.
