### PR TITLE
fix(release-scripts): surface YAML parse errors instead of swallowing

### DIFF
--- a/.github/scripts/detect-version-changes.py
+++ b/.github/scripts/detect-version-changes.py
@@ -48,8 +48,8 @@ def extract_version_from_commit(skill_md_path: str, commit: str) -> str | None:
                 if isinstance(frontmatter, dict):
                     if "metadata" in frontmatter and "version" in frontmatter["metadata"]:
                         return frontmatter["metadata"]["version"]
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"WARNING: YAML parse error in {skill_md_path} at {commit}: {e}", file=sys.stderr)
 
     return None
 

--- a/.github/scripts/extract-version.py
+++ b/.github/scripts/extract-version.py
@@ -45,8 +45,9 @@ def extract_version(skill_dir: Path) -> str:
                     if isinstance(frontmatter, dict):
                         if "metadata" in frontmatter and "version" in frontmatter["metadata"]:
                             return frontmatter["metadata"]["version"]
-        except Exception:
-            pass  # Fall through to VERSION file
+        except Exception as e:
+            print(f"WARNING: YAML parse error in {skill_md}: {e}", file=sys.stderr)
+            # Fall through to VERSION file
 
     # Fall back to VERSION file (backward compatibility)
     version_file = skill_dir / "VERSION"


### PR DESCRIPTION
Closes #628.

Both `extract-version.py` and `detect-version-changes.py` had `except Exception: pass` around `yaml.safe_load`. When SKILL.md frontmatter failed to parse, the error vanished — three flowing releases were lost silently as a result (#627 has the trace).

Two-line change in each: print the exception to stderr before falling through. Same control flow otherwise — `extract-version.py` still falls through to the VERSION file, `detect-version-changes.py` still returns `None`. The only difference is the failure now leaves a breadcrumb in the workflow log.