### PR TITLE
Add scheduled sync of remembering/ from muninn-utilities

### DIFF
--- a/.github/workflows/sync-remembering-from-muninn-utilities.yml
+++ b/.github/workflows/sync-remembering-from-muninn-utilities.yml
@@ -1,0 +1,68 @@
+name: Sync remembering from muninn-utilities
+
+# Source-of-truth for the `remembering` skill is now
+# oaustegard/muninn-utilities. This repo holds a deprecated mirror,
+# kept fresh by this workflow so the marketplace listing keeps
+# working for anyone who installed the skill directly from here.
+#
+# This is a same-repo write — uses the default GITHUB_TOKEN, no
+# extra secrets required. Mirrors mac/.github/workflows/update-remembering.yml
+# in shape (it pulls from claude-skills into mac the same way).
+
+on:
+  schedule:
+    - cron: '17 5 * * *'   # daily at 05:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull latest remembering/ from muninn-utilities
+        run: |
+          rm -rf remembering
+          mkdir -p remembering
+          curl -sfL "https://codeload.github.com/oaustegard/muninn-utilities/tar.gz/main" \
+            | tar -xz --strip-components=2 -C remembering \
+              "muninn-utilities-main/remembering"
+          echo "Pulled:"
+          find remembering -maxdepth 2 -type f | sort | head -20
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "remembering already in sync with muninn-utilities"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            git diff --stat
+          fi
+
+      - name: Open PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="auto/sync-remembering-$(date +%Y%m%d-%H%M)"
+          git checkout -b "$BRANCH"
+          git add remembering/
+          git commit -m "chore: sync vendored remembering from muninn-utilities"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: sync vendored remembering from muninn-utilities" \
+            --body "Automated daily sync of \`remembering/\` from [oaustegard/muninn-utilities](https://github.com/oaustegard/muninn-utilities/tree/main/remembering). Source-of-truth for the memory system has moved there; this repo holds a deprecated mirror." \
+            --base main \
+            --head "$BRANCH"
+
+      - name: No changes
+        if: steps.changes.outputs.changed == 'false'
+        run: echo "remembering is already up to date"


### PR DESCRIPTION
## Why

Source-of-truth for the `remembering` skill has moved to [`oaustegard/muninn-utilities`](https://github.com/oaustegard/muninn-utilities) (see [#625](https://github.com/oaustegard/claude-skills/pull/625) and [muninn-utilities#1](https://github.com/oaustegard/muninn-utilities/pull/1) for the architectural pivot). This repo now holds a deprecated mirror — kept fresh so the marketplace listing keeps working for anyone who installed the skill directly from here.

## What

`.github/workflows/sync-remembering-from-muninn-utilities.yml`: pulls `remembering/` from public `muninn-utilities` via `codeload.github.com`, replaces the local copy, and opens a PR if anything changed.

- **Schedule**: daily at 05:17 UTC + `workflow_dispatch` for manual runs
- **Auth**: default `GITHUB_TOKEN` only — same-repo write, no cross-repo secrets needed
- **Pattern**: mirrors `mac/.github/workflows/update-remembering.yml` which historically pulled the other direction (this repo → mac)

## Why pull (here) vs. push (from muninn-utilities)

First draft put the workflow in muninn-utilities pushing here, which would have required a PAT secret on muninn-utilities with `repo` scope here. Inverting the trigger keeps the writer same-repo with the resource, so `GITHUB_TOKEN` is sufficient.

The tradeoff is sync delay: pushed sync would be near-instant on muninn-utilities `main` updates; this version is at most ~24h stale. Acceptable for a deprecated mirror.

## Verification

After merge, trigger the first run manually via the Actions tab → "Sync remembering from muninn-utilities" → Run workflow. If muninn-utilities has any newer content than what this repo currently ships, a PR opens automatically. If not, the run logs `remembering is already up to date`.