### PR TITLE
remembering: pull canonical muninn_utils from public muninn-utilities repo

### DIFF
--- a/remembering/CHANGELOG.md
+++ b/remembering/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `remembering` skill (Muninn) are documented in this f
 
 ## [Unreleased]
 
+### Added
+
+- `fetch_muninn_utils()` in `scripts/utilities.py`. Pulls canonical
+  `muninn_utils/*.py` from `oaustegard/muninn-utilities` (public) via a
+  single tarball fetch and writes them into `UTIL_DIR`, overriding any
+  Turso `utility-code` materialization for utilities already migrated.
+  `boot()` calls it after `install_utilities()` — non-migrated utilities
+  continue to work via the Turso fallback. No auth required (public repo),
+  no-ops cleanly on network failure. Continues the migration tracked in
+  memory `0d63ed4f`.
+
 ### Fixed
 
 - `config_set` now preserves `boot_load` on update. Previously, every update silently re-promoted reference-only entries to boot-loaded because `INSERT OR REPLACE` omitted the `boot_load` column. This was particularly painful for auto-maintained keys like `recall-triggers` (rewritten on every `remember()` call).

--- a/remembering/SKILL.md
+++ b/remembering/SKILL.md
@@ -2,7 +2,7 @@
 name: remembering
 description: Advanced memory operations reference. Basic patterns (profile loading, simple recall/remember) are in project instructions. Consult this skill for background writes, memory versioning, complex queries, edge cases, session scoping, retention management, type-safe results, proactive memory hints, GitHub access detection, autonomous curation, episodic scoring, and decision traces.
 metadata:
-  version: 5.7.1
+  version: 5.8.0
 ---
 
 # Remembering - Advanced Operations

--- a/remembering/scripts/boot.py
+++ b/remembering/scripts/boot.py
@@ -27,7 +27,7 @@ from .state import get_session_id
 from .turso import _exec, _exec_batch
 from .memory import recall, recall_since, remember, supersede
 from .config import config_list, config_set, config_delete
-from .utilities import install_utilities
+from .utilities import UTIL_DIR, install_utilities, fetch_muninn_utils
 
 
 # --- Ops Topic Classification ---
@@ -669,6 +669,25 @@ def boot(mode: str = None, task: str = None, telemetry: bool = False) -> str:
     # Install utility code memories to disk
     installed_utils = install_utilities()
     _mark("utilities")
+
+    # Override Turso copies with canonical files from the public
+    # oaustegard/muninn-utilities repo for migrated utilities (memory
+    # 0d63ed4f). Best-effort — never blocks boot.
+    try:
+        repo_sync = fetch_muninn_utils()
+        for fname in repo_sync.get("fetched", []):
+            stem = fname[:-3] if fname.endswith(".py") else fname
+            if stem == "__init__":
+                continue
+            existing = installed_utils.get(stem) or {}
+            installed_utils[stem] = {
+                "path": os.path.join(UTIL_DIR, fname),
+                "use_when": existing.get("use_when"),
+                "source": "muninn-utilities",
+            }
+    except Exception:
+        pass  # Repo sync is best-effort; Turso materialization stands
+    _mark("muninn_utils_sync")
 
     # Surface incomplete cross-session tasks (#332)
     pending_tasks = _load_incomplete_tasks()

--- a/remembering/scripts/utilities.py
+++ b/remembering/scripts/utilities.py
@@ -1,10 +1,19 @@
+import io
 import os
 import re
 import sys
+import tarfile
+import urllib.request
 
 UTIL_DIR = os.environ.get("MUNINN_UTIL_DIR", os.path.join(os.path.expanduser("~"), "muninn_utils"))
 CODE_START = "<" + "<" + "<PYTHON>" + ">" + ">"
 CODE_END = "<" + "<" + "<END>" + ">" + ">"
+
+# muninn_utils source-of-truth has moved from Turso `utility-code` memories
+# to files in oaustegard/muninn-utilities (public). See memory `0d63ed4f`.
+MUNINN_UTILS_REPO = os.environ.get("MUNINN_UTILS_REPO", "oaustegard/muninn-utilities")
+MUNINN_UTILS_BRANCH = os.environ.get("MUNINN_UTILS_BRANCH", "main")
+MUNINN_UTILS_SUBDIR = "muninn_utils"
 
 # Valid utility names: alphanumeric, underscore, hyphen only
 _VALID_NAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*$')
@@ -64,3 +73,85 @@ def install_utilities() -> dict:
         installed[name] = {"path": file_path, "use_when": use_when}
 
     return installed
+
+
+# @lat: [[infrastructure#Utility Materialization]]
+def fetch_muninn_utils() -> dict:
+    """
+    Pull canonical muninn_utils/*.py from oaustegard/muninn-utilities over
+    the Turso materialization. Source-of-truth has moved from `utility-code`
+    memories to files in a dedicated public repo (per memory 0d63ed4f).
+
+    Runs after install_utilities() so disk files override Turso copies for
+    utilities already migrated. Non-migrated utilities continue to work via
+    the Turso fallback that install_utilities() produces.
+
+    Single tarball fetch from codeload.github.com — no auth required since
+    the repo is public. Skips tests/ subdir; only top-level *.py land in
+    UTIL_DIR.
+
+    Returns:
+        Dict with keys:
+        - fetched: list[str] — names of .py files written
+        - failed: list[str] — names that errored during write
+    """
+    result = {"fetched": [], "failed": []}
+
+    os.makedirs(UTIL_DIR, exist_ok=True)
+    init_path = os.path.join(UTIL_DIR, "__init__.py")
+    if not os.path.exists(init_path):
+        open(init_path, "w").close()
+
+    parent = os.path.dirname(UTIL_DIR)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+
+    url = f"https://codeload.github.com/{MUNINN_UTILS_REPO}/tar.gz/{MUNINN_UTILS_BRANCH}"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            raw = resp.read()
+    except Exception:
+        return result
+
+    util_realpath = os.path.realpath(UTIL_DIR) + os.sep
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tf:
+            for member in tf.getmembers():
+                if not member.isfile():
+                    continue
+                # Tarball paths look like: <repo>-<sha>/muninn_utils/<name>.py
+                # Skip nested dirs (tests/, etc.)
+                parts = member.name.split("/")
+                if len(parts) != 3 or parts[1] != MUNINN_UTILS_SUBDIR:
+                    continue
+                name = parts[2]
+                if not name.endswith(".py"):
+                    continue
+                stem = name[:-3]
+                # __init__.py is the one allowed exception to the name regex
+                if stem != "__init__" and not _VALID_NAME_RE.match(stem):
+                    continue
+
+                file_path = os.path.join(UTIL_DIR, name)
+                # Final guard: resolved path must be within UTIL_DIR
+                resolved = os.path.realpath(file_path)
+                if not resolved.startswith(util_realpath):
+                    result["failed"].append(name)
+                    continue
+
+                try:
+                    fileobj = tf.extractfile(member)
+                    if fileobj is None:
+                        result["failed"].append(name)
+                        continue
+                    content = fileobj.read().decode("utf-8")
+                    with open(file_path, "w") as f:
+                        f.write(content)
+                    result["fetched"].append(name)
+                except Exception:
+                    result["failed"].append(name)
+    except Exception:
+        return result
+
+    return result

--- a/remembering/tests/test_hardening.py
+++ b/remembering/tests/test_hardening.py
@@ -11,6 +11,7 @@ Validates both the vulnerability and the fix for each finding:
 7. JSON decode error handling in _exec/_exec_batch
 """
 
+import io
 import os
 import re
 import sys
@@ -110,6 +111,170 @@ def test_install_utilities_rejects_malicious_names():
                 utilities.UTIL_DIR = old_dir
 
     print("PASS: install_utilities rejects malicious names")
+
+
+# ── 1b. fetch_muninn_utils ──
+
+def _build_fake_tarball(files: dict, top_dir: str = "muninn-utilities-abc123"):
+    """Construct an in-memory tar.gz that mimics codeload.github.com output.
+
+    `files` maps relative paths (e.g. "muninn_utils/blog_publish.py") to bytes.
+    Returns the gzipped tar bytes, ready to feed urllib.request.urlopen mock.
+    """
+    import tarfile as _tarfile
+    buf = io.BytesIO()
+    with _tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for relpath, content in files.items():
+            data = content if isinstance(content, bytes) else content.encode("utf-8")
+            info = _tarfile.TarInfo(name=f"{top_dir}/{relpath}")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class _FakeUrlopen:
+    """Context-manager wrapper that yields a fake response with .read()."""
+    def __init__(self, data):
+        self._data = data
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return False
+    def read(self):
+        return self._data
+
+
+def test_fetch_muninn_utils_writes_files():
+    """Tarball with .py files at the muninn_utils/ root extracts to UTIL_DIR."""
+    import io as _io
+    from scripts import utilities
+
+    tarball = _build_fake_tarball({
+        "muninn_utils/blog_publish.py": b"# blog_publish source\n",
+        "muninn_utils/bsky_card.py": b"# bsky_card source\n",
+        "muninn_utils/__init__.py": b"",
+        "muninn_utils/tests/test_blog_publish_flow.py": b"# test - should NOT land",
+        "README.md": b"# repo readme - should NOT land",
+    })
+
+    with patch("scripts.utilities.urllib.request.urlopen",
+               return_value=_FakeUrlopen(tarball)):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir = utilities.UTIL_DIR
+            utilities.UTIL_DIR = tmpdir
+            try:
+                result = utilities.fetch_muninn_utils()
+                # All three top-level .py files are landed (incl. __init__.py)
+                assert sorted(result["fetched"]) == ["__init__.py", "blog_publish.py", "bsky_card.py"]
+                assert result["failed"] == []
+                with open(os.path.join(tmpdir, "blog_publish.py")) as fh:
+                    assert fh.read() == "# blog_publish source\n"
+                with open(os.path.join(tmpdir, "bsky_card.py")) as fh:
+                    assert fh.read() == "# bsky_card source\n"
+                # tests/ subdir shouldn't have leaked into UTIL_DIR
+                assert not os.path.exists(os.path.join(tmpdir, "tests"))
+                assert not os.path.exists(os.path.join(tmpdir, "test_blog_publish_flow.py"))
+                assert not os.path.exists(os.path.join(tmpdir, "README.md"))
+            finally:
+                utilities.UTIL_DIR = old_dir
+
+    print("PASS: fetch_muninn_utils writes top-level .py files only")
+
+
+def test_fetch_muninn_utils_rejects_malicious_names():
+    """Skips entries whose stem fails the same name validation as install_utilities."""
+    from scripts import utilities
+
+    tarball = _build_fake_tarball({
+        "muninn_utils/.hidden.py": b"# starts with dot - reject",
+        "muninn_utils/good_one.py": b"# good\n",
+    })
+
+    with patch("scripts.utilities.urllib.request.urlopen",
+               return_value=_FakeUrlopen(tarball)):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir = utilities.UTIL_DIR
+            utilities.UTIL_DIR = tmpdir
+            try:
+                result = utilities.fetch_muninn_utils()
+                assert "good_one.py" in result["fetched"]
+                assert ".hidden.py" not in result["fetched"]
+                # Nothing escaped tmpdir
+                for root, dirs, files in os.walk(tmpdir):
+                    for f in files:
+                        path = os.path.join(root, f)
+                        assert os.path.realpath(path).startswith(os.path.realpath(tmpdir))
+            finally:
+                utilities.UTIL_DIR = old_dir
+
+    print("PASS: fetch_muninn_utils rejects malicious names")
+
+
+def test_fetch_muninn_utils_network_failure_is_safe():
+    """Network errors return cleanly without raising."""
+    from scripts import utilities
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated network failure")
+
+    with patch("scripts.utilities.urllib.request.urlopen", side_effect=boom):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir = utilities.UTIL_DIR
+            utilities.UTIL_DIR = tmpdir
+            try:
+                result = utilities.fetch_muninn_utils()
+                assert result == {"fetched": [], "failed": []}
+            finally:
+                utilities.UTIL_DIR = old_dir
+
+    print("PASS: fetch_muninn_utils handles network failure")
+
+
+def test_fetch_muninn_utils_corrupt_tarball_is_safe():
+    """A non-tarball response returns cleanly without raising."""
+    from scripts import utilities
+
+    with patch("scripts.utilities.urllib.request.urlopen",
+               return_value=_FakeUrlopen(b"not a tarball")):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir = utilities.UTIL_DIR
+            utilities.UTIL_DIR = tmpdir
+            try:
+                result = utilities.fetch_muninn_utils()
+                assert result == {"fetched": [], "failed": []}
+            finally:
+                utilities.UTIL_DIR = old_dir
+
+    print("PASS: fetch_muninn_utils handles corrupt tarball")
+
+
+def test_fetch_muninn_utils_skips_non_py_and_subdirs():
+    """Skips non-.py files at root, and skips files in subdirs (tests/)."""
+    from scripts import utilities
+
+    tarball = _build_fake_tarball({
+        "muninn_utils/legit.py": b"# legit\n",
+        "muninn_utils/README.md": b"# wrong extension",
+        "muninn_utils/tests/inner.py": b"# in subdir - skip",
+        "other_dir/something.py": b"# wrong subdir",
+    })
+
+    with patch("scripts.utilities.urllib.request.urlopen",
+               return_value=_FakeUrlopen(tarball)):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir = utilities.UTIL_DIR
+            utilities.UTIL_DIR = tmpdir
+            try:
+                result = utilities.fetch_muninn_utils()
+                assert result["fetched"] == ["legit.py"]
+                assert os.path.exists(os.path.join(tmpdir, "legit.py"))
+                assert not os.path.exists(os.path.join(tmpdir, "README.md"))
+                assert not os.path.exists(os.path.join(tmpdir, "inner.py"))
+                assert not os.path.exists(os.path.join(tmpdir, "something.py"))
+            finally:
+                utilities.UTIL_DIR = old_dir
+
+    print("PASS: fetch_muninn_utils skips non-.py and subdir files")
 
 
 # ── 2. LIKE wildcard injection ──
@@ -581,6 +746,12 @@ if __name__ == "__main__":
         test_path_traversal_name_rejected,
         test_path_traversal_realpath_guard,
         test_install_utilities_rejects_malicious_names,
+        # 1b. fetch_muninn_utils
+        test_fetch_muninn_utils_writes_files,
+        test_fetch_muninn_utils_rejects_malicious_names,
+        test_fetch_muninn_utils_network_failure_is_safe,
+        test_fetch_muninn_utils_corrupt_tarball_is_safe,
+        test_fetch_muninn_utils_skips_non_py_and_subdirs,
         # 2. LIKE wildcards
         test_escape_like,
         test_like_escape_in_fts5_search,


### PR DESCRIPTION
## Why

Continues the migration tracked in memory `0d63ed4f`: muninn_utils source-of-truth moved from Turso `utility-code` memories to files. The first three (`blog_publish`, `bsky_card`, `issue_close`) initially landed in [`mac`](https://github.com/oaustegard/muninn.austegard.com) via mac PR #124 and have now moved to a dedicated public repo: [`oaustegard/muninn-utilities`](https://github.com/oaustegard/muninn-utilities).

Why a dedicated repo (not mac, not claude-skills): mac is a website (blog/perch/feeds), different domain & lifecycle from infra code. claude-skills is a general skill library — Muninn-flavored utilities aren't general. A public dedicated repo gives muninn_utils its own home with no `GH_TOKEN` requirement at boot.

This is the **Claude.ai-side** complement to [claude-workspace#55](https://github.com/oaustegard/claude-workspace/pull/55). That one only runs in Claude Code on the Web shell sessions; this one runs whenever `boot()` is called — including pure Claude.ai sessions where no shell hook exists.

## What

`fetch_muninn_utils()` in `scripts/utilities.py`:

1. Single tarball fetch from `codeload.github.com/oaustegard/muninn-utilities/tar.gz/main` — no auth required (public repo)
2. Extracts only top-level `*.py` files at `muninn_utils/` root; skips `tests/` subdir
3. Same name validation as `install_utilities()` — `_VALID_NAME_RE` + realpath guard (`__init__.py` is the one allowed exception)
4. Returns cleanly on network failure or corrupt tarball

`boot()` calls it after `install_utilities()` so disk files override Turso materialization for migrated utilities. Non-migrated utilities (`bsky_limit`, `perch_publish`, `verify_patch`, `remind`, `perch_triage`, `memory_tfidf`, `whtwnd`, `function_name`) keep working via the Turso fallback.

## Test plan

- [x] 5 new test cases in `test_hardening.py` (happy path, malicious-name rejection, network failure, corrupt tarball, subdir filtering)
- [x] All 30 hardening tests pass
- [x] **Live integration**: ran `fetch_muninn_utils()` against the real `oaustegard/muninn-utilities` repo — fetched `__init__.py`, `blog_publish.py`, `bsky_card.py`, `issue_close.py`
- [ ] Pre-existing unrelated failure in `test_remembering.py::test_imports` (TYPES set mismatch — codebase has 7, test expects 6); not addressed in this PR

## Version

Bump 5.7.1 → 5.8.0 (minor, additive feature).

## Follow-ups

- Migrate the remaining 8 utilities (`bsky_limit`, `perch_publish`, `verify_patch`, `remind`, `perch_triage`, `memory_tfidf`, `whtwnd`, `function_name`) into `muninn-utilities/muninn_utils/`
- A separate PR on `oaustegard/muninn.austegard.com` will remove `muninn_utils/` from mac (since it now lives in muninn-utilities)
- Once disk-loading is verified stable, supersede or delete the Turso `utility-code` memories for migrated utilities

Refs `oaustegard/muninn-utilities`, `oaustegard/muninn.austegard.com#124`, `oaustegard/claude-workspace#55`.