### PR TITLE
fix(flowing): unbreak SKILL.md frontmatter, bump 1.2.1

### DIFF
--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: flowing
-description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also: parallel execution, checkpoint resume, detached side-effects.
+description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also covers parallel execution, checkpoint resume, detached side-effects.
 metadata:
-  version: 1.2.0
+  version: 1.2.1
 ---
 
 # Flowing — Control Flow in Code, Not Prose


### PR DESCRIPTION
## What

Two-line change to `flowing/SKILL.md`:

1. `Also: parallel execution...` → `Also covers parallel execution...`
2. `metadata.version: 1.2.0` → `1.2.1`

## Why

The flowing release workflow has silently failed for three consecutive versions (v1.1, v1.1.1, v1.2.0). Each time the post-merge run reports `No skills to release` and exits clean, even though `flowing/SKILL.md` is in the diff and `metadata.version` differs from the prior commit.

**Root cause:** the description contains `Also:` mid-sentence. YAML's scanner reads `Also:` as the start of a mapping value, hits the rest of the description, and raises `ScannerError: mapping values are not allowed here` at column 317. Both `.github/scripts/extract-version.py` and `.github/scripts/detect-version-changes.py` wrap their parse in `except Exception: pass`, so the error vanishes — the functions return `None`, `None != None` is `False`, and flowing is excluded from the release set.

`workflow_dispatch` on `flowing` fails the same way (`Error: No version found in flowing`, run [25572849679](https://github.com/oaustegard/claude-skills/actions/runs/25572849679)). A bare version bump wouldn't help — the YAML parse fails at 1.2.1 just like at 1.2.0. The description must be repaired.

## Effect

After merge, the next push-to-main workflow run should see `flowing/SKILL.md` changed, version `1.2.0 → 1.2.1`, and emit `flowing-v1.2.1` with the detached auto-discovery feature from #613 included.

## Follow-up (separate issue, not this PR)

`extract-version.py` and `detect-version-changes.py` shouldn't silently swallow YAML errors. A `print(..., file=sys.stderr); raise` in those `except Exception` blocks would have surfaced this in the first failed run instead of eating three releases.