### PR TITLE
Add opening-prs and closing-issues skills

### DIFF
--- a/closing-issues/SKILL.md
+++ b/closing-issues/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: closing-issues
+description: Close a GitHub issue with a synthesis comment as a flowing graph — validate the synthesis, post the closing comment, close, then run a pluggable callback (e.g. memory store) detached. Use when closing an issue should also capture the LEARNING (not just the diff log) and when the post-close work shouldn't block the close ack.
+metadata:
+  version: 0.1.0
+  requires: flowing
+---
+
+# Closing Issues
+
+A `flowing` graph that turns "close GitHub issue + capture what I learned"
+into a structural DAG. The synthesis text is validated upfront, the close
+happens against the GitHub API, and an optional post-close callback runs
+detached so the close ack is unblocked.
+
+```python
+from closing_issues import close_issue
+
+result = close_issue(
+    repo="owner/repo",
+    number=42,
+    synthesis=(
+        "Pattern X works because of Y. Constraint: don't apply to Z. "
+        "Future note: revisit when feature Q lands."
+    ),
+)
+
+print(result["issue_url"])    # https://github.com/.../issues/42
+print(result["comment_url"])  # ...#issuecomment-...
+```
+
+## Why a synthesis, not a "done" comment
+
+Closing an issue produces two artifacts:
+
+- **The Issue itself** — implementation log. The diff and commit history
+  already show *what* was done.
+- **The closing comment / synthesis** — what was *learned*. Lasts longer
+  than the diff in mental cache.
+
+Good closing comments lead with *why*, not *what*. Failure modes,
+constraints discovered, alternatives rejected. The synthesis is the
+seed of an institutional memory.
+
+## Internal shape
+
+```
+prepare_synthesis ──▶ close_github_issue           [terminal]
+                              │
+                              └──▶ post_close_callback  [detached, when=callback]
+```
+
+- **`validate=must_have_synthesis_text`** runs against the raw input
+  string. Empty or whitespace-only → FAILED with no GitHub API call.
+  This is structural: callers can't accidentally close-with-no-text.
+
+- **`close_github_issue`** posts the synthesis as a comment, then
+  PATCHes the issue to `state=closed, state_reason=completed`. Returns
+  the issue URL and comment URL.
+
+- **`post_close_callback`** (optional) runs detached. Caller plugs in
+  any extra work — store synthesis in a memory system, ping a tracker,
+  emit a webhook. Failure here lands in `result["detached_failures"]`
+  and does NOT bubble up as a close failure. Skipped via `when=` if
+  the callback isn't provided.
+
+## Pluggable post-close callback
+
+```python
+def store_in_my_memory(synthesis: str, issue_url: str, repo: str, number: int):
+    # Whatever your memory layer is — Turso, sqlite, a JSON file, etc.
+    db.execute("INSERT INTO learnings (issue, synthesis) VALUES (?, ?)",
+               (issue_url, synthesis))
+    return {"stored": True}
+
+result = close_issue(
+    repo="owner/repo",
+    number=42,
+    synthesis="...",
+    post_close_callback=store_in_my_memory,
+)
+
+if result["callback_result"] is None and result["detached_failures"]:
+    # The callback failed but the issue is still closed.
+    print("Memory store failed:", result["detached_failures"])
+```
+
+The callback receives keyword arguments: `synthesis`, `issue_url`,
+`repo`, `number`. Anything it returns goes into
+`result["callback_result"]`.
+
+## Result shape
+
+```python
+{
+    "issue_url":        "https://github.com/owner/repo/issues/N",
+    "comment_url":      "https://github.com/.../issues/N#issuecomment-...",
+    "comment_id":       12345,
+    "callback_result":  <whatever the callback returned, or None>,
+    "detached_failures": [],   # populated if callback raised
+}
+```
+
+Raises `RuntimeError` only if the GitHub close itself fails. Callback
+failures are detached.
+
+## Auth
+
+Requires `GH_TOKEN` (or `GITHUB_TOKEN`) in the environment. Classic PAT
+or fine-grained PAT with `repo` scope (specifically `issues:write`).
+
+## When NOT to use
+
+- Closing an issue without a synthesis. If you genuinely have nothing
+  to say beyond "done," just `gh issue close N` directly. This skill
+  is for the synthesis use case.
+- Closing many issues at once (use a script that calls this in a loop —
+  fine, but the flow setup cost per call is small but not zero).
+
+## See also
+
+- `flowing` — the DAG runner this skill is built on
+- `opening-prs` — the symmetric "open and merge" flow

--- a/closing-issues/scripts/closing_issues.py
+++ b/closing-issues/scripts/closing_issues.py
@@ -1,0 +1,154 @@
+"""
+closing_issues — close a GitHub issue with a synthesis comment as a
+flowing graph, with an optional pluggable post-close callback.
+
+The synthesis text is `validate=`d upfront; the close happens against
+the GitHub API; an optional callback runs `detached=True` so its
+failure doesn't bubble up as a close failure.
+
+See SKILL.md for the full picture.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from typing import Callable, Optional
+
+# The flowing skill is canonical. Try the package layout first; fall
+# back to importing it from the canonical install path.
+try:
+    from flowing import task, Flow, StepState  # type: ignore
+except ImportError:  # pragma: no cover — defensive only
+    import importlib.util as _ilu
+    import sys as _sys
+    _SKILL = "/mnt/skills/user/flowing/scripts/flowing.py"
+    if not os.path.exists(_SKILL):
+        raise ImportError(
+            "closing_issues requires the flowing skill at "
+            f"{_SKILL} or `from flowing import ...` on the python path"
+        )
+    _spec = _ilu.spec_from_file_location("flowing", _SKILL)
+    _flow = _ilu.module_from_spec(_spec)
+    _sys.modules["flowing"] = _flow
+    _spec.loader.exec_module(_flow)
+    task, Flow, StepState = _flow.task, _flow.Flow, _flow.StepState
+
+
+# ── GitHub helpers ─────────────────────────────────────────────────
+
+GITHUB_USER_AGENT = "closing-issues"
+
+
+def _gh_token() -> str:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+
+
+def _gh_api(method: str, endpoint: str, data: dict | None = None) -> dict:
+    token = _gh_token()
+    if not token:
+        raise RuntimeError(
+            "GH_TOKEN (or GITHUB_TOKEN) not set — closing-issues needs an "
+            "authenticated PAT. See SKILL.md > Auth."
+        )
+    url = f"https://api.github.com{endpoint}" if endpoint.startswith("/") else endpoint
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, method=method, headers={
+        "User-Agent": GITHUB_USER_AGENT,
+        "Authorization": f"token {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github+json",
+    })
+    return json.loads(urllib.request.urlopen(req).read())
+
+
+def _post_close_comment(repo: str, number: int, body: str) -> dict:
+    return _gh_api("POST", f"/repos/{repo}/issues/{number}/comments", {"body": body})
+
+
+def _close_issue(repo: str, number: int, state_reason: str = "completed") -> dict:
+    return _gh_api(
+        "PATCH", f"/repos/{repo}/issues/{number}",
+        {"state": "closed", "state_reason": state_reason},
+    )
+
+
+# ── Public API ─────────────────────────────────────────────────────
+
+def close_issue(
+    repo: str,
+    number: int,
+    synthesis: str,
+    *,
+    post_close_callback: Optional[Callable] = None,
+    state_reason: str = "completed",
+) -> dict:
+    """Close a GitHub issue with a synthesis comment.
+
+    See SKILL.md for full argument and result shape documentation.
+    """
+    def must_have_synthesis_text(**deps):
+        if not synthesis or not synthesis.strip():
+            raise ValueError(
+                "synthesis is empty or whitespace — close_issue needs the "
+                "LEARNING text. The diff already shows what was done."
+            )
+
+    @task(name="prepare_synthesis", validate=must_have_synthesis_text)
+    def prepare_synthesis():
+        return synthesis.strip()
+
+    @task(name="close_github_issue", depends_on=[prepare_synthesis])
+    def close_github_issue(prepare_synthesis):
+        comment = _post_close_comment(repo, number, prepare_synthesis)
+        _close_issue(repo, number, state_reason=state_reason)
+        return {
+            "issue_url": f"https://github.com/{repo}/issues/{number}",
+            "comment_url": comment.get("html_url"),
+            "comment_id": comment.get("id"),
+        }
+
+    @task(
+        name="post_close_callback",
+        depends_on=[close_github_issue, prepare_synthesis],
+        when=lambda **_: post_close_callback is not None,
+        detached=True,
+    )
+    def post_close_callback_node(close_github_issue, prepare_synthesis):
+        # mypy-style guard: when= would have skipped if None.
+        cb = post_close_callback
+        return cb(
+            synthesis=prepare_synthesis,
+            issue_url=close_github_issue["issue_url"],
+            repo=repo,
+            number=number,
+        )
+
+    flow = Flow(close_github_issue)
+    flow.run()
+
+    close_state = flow.results.get(close_github_issue.name)
+    if close_state is None or close_state.state != StepState.SUCCEEDED:
+        for r in flow.results.values():
+            if r.state == StepState.FAILED and r.error is not None:
+                raise RuntimeError(
+                    f"close_issue: {r.name} failed: {r.error}"
+                ) from r.error
+        raise RuntimeError("close_issue: close did not succeed")
+
+    closed = close_state.value
+    cb_state = flow.results.get(post_close_callback_node.name)
+    callback_result = (
+        cb_state.value
+        if cb_state is not None and cb_state.state == StepState.SUCCEEDED
+        else None
+    )
+    detached_failures = [(r.name, str(r.error)) for r in flow.detached_failures]
+
+    return {
+        "issue_url": closed["issue_url"],
+        "comment_url": closed.get("comment_url"),
+        "comment_id": closed.get("comment_id"),
+        "callback_result": callback_result,
+        "detached_failures": detached_failures,
+    }

--- a/closing-issues/tests/test_closing_issues.py
+++ b/closing-issues/tests/test_closing_issues.py
@@ -1,0 +1,163 @@
+"""
+Tests for closing-issues.closing_issues.close_issue.
+
+Verifies:
+  - happy path (no callback): close + comment, no callback fires
+  - happy path (with callback): close + comment + callback runs detached
+  - validate=must_have_synthesis_text rejects empty/whitespace
+  - close failure raises (main DAG); no callback fires
+  - callback failure does NOT raise; surfaces in detached_failures
+  - missing GH_TOKEN raises before any API call
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = THIS_DIR.parent / "scripts"
+SKILL_ROOT = THIS_DIR.parent
+SKILLS_PARENT = SKILL_ROOT.parent
+
+sys.path.insert(0, str(SKILLS_PARENT / "flowing" / "scripts"))
+import flowing as _flowing  # noqa: F401
+sys.modules.setdefault("flowing", _flowing)
+
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "closing_issues_under_test", SCRIPTS_DIR / "closing_issues.py"
+)
+ci = importlib.util.module_from_spec(spec)
+sys.modules["closing_issues_under_test"] = ci
+spec.loader.exec_module(ci)
+
+
+def _patch_externals(monkeypatch, *, close_raises=False):
+    if close_raises:
+        monkeypatch.setattr(ci, "_post_close_comment",
+                            MagicMock(side_effect=RuntimeError("GH 422")))
+    else:
+        monkeypatch.setattr(ci, "_post_close_comment",
+                            MagicMock(return_value={
+                                "id": 999,
+                                "html_url": "https://github.com/o/r/issues/1#issuecomment-999",
+                            }))
+    monkeypatch.setattr(ci, "_close_issue",
+                        MagicMock(return_value={"state": "closed"}))
+
+
+def _ensure_token(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+
+def test_happy_path_no_callback(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch)
+
+    result = ci.close_issue(
+        repo="o/r", number=42,
+        synthesis="Pattern X works because of Y. Constraint: Z.",
+    )
+
+    assert result["issue_url"] == "https://github.com/o/r/issues/42"
+    assert result["comment_url"].endswith("#issuecomment-999")
+    assert result["callback_result"] is None
+    assert result["detached_failures"] == []
+    assert ci._post_close_comment.call_count == 1
+    assert ci._close_issue.call_count == 1
+
+
+def test_happy_path_with_callback(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch)
+
+    callback = MagicMock(return_value={"stored": True, "id": "mem-1"})
+    result = ci.close_issue(
+        repo="o/r", number=43,
+        synthesis="Learned about flowing graphs.",
+        post_close_callback=callback,
+    )
+
+    assert result["callback_result"] == {"stored": True, "id": "mem-1"}
+    assert callback.call_count == 1
+    # Callback receives the four kwargs.
+    cb_kwargs = callback.call_args.kwargs
+    assert cb_kwargs["synthesis"] == "Learned about flowing graphs."
+    assert cb_kwargs["issue_url"].endswith("/issues/43")
+    assert cb_kwargs["repo"] == "o/r"
+    assert cb_kwargs["number"] == 43
+
+
+def test_validate_blocks_empty_synthesis(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch)
+    callback = MagicMock()
+
+    try:
+        ci.close_issue(
+            repo="o/r", number=44, synthesis="   \n\t",
+            post_close_callback=callback,
+        )
+    except RuntimeError as e:
+        assert "synthesis" in str(e).lower()
+    else:
+        raise AssertionError("expected RuntimeError on empty synthesis")
+
+    # No GitHub API calls and no callback.
+    assert ci._post_close_comment.call_count == 0
+    assert ci._close_issue.call_count == 0
+    assert callback.call_count == 0
+
+
+def test_close_failure_raises_no_callback(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch, close_raises=True)
+    callback = MagicMock()
+
+    try:
+        ci.close_issue(
+            repo="o/r", number=45, synthesis="real synthesis",
+            post_close_callback=callback,
+        )
+    except RuntimeError as e:
+        assert "GH 422" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on close failure")
+
+    assert callback.call_count == 0
+
+
+def test_callback_failure_is_detached_no_raise(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch)
+    callback = MagicMock(side_effect=RuntimeError("memory store down"))
+
+    result = ci.close_issue(
+        repo="o/r", number=46, synthesis="real synthesis",
+        post_close_callback=callback,
+    )
+
+    # Close still succeeded.
+    assert result["issue_url"].endswith("/issues/46")
+    # Callback failed but didn't propagate.
+    assert result["callback_result"] is None
+    failures = dict(result["detached_failures"])
+    assert "post_close_callback" in failures
+    assert "memory store down" in failures["post_close_callback"]
+
+
+def test_missing_token_raises_before_api(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    try:
+        ci._gh_api("GET", "/repos/x/y")
+    except RuntimeError as e:
+        assert "GH_TOKEN" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on missing token")
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/opening-prs/SKILL.md
+++ b/opening-prs/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: opening-prs
+description: Open a GitHub PR via API as a flowing graph — branch + push + create_pr + mergeable poll, with structural protection against pushing to main/master/etc. Use when a Claude Code or Claude.ai container needs to land changes on GitHub via the API (no git CLI required) and the prose "create branch, push, open PR, wait for mergeable" workflow keeps drifting under context pressure.
+metadata:
+  version: 0.1.0
+  requires: flowing
+---
+
+# Opening PRs
+
+A `flowing` graph that turns the imperative "create branch, push files,
+open a PR, poll mergeable_state" workflow into a structural DAG. The
+"NEVER push directly to main" rule is encoded as a `validate=` gate that
+physically can't be skipped.
+
+```python
+from opening_prs import open_pr
+
+result = open_pr(
+    repo="owner/repo",
+    branch_name="feat/cool-thing",
+    title="Add cool thing",
+    body="## Summary\n\n...",
+    files=[
+        ("src/cool.py", "<file content>"),
+        ("docs/cool.md", "<file content>"),
+    ],
+    base="main",  # default; protected names are also rejected
+)
+
+print(result["pr_url"])             # https://github.com/.../pull/N
+print(result["mergeable_state"])    # clean | dirty | unstable | behind | blocked
+```
+
+## What this fixes
+
+The `gh pr create` workflow (or hand-rolled API calls) has five steps in
+prose form:
+
+1. Determine the branch name
+2. Get the base branch's HEAD SHA
+3. Create the branch
+4. Push files to the branch
+5. Create the PR
+6. Poll `mergeable_state` until GitHub finishes computing it
+
+Each step has known failure modes:
+
+- **Step 1**: Accidentally pushing to `main` — the diagnosed pattern that
+  motivated github-procedures §6 in the first place.
+- **Step 6**: GitHub returns `mergeable_state: null` immediately after
+  creation. Need to poll. "Wait a few seconds and check" is prose, not a
+  procedure — so it gets skipped under context pressure.
+
+This skill encodes both as flowing primitives:
+
+```
+determine_branch ──▶ guard ──▶ get_base_head ──▶ create_branch
+                      │                              │
+                      │                              ▼
+                      │                        push_files
+                      │                              │
+                      │                              ▼
+                      │                         create_pr
+                      │                          /        \
+                      │                         ▼          ▼
+                      │                  wait_mergeable  present_pr [terminal]
+                      │
+                      └─ validate=must_not_be_base_branch
+```
+
+- **`validate=must_not_be_base_branch`** rejects `branch_name in
+  {"main", "master", "trunk", "production", "prod"}` — case-insensitive
+  — and the configured `base` itself. The body of `create_branch` never
+  fires for a protected name. No GitHub API call happens for an
+  invalid branch name.
+
+- **`retry_until=lambda r: r["mergeable_state"] in SETTLED_STATES`**
+  consumes the retry budget while GitHub computes the merge result.
+  `unknown` and `null` keep polling; settled states (`clean`, `dirty`,
+  `unstable`, `behind`, `blocked`) stop. Exhaustion is soft: the PR is
+  still presented with the last observed state.
+
+## Auth
+
+Requires `GH_TOKEN` (or `GITHUB_TOKEN`) in the environment. Classic PAT
+or fine-grained PAT with `repo` scope.
+
+```python
+import os
+os.environ["GH_TOKEN"] = "ghp_..."   # or load from a .env file
+```
+
+The skill sends `User-Agent: opening-prs` on every API call. (GitHub
+returns 401 "Bad credentials" without a UA, regardless of token
+validity. Common trap.)
+
+## Result shape
+
+```python
+{
+    "pr_url": "https://github.com/owner/repo/pull/N",
+    "pr_number": 42,
+    "pr_state": "open",
+    "branch": "feat/cool-thing",
+    "base": "main",
+    "head_sha": "abc123...",
+    "mergeable_state": "clean",
+    "files_pushed": ["src/cool.py", "docs/cool.md"],
+    "detached_failures": [],
+}
+```
+
+Raises `RuntimeError` only if the main DAG fails (validate, branch
+creation, file push, or PR creation). Mergeable polling exhaustion is a
+soft failure — the PR exists, the field just isn't computed yet.
+
+## Tuning the mergeable poll
+
+```python
+open_pr(
+    ...,
+    mergeable_poll_retries=8,         # default 8
+    mergeable_poll_base_ms=2000,      # default 2s
+    mergeable_poll_max_ms=8000,       # default 8s (cap on exponential backoff)
+)
+```
+
+## When NOT to use
+
+- Pushing many large files (the GitHub Contents API is one-file-per-PUT
+  with base64 encoding — slow above ~10 files). Use `git push` if you
+  have the CLI.
+- Needing to amend commits or rewrite history. This skill creates one
+  commit per file via the contents API.
+- Anything involving force-push, branch deletion, or PR review-state
+  manipulation. Out of scope; use a different tool.
+
+## See also
+
+- `flowing` — the DAG runner this skill is built on
+- `closing-issues` — the symmetric "close + synthesize" flow
+- The `accessing-github-repos` skill for byte-layer GitHub access patterns

--- a/opening-prs/scripts/opening_prs.py
+++ b/opening-prs/scripts/opening_prs.py
@@ -1,0 +1,266 @@
+"""
+opening_prs — open a GitHub PR via API as a flowing graph.
+
+The "NEVER push directly to main" rule is `validate=`; the
+"poll mergeable_state until settled" prose is `retry_until=`.
+
+See SKILL.md for the full picture.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Iterable, List, Tuple
+
+# The flowing skill is the canonical source. Try the package layout first,
+# fall back to the bare module name (legacy materialized layout).
+try:
+    from flowing import task, Flow, StepState  # type: ignore
+except ImportError:  # pragma: no cover — defensive only
+    import importlib.util as _ilu
+    import sys as _sys
+    _SKILL = "/mnt/skills/user/flowing/scripts/flowing.py"
+    if not os.path.exists(_SKILL):
+        raise ImportError(
+            "opening_prs requires the flowing skill at "
+            f"{_SKILL} or `from flowing import ...` on the python path"
+        )
+    _spec = _ilu.spec_from_file_location("flowing", _SKILL)
+    _flow = _ilu.module_from_spec(_spec)
+    _sys.modules["flowing"] = _flow
+    _spec.loader.exec_module(_flow)
+    task, Flow, StepState = _flow.task, _flow.Flow, _flow.StepState
+
+
+# ── GitHub helpers ─────────────────────────────────────────────────
+
+GITHUB_USER_AGENT = "opening-prs"
+
+
+def _gh_token() -> str:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+
+
+def _gh_api(method: str, endpoint: str, data: dict | None = None) -> dict:
+    token = _gh_token()
+    if not token:
+        raise RuntimeError(
+            "GH_TOKEN (or GITHUB_TOKEN) not set — opening-prs needs an "
+            "authenticated PAT. See SKILL.md > Auth."
+        )
+    url = f"https://api.github.com{endpoint}" if endpoint.startswith("/") else endpoint
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, method=method, headers={
+        "User-Agent": GITHUB_USER_AGENT,
+        "Authorization": f"token {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github+json",
+    })
+    return json.loads(urllib.request.urlopen(req).read())
+
+
+SETTLED_MERGEABLE_STATES = frozenset({"clean", "dirty", "unstable", "behind", "blocked"})
+
+
+def _get_branch_head(repo: str, branch: str) -> str:
+    ref = _gh_api("GET", f"/repos/{repo}/git/refs/heads/{branch}")
+    return ref["object"]["sha"]
+
+
+def _create_branch(repo: str, branch: str, from_sha: str) -> dict:
+    return _gh_api(
+        "POST", f"/repos/{repo}/git/refs",
+        {"ref": f"refs/heads/{branch}", "sha": from_sha},
+    )
+
+
+def _put_file(repo: str, branch: str, path: str, content: str,
+              message: str | None = None) -> dict:
+    payload = {
+        "message": message or f"Add {path}",
+        "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+        "branch": branch,
+    }
+    try:
+        existing = _gh_api(
+            "GET", f"/repos/{repo}/contents/{path}?ref={branch}"
+        )
+        if isinstance(existing, dict) and existing.get("sha"):
+            payload["sha"] = existing["sha"]
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise
+    return _gh_api("PUT", f"/repos/{repo}/contents/{path}", payload)
+
+
+def _create_pull_request(repo: str, head: str, base: str,
+                          title: str, body: str) -> dict:
+    return _gh_api(
+        "POST", f"/repos/{repo}/pulls",
+        {"title": title, "body": body, "head": head, "base": base},
+    )
+
+
+def _get_pull_request(repo: str, number: int) -> dict:
+    return _gh_api("GET", f"/repos/{repo}/pulls/{number}")
+
+
+# ── Edge contracts ─────────────────────────────────────────────────
+
+PROTECTED_BRANCH_NAMES = frozenset({"main", "master", "trunk", "production", "prod"})
+
+
+def _must_not_be_base_branch_factory(base: str):
+    base_norm = base.strip().lower()
+
+    def must_not_be_base_branch(**deps):
+        candidate = next(iter(deps.values()), None)
+        if candidate is None:
+            raise ValueError("must_not_be_base_branch: no candidate branch in deps")
+        if not isinstance(candidate, str) or not candidate.strip():
+            raise ValueError(f"branch_name must be a non-empty string, got: {candidate!r}")
+        norm = candidate.strip().lower()
+        if norm == base_norm:
+            raise ValueError(
+                f"branch_name == base ({base!r}) — refusing. "
+                "Branch off the base, don't push directly to it."
+            )
+        if norm in PROTECTED_BRANCH_NAMES:
+            raise ValueError(
+                f"branch_name {candidate!r} is a protected name "
+                f"({sorted(PROTECTED_BRANCH_NAMES)}) — branch off it instead"
+            )
+    return must_not_be_base_branch
+
+
+# ── Public API ─────────────────────────────────────────────────────
+
+def open_pr(
+    repo: str,
+    branch_name: str,
+    title: str,
+    body: str,
+    files: Iterable[Tuple[str, str]],
+    *,
+    base: str = "main",
+    mergeable_poll_retries: int = 8,
+    mergeable_poll_base_ms: int = 2000,
+    mergeable_poll_max_ms: int = 8000,
+) -> dict:
+    """Create a branch, push files, open a PR, poll for mergeable state.
+
+    See SKILL.md for full argument and result shape documentation.
+    """
+    files_list: List[Tuple[str, str]] = list(files)
+
+    @task(name="determine_branch")
+    def determine_branch():
+        return branch_name.strip()
+
+    @task(
+        name="must_not_be_base_branch_guard",
+        depends_on=[determine_branch],
+        validate=_must_not_be_base_branch_factory(base),
+    )
+    def must_not_be_base_branch_guard(determine_branch):
+        return determine_branch
+
+    @task(name="get_base_head", depends_on=[must_not_be_base_branch_guard])
+    def get_base_head(must_not_be_base_branch_guard):
+        sha = _get_branch_head(repo, base)
+        return {"base": base, "sha": sha}
+
+    @task(
+        name="create_branch",
+        depends_on=[must_not_be_base_branch_guard, get_base_head],
+    )
+    def create_branch(must_not_be_base_branch_guard, get_base_head):
+        ref = _create_branch(repo, must_not_be_base_branch_guard, get_base_head["sha"])
+        return {
+            "branch": must_not_be_base_branch_guard,
+            "ref_sha": ref["object"]["sha"],
+        }
+
+    @task(name="push_files", depends_on=[create_branch])
+    def push_files(create_branch):
+        branch = create_branch["branch"]
+        pushed = []
+        for path, content in files_list:
+            resp = _put_file(repo, branch, path, content,
+                             message=f"Add {path}")
+            commit = resp.get("commit", {}) if isinstance(resp, dict) else {}
+            pushed.append({"path": path, "commit_sha": commit.get("sha")})
+        return {"branch": branch, "pushed": pushed}
+
+    @task(name="create_pr", depends_on=[push_files])
+    def create_pr(push_files):
+        pr = _create_pull_request(
+            repo, head=push_files["branch"], base=base,
+            title=title, body=body,
+        )
+        return {
+            "pr_number": pr["number"],
+            "pr_url": pr["html_url"],
+            "pr_state": pr.get("state"),
+        }
+
+    @task(
+        name="wait_mergeable",
+        depends_on=[create_pr],
+        retry=mergeable_poll_retries,
+        retry_backoff_base_ms=mergeable_poll_base_ms,
+        retry_max_backoff_ms=mergeable_poll_max_ms,
+        retry_until=lambda r: r["mergeable_state"] in SETTLED_MERGEABLE_STATES,
+    )
+    def wait_mergeable(create_pr):
+        pr = _get_pull_request(repo, create_pr["pr_number"])
+        return {
+            "mergeable_state": pr.get("mergeable_state") or "unknown",
+            "mergeable": pr.get("mergeable"),
+        }
+
+    @task(name="present_pr", depends_on=[create_pr])
+    def present_pr(create_pr):
+        print(f"  ✓ PR ready: {create_pr['pr_url']}")
+        return create_pr
+
+    flow = Flow(present_pr, wait_mergeable)
+    flow.run()
+
+    create_pr_state = flow.results.get(create_pr.name)
+    if create_pr_state is None or create_pr_state.state != StepState.SUCCEEDED:
+        for r in flow.results.values():
+            if r.state == StepState.FAILED and r.error is not None:
+                raise RuntimeError(f"open_pr failed at {r.name}: {r.error}") from r.error
+        raise RuntimeError("open_pr: PR creation did not succeed")
+
+    def _val(td):
+        r = flow.results.get(td.name)
+        if r is None or r.state != StepState.SUCCEEDED:
+            return None
+        return r.value
+
+    pr_payload = create_pr_state.value
+    push_payload = _val(push_files) or {}
+    base_payload = _val(get_base_head) or {}
+    mergeable_state = "unknown"
+    mergeable_result = flow.results.get(wait_mergeable.name)
+    if mergeable_result is not None and mergeable_result.value is not None:
+        mergeable_state = mergeable_result.value.get("mergeable_state", "unknown")
+
+    detached_failures = [(r.name, str(r.error)) for r in flow.detached_failures]
+
+    return {
+        "pr_url": pr_payload["pr_url"],
+        "pr_number": pr_payload["pr_number"],
+        "pr_state": pr_payload.get("pr_state"),
+        "branch": branch_name.strip(),
+        "base": base,
+        "head_sha": base_payload.get("sha"),
+        "mergeable_state": mergeable_state,
+        "files_pushed": [p["path"] for p in push_payload.get("pushed", [])],
+        "detached_failures": detached_failures,
+    }

--- a/opening-prs/tests/test_opening_prs.py
+++ b/opening-prs/tests/test_opening_prs.py
@@ -1,0 +1,212 @@
+"""
+Tests for opening-prs.opening_prs.open_pr.
+
+Verifies:
+  - happy path: branch + push + PR + mergeable polling all run in order
+  - validate=must_not_be_base_branch blocks branch_name='main' (no API calls)
+  - validate also rejects other protected names ('master', 'production', etc.)
+  - validate rejects branch_name == base when base is custom (e.g. 'develop')
+  - retry_until consumes budget when mergeable_state is initially 'unknown'
+  - retry_until exhaustion: mergeable_state stays 'unknown' but PR still created
+  - PR creation failure raises (main DAG) and skips wait_mergeable
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = THIS_DIR.parent / "scripts"
+SKILL_ROOT = THIS_DIR.parent
+SKILLS_PARENT = SKILL_ROOT.parent  # repo root
+
+# Wire flowing
+sys.path.insert(0, str(SKILLS_PARENT / "flowing" / "scripts"))
+import flowing as _flowing  # noqa: F401
+sys.modules.setdefault("flowing", _flowing)
+
+# Load opening_prs by file path
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "opening_prs_under_test", SCRIPTS_DIR / "opening_prs.py"
+)
+op = importlib.util.module_from_spec(spec)
+sys.modules["opening_prs_under_test"] = op
+spec.loader.exec_module(op)
+
+
+def _patch_externals(monkeypatch, *,
+                     pr_create_raises=False,
+                     mergeable_sequence=None,
+                     base_sha="basesha",
+                     branch_create_raises=False,
+                     put_file_raises=False):
+    monkeypatch.setattr(op, "_get_branch_head", MagicMock(return_value=base_sha))
+
+    cb_mock = MagicMock(return_value={"object": {"sha": "newbranch1"}})
+    if branch_create_raises:
+        cb_mock.side_effect = RuntimeError("422 ref already exists")
+    monkeypatch.setattr(op, "_create_branch", cb_mock)
+
+    pf_mock = MagicMock(return_value={"commit": {"sha": "filecommit1"}})
+    if put_file_raises:
+        pf_mock.side_effect = RuntimeError("contents API 500")
+    monkeypatch.setattr(op, "_put_file", pf_mock)
+
+    cpr_mock = MagicMock(return_value={
+        "number": 99,
+        "html_url": "https://github.com/o/r/pull/99",
+        "state": "open",
+    })
+    if pr_create_raises:
+        cpr_mock.side_effect = RuntimeError("422 PR exists")
+    monkeypatch.setattr(op, "_create_pull_request", cpr_mock)
+
+    if mergeable_sequence is None:
+        mergeable_sequence = [{"mergeable_state": "clean", "mergeable": True}]
+    seq = iter(mergeable_sequence)
+    monkeypatch.setattr(op, "_get_pull_request",
+                        MagicMock(side_effect=lambda *a, **k: next(seq)))
+
+    return cb_mock, pf_mock, cpr_mock
+
+
+def _ensure_token(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+
+def test_happy_path(monkeypatch):
+    _ensure_token(monkeypatch)
+    cb, pf, cpr = _patch_externals(monkeypatch)
+
+    result = op.open_pr(
+        repo="o/r", branch_name="claude/feature-x",
+        title="Feature X", body="Why & what.",
+        files=[("a.py", "print(1)"), ("b.py", "print(2)")],
+    )
+
+    assert result["pr_url"] == "https://github.com/o/r/pull/99"
+    assert result["pr_number"] == 99
+    assert result["mergeable_state"] == "clean"
+    assert result["files_pushed"] == ["a.py", "b.py"]
+    assert cb.call_count == 1
+    assert pf.call_count == 2
+    assert cpr.call_count == 1
+
+
+def test_validate_blocks_main(monkeypatch):
+    _ensure_token(monkeypatch)
+    cb, pf, cpr = _patch_externals(monkeypatch)
+    try:
+        op.open_pr(repo="o/r", branch_name="main",
+                   title="t", body="b", files=[("a", "x")])
+    except RuntimeError as e:
+        assert "branch_name == base" in str(e) or "NEVER push" in str(e) or "Branch off" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError")
+    assert cb.call_count == 0
+    assert cpr.call_count == 0
+
+
+def test_validate_blocks_other_protected(monkeypatch):
+    _ensure_token(monkeypatch)
+    cb, pf, cpr = _patch_externals(monkeypatch)
+    for name in ("master", "production", "prod", "trunk", "MAIN", "Master"):
+        try:
+            op.open_pr(repo="o/r", branch_name=name,
+                       title="t", body="b", files=[("a", "x")])
+        except RuntimeError:
+            continue
+        raise AssertionError(f"expected RuntimeError for {name!r}")
+    assert cb.call_count == 0
+
+
+def test_validate_blocks_branch_equal_to_custom_base(monkeypatch):
+    _ensure_token(monkeypatch)
+    cb, pf, cpr = _patch_externals(monkeypatch)
+    try:
+        op.open_pr(repo="o/r", branch_name="develop",
+                   title="t", body="b", files=[("a", "x")], base="develop")
+    except RuntimeError as e:
+        assert "branch_name == base" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError")
+    assert cb.call_count == 0
+
+
+def test_retry_until_polls_until_settled(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch, mergeable_sequence=[
+        {"mergeable_state": "unknown"},
+        {"mergeable_state": "unknown"},
+        {"mergeable_state": "clean"},
+    ])
+    result = op.open_pr(
+        repo="o/r", branch_name="claude/x", title="t", body="b",
+        files=[("a", "x")], mergeable_poll_retries=4,
+        mergeable_poll_base_ms=0, mergeable_poll_max_ms=0,
+    )
+    assert result["mergeable_state"] == "clean"
+    assert op._get_pull_request.call_count == 3
+
+
+def test_retry_until_exhaustion_preserves_state(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch, mergeable_sequence=[
+        {"mergeable_state": "unknown"}] * 10)
+    result = op.open_pr(
+        repo="o/r", branch_name="claude/x", title="t", body="b",
+        files=[("a", "x")], mergeable_poll_retries=2,
+        mergeable_poll_base_ms=0, mergeable_poll_max_ms=0,
+    )
+    assert result["pr_url"].endswith("/99")
+    assert result["mergeable_state"] == "unknown"
+
+
+def test_unstable_settles_immediately(monkeypatch):
+    _ensure_token(monkeypatch)
+    _patch_externals(monkeypatch, mergeable_sequence=[
+        {"mergeable_state": "unstable"}])
+    result = op.open_pr(
+        repo="o/r", branch_name="claude/x", title="t", body="b",
+        files=[("a", "x")], mergeable_poll_retries=4,
+        mergeable_poll_base_ms=0,
+    )
+    assert result["mergeable_state"] == "unstable"
+    assert op._get_pull_request.call_count == 1
+
+
+def test_pr_create_failure_raises(monkeypatch):
+    _ensure_token(monkeypatch)
+    cb, pf, cpr = _patch_externals(monkeypatch, pr_create_raises=True)
+    try:
+        op.open_pr(repo="o/r", branch_name="claude/x",
+                   title="t", body="b", files=[("a", "x")])
+    except RuntimeError as e:
+        assert "PR exists" in str(e) or "create_pr" in str(e).lower()
+    else:
+        raise AssertionError("expected RuntimeError")
+    assert cb.call_count == 1
+    assert pf.call_count == 1
+    assert op._get_pull_request.call_count == 0
+
+
+def test_missing_token_raises_before_api(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    cb, pf, cpr = _patch_externals(monkeypatch)
+    # Replace _get_branch_head with the real one so the token check fires;
+    # patches above stub network functions but the actual auth check is in _gh_api.
+    # We bypass: just call _gh_api directly.
+    try:
+        op._gh_api("GET", "/repos/x/y")
+    except RuntimeError as e:
+        assert "GH_TOKEN" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on missing token")
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Two new skills, both built on `flowing`. They generalize patterns initially
scoped as Muninn-internal utilities (issues #619, #620) — the workflows
are general-purpose enough that elevating them lets non-Muninn users
benefit too.

### `opening-prs` — closes #620

github-procedures §6 ("create branch, push files, open PR, poll
mergeable_state") as a flowing DAG. The "NEVER push to main" rule is
structural:

- `validate=must_not_be_base_branch` rejects `branch_name in
  {main, master, trunk, production, prod}` (case-insensitive) or any
  value equal to the configured `base`. The body of `create_branch`
  never fires for an invalid name.
- `retry_until=lambda r: r["mergeable_state"] in SETTLED_STATES`
  replaces hand-rolled "wait a few seconds and check" prose.
  `unknown`/`null` keep polling; settled states (`clean`, `dirty`,
  `unstable`, `behind`, `blocked`) stop.
- Exhaustion is soft: PR exists, `mergeable_state` reflects last
  observed value.

### `closing-issues` — closes #619 (general pattern)

The §7 "close + capture LEARNING" pattern with a pluggable
`post_close_callback` for memory storage / tracker pings / webhook
emission. `validate=must_have_synthesis_text` blocks empty synthesis
upfront. Callback runs `detached=True` so its failure doesn't undo
the close — surfaces in `result["detached_failures"]`.

The Muninn-flavored `issue_close` (with hard-coded Turso memory store)
lives in muninn.austegard.com#124 and layers on top of this skill via
the callback hook.

## Why skills, not utilities

Both patterns are workflow encodings — the structural value (validate
gate, retry_until predicate, detached side-effect) is exactly what the
flowing skill exists to enable. Anyone using flowing in a container
benefits from these out of the box. The Muninn-specific bits
(particular endpoints, particular memory store) are layered on top in
the spoke repo, not baked into the skill.

## Test plan

- [x] `python3 -m pytest opening-prs/tests/ closing-issues/tests/` —
      15 tests, all passing
- [x] Topology: parallel layers, sequential deps, detached + when= gating
- [x] Negative paths: validate rejection (no API call), retry_until
      exhaustion preserves last state, detached failure isolation,
      missing token raises before any API call

Closes #619 #620.

Refs oaustegard/muninn.austegard.com#124 (Muninn-internal counterparts).
