### PR TITLE
flowing v1.3.0: enforce timeout_s, validate signatures, prune dead code

### DIFF
--- a/flowing/CHANGELOG.md
+++ b/flowing/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `flowing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3.0] - 2026-05-14
+
+### Added
+
+- **`timeout_s` is now enforced.** It was declared on `TaskDef` and accepted by `@task` but never read — the body ran unbounded. A task with `timeout_s` set now runs in a one-shot worker; overrunning the limit aborts the attempt as a retryable `TimeoutError` that consumes the `retry=` budget. Python can't kill the orphaned thread, so it runs until the container exits (acceptable for run-once use).
+- **Graph-build-time signature validation.** `flow.run()` now checks that every task body has a parameter for each of its dependencies (or `**kwargs`). A mismatch raises a clear `ValueError` naming both tasks, instead of failing mid-run with a confusing `TypeError`.
+- **`clear_registry()`** — module-level helper to empty `_TASK_REGISTRY`. Lets tests and long-lived REPLs run independent flows without stale detached tasks leaking across them via auto-discovery.
+- 8 new tests (timeout enforcement + retry interaction, signature validation, registry clearing). Suite now 28 tests.
+
+### Fixed
+
+- **`fail_fast` parallel cancellation** now uses `pool.shutdown(wait=False, cancel_futures=True)`, which cancels queued-but-unstarted siblings. Siblings already running still can't be killed; the guarantee is "the next layer won't start," now stated explicitly in code and SKILL.md.
+- **`summary()` was O(n²)** — it rebuilt the task-def set on every row. Built once now, and it also picks up auto-discovered detached tasks that the old terminal-only walk missed.
+
+### Removed
+
+- Dead `traceback` import and unused `functools.wraps` import.
+- `StepState.PENDING`, `RUNNING`, `RETRYING` — defined but never assignable, since `_run_step` is synchronous and only ever returns a terminal state.
+- Dead `_topo_sort()` function — superseded by `Flow._build_layers` and never called.
+- `Flow._all_task_defs()` — folded into `summary()`'s single call to `_collect_tasks()`.
+
 ## [1.2.1] - 2026-05-08
 
 ### Other

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -2,7 +2,7 @@
 name: flowing
 description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also covers parallel execution, checkpoint resume, detached side-effects.
 metadata:
-  version: 1.2.1
+  version: 1.3.0
 ---
 
 # Flowing — Control Flow in Code, Not Prose
@@ -129,6 +129,17 @@ def my_step(other_task):
     return result
 ```
 
+`timeout_s` (v1.3): if set, the body runs in a one-shot worker and a call that
+overruns is aborted as a retryable `TimeoutError` — it consumes the `retry=`
+budget like any other failure. Python can't kill the orphaned thread, so it
+keeps running until the container exits; fine for run-once ephemeral use, not a
+hard cancel.
+
+A task body receives each dependency as a kwarg named after the dependency's
+TaskDef name. As of v1.3 a mismatch (the body has no parameter of that name and
+no `**kwargs`) is caught at `flow.run()` with a clear `ValueError` instead of a
+confusing mid-run `TypeError`.
+
 ### `Flow` class
 
 ```python
@@ -137,6 +148,15 @@ results = flow.run()
 flow.summary()
 flow.value(some_task)
 ```
+
+`fail_fast` stops the *next* layer from starting once a task in the current
+layer fails; siblings already running in parallel can't be killed and run to
+completion on their pool threads.
+
+`clear_registry()` (module-level function) empties the registry that `@task`
+appends to. For run-once container use you never need it; call it between
+independent flows in the same process (tests, REPLs) so detached
+auto-discovery can't pull a stale task into an unrelated graph.
 
 ### Resume from failure
 

--- a/flowing/scripts/flowing.py
+++ b/flowing/scripts/flowing.py
@@ -35,22 +35,25 @@ Detached side-effects:
 
 from __future__ import annotations
 
+import inspect
 import sys
 import time
-import traceback
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    TimeoutError as FuturesTimeoutError,
+    as_completed,
+)
 from dataclasses import dataclass, field
 from enum import Enum
-from functools import wraps
 from typing import Any, Callable, Optional
 
 
 class StepState(Enum):
-    PENDING = "pending"
-    RUNNING = "running"
+    # _run_step is synchronous and only ever returns a terminal state, so
+    # PENDING/RUNNING/RETRYING would never be observable — they are omitted
+    # rather than defined-but-never-assigned.
     SUCCEEDED = "succeeded"
     FAILED = "failed"
-    RETRYING = "retrying"
     SKIPPED = "skipped"
 
 
@@ -98,6 +101,17 @@ class TaskDef:
 _TASK_REGISTRY: list[TaskDef] = []
 
 
+def clear_registry() -> None:
+    """Empty the module-level task registry.
+
+    The registry accumulates every TaskDef created via @task for the life of
+    the process. For run-once container use that is fine. Call this between
+    independent flows in the same process (tests, REPLs) so detached
+    auto-discovery can't pull a stale task into an unrelated graph.
+    """
+    _TASK_REGISTRY.clear()
+
+
 # @lat: [[orchestration#DAG Workflow Runner]]
 def task(
     fn: Optional[Callable] = None,
@@ -133,45 +147,6 @@ def task(
     if fn is not None:
         return wrap(fn)
     return wrap
-
-
-def _topo_sort(terminal: TaskDef) -> list[list[TaskDef]]:
-    all_tasks: set[TaskDef] = set()
-    stack = [terminal]
-    while stack:
-        t = stack.pop()
-        if t not in all_tasks:
-            all_tasks.add(t)
-            stack.extend(t.depends_on)
-
-    in_degree: dict[TaskDef, int] = {t: 0 for t in all_tasks}
-    dependents: dict[TaskDef, list[TaskDef]] = {t: [] for t in all_tasks}
-    for t in all_tasks:
-        for dep in t.depends_on:
-            in_degree[t] += 1
-            dependents[dep].append(t)
-
-    layers: list[list[TaskDef]] = []
-    current = [t for t, d in in_degree.items() if d == 0]
-    visited = 0
-
-    while current:
-        layers.append(current)
-        visited += len(current)
-        next_layer = []
-        for t in current:
-            for dep in dependents[t]:
-                in_degree[dep] -= 1
-                if in_degree[dep] == 0:
-                    next_layer.append(dep)
-        current = next_layer
-
-    if visited != len(all_tasks):
-        raise ValueError(
-            f"Cycle detected in task graph. "
-            f"Visited {visited}/{len(all_tasks)} tasks."
-        )
-    return layers
 
 
 def _log(msg: str, **kw):
@@ -219,7 +194,24 @@ def _run_step(td: TaskDef, results: dict[str, StepResult]) -> StepResult:
 
         t0 = time.monotonic()
         try:
-            value = td.fn(**kwargs)
+            if td.timeout_s is not None:
+                # Run the body in a one-shot worker so a hung call can't stall
+                # the whole flow. Python can't kill a running thread, so on
+                # timeout the orphaned worker keeps going until the container
+                # exits — acceptable for run-once ephemeral use. shutdown is
+                # wait=False precisely so we don't re-block on that orphan.
+                one_shot = ThreadPoolExecutor(max_workers=1)
+                fut = one_shot.submit(td.fn, **kwargs)
+                try:
+                    value = fut.result(timeout=td.timeout_s)
+                except FuturesTimeoutError:
+                    raise TimeoutError(
+                        f"{td.name} exceeded timeout_s={td.timeout_s}"
+                    ) from None
+                finally:
+                    one_shot.shutdown(wait=False)
+            else:
+                value = td.fn(**kwargs)
             last_dur = (time.monotonic() - t0) * 1000
 
             # GATE 3: retry_until() — predicate-driven loop. True -> done; False -> retry (consumes retry budget).
@@ -348,6 +340,38 @@ class Flow:
             raise ValueError("Cycle detected in task graph")
         return layers
 
+    def _validate_signatures(self, tasks: set[TaskDef]) -> None:
+        """Fail at graph-build time if a task body can't receive a dep by name.
+
+        Deps are passed to the body as kwargs keyed by the producer's TaskDef
+        name. If the consumer's signature has no matching parameter (and no
+        **kwargs), the run would otherwise die mid-flight with a confusing
+        TypeError. Catch it here with a message that names both ends.
+        """
+        for t in tasks:
+            if not t.depends_on:
+                continue
+            try:
+                params = inspect.signature(t.fn).parameters
+            except (ValueError, TypeError):
+                continue  # builtins / C functions — can't introspect, skip
+            if any(p.kind == inspect.Parameter.VAR_KEYWORD
+                   for p in params.values()):
+                continue  # **kwargs absorbs anything
+            accepted = {
+                name for name, p in params.items()
+                if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                              inspect.Parameter.KEYWORD_ONLY)
+            }
+            for dep in t.depends_on:
+                if dep.name not in accepted:
+                    raise ValueError(
+                        f"Task '{t.name}' depends on '{dep.name}', but its "
+                        f"function has no parameter named '{dep.name}'. "
+                        f"Rename the parameter to match, add **kwargs, or set "
+                        f"@task(name=...) on the dependency."
+                    )
+
     def _execute(self, layers: list[list[TaskDef]], skip_succeeded: bool = False) -> None:
         """Execute layers. If skip_succeeded=True, skip tasks already SUCCEEDED in self.results."""
         for layer_idx, layer in enumerate(layers):
@@ -375,8 +399,11 @@ class Flow:
                         self.results[result.name] = result
                         if self.fail_fast and result.state == StepState.FAILED:
                             _log(f"FAIL_FAST triggered by {result.name}")
-                            for f in futures:
-                                f.cancel()
+                            # Cancels queued-but-unstarted siblings. Siblings
+                            # already running can't be killed — they finish on
+                            # their pool threads — but fail_fast's real job is
+                            # done: the next layer won't start.
+                            pool.shutdown(wait=False, cancel_futures=True)
                             break
             else:
                 for td in layer:
@@ -450,6 +477,7 @@ class Flow:
         self.detached_failures = []
 
         main_tasks, detached_tasks = self._collect_tasks()
+        self._validate_signatures(main_tasks | detached_tasks)
         main_layers = self._build_layers(main_tasks)
 
         total_tasks = sum(len(l) for l in main_layers) + len(detached_tasks)
@@ -476,7 +504,7 @@ class Flow:
 
     def resume(self) -> dict[str, StepResult]:
         """Re-run from failure point. SUCCEEDED tasks keep their cached values.
-        FAILED and SKIPPED tasks reset to PENDING and re-execute."""
+        FAILED and SKIPPED tasks are cleared from results and re-execute."""
         self.detached_failures = []
 
         # Reset FAILED and SKIPPED tasks
@@ -525,26 +553,16 @@ class Flow:
         return r.value
 
     def summary(self) -> str:
+        # Build the detached-name set once — including auto-discovered
+        # detached tasks, which a terminal-only walk would miss.
+        _, detached_tasks = self._collect_tasks()
+        detached_names = {t.name for t in detached_tasks}
         lines = []
         for name, r in self.results.items():
             status = r.state.value.upper()
             dur = f"{r.duration_ms:.0f}ms"
             att = f"x{r.attempts}" if r.attempts > 1 else ""
             err = f" err={r.error}" if r.error else ""
-            det = " [detached]" if any(
-                t.name == name and t.detached
-                for t in self._all_task_defs()
-            ) else ""
+            det = " [detached]" if name in detached_names else ""
             lines.append(f"  {status:9s} {name} ({dur}{att}){det}{err}")
         return "\n".join(lines)
-
-    def _all_task_defs(self) -> set[TaskDef]:
-        """Collect all TaskDef objects in the graph."""
-        all_tasks: set[TaskDef] = set()
-        stack = list(self.terminals)
-        while stack:
-            t = stack.pop()
-            if t not in all_tasks:
-                all_tasks.add(t)
-                stack.extend(t.depends_on)
-        return all_tasks

--- a/flowing/tests/test_flowing.py
+++ b/flowing/tests/test_flowing.py
@@ -1,4 +1,4 @@
-"""Tests for flowing v1.1 control-flow primitives.
+"""Tests for flowing control-flow primitives.
 
 Coverage:
 - v1.0 backward compat (existing DAG, retry, override, resume, detached)
@@ -6,15 +6,17 @@ Coverage:
 - v1.1: validate= edge contract
 - v1.1: retry_until= predicate loop
 - Composition of new primitives
+- v1.3: timeout_s enforcement, signature validation, clear_registry
 """
 
 import sys
 import os
+import time
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-from flowing import task, Flow, StepState  # noqa: E402
+from flowing import task, Flow, StepState, clear_registry  # noqa: E402
 
 
 class TestBackwardCompat(unittest.TestCase):
@@ -411,6 +413,126 @@ class TestDetachedAutoDiscovery(unittest.TestCase):
         self.assertEqual(results["flaky_side"].state, StepState.FAILED)
         self.assertEqual(len(flow.detached_failures), 1)
         self.assertEqual(flow.detached_failures[0].name, "flaky_side")
+
+
+class TestTimeout(unittest.TestCase):
+    """timeout_s aborts a hung body and is retryable (v1.3)."""
+
+    def test_timeout_fails_slow_task(self):
+        @task(timeout_s=0.05)
+        def slow():
+            time.sleep(0.5)
+            return "done"
+
+        flow = Flow(slow, fail_fast=False)
+        flow.run()
+        r = flow.results["slow"]
+        self.assertEqual(r.state, StepState.FAILED)
+        self.assertIsInstance(r.error, TimeoutError)
+
+    def test_timeout_consumes_retry_then_succeeds(self):
+        calls = {"n": 0}
+
+        @task(timeout_s=0.05, retry=2, retry_backoff_base_ms=1)
+        def sometimes_slow():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                time.sleep(0.5)  # first attempt times out
+            return calls["n"]
+
+        flow = Flow(sometimes_slow)
+        flow.run()
+        self.assertEqual(flow.results["sometimes_slow"].state, StepState.SUCCEEDED)
+        self.assertEqual(flow.value(sometimes_slow), 2)
+
+    def test_no_timeout_runs_normally(self):
+        @task
+        def quick():
+            return "ok"
+
+        flow = Flow(quick)
+        flow.run()
+        self.assertEqual(flow.value(quick), "ok")
+
+
+class TestSignatureValidation(unittest.TestCase):
+    """Mismatched dep/parameter names are caught at graph-build time (v1.3)."""
+
+    def test_mismatched_param_raises(self):
+        @task
+        def producer():
+            return 1
+
+        @task(depends_on=[producer])
+        def consumer(wrong_name):
+            return wrong_name + 1
+
+        flow = Flow(consumer)
+        with self.assertRaises(ValueError) as ctx:
+            flow.run()
+        msg = str(ctx.exception)
+        self.assertIn("producer", msg)
+        self.assertIn("consumer", msg)
+
+    def test_kwargs_absorbs_any_dep(self):
+        @task
+        def producer():
+            return 7
+
+        @task(depends_on=[producer])
+        def consumer(**kwargs):
+            return kwargs["producer"]
+
+        flow = Flow(consumer)
+        flow.run()
+        self.assertEqual(flow.value(consumer), 7)
+
+    def test_name_override_matches_param(self):
+        @task(name="aliased")
+        def producer():
+            return 3
+
+        @task(depends_on=[producer])
+        def consumer(aliased):
+            return aliased * 2
+
+        flow = Flow(consumer)
+        flow.run()
+        self.assertEqual(flow.value(consumer), 6)
+
+
+class TestClearRegistry(unittest.TestCase):
+    """clear_registry empties the module-level task registry (v1.3)."""
+
+    def test_clear_registry_drops_detached_candidates(self):
+        side_effects = []
+
+        @task
+        def shared():
+            return 1
+
+        @task(depends_on=[shared], detached=True)
+        def stale_side(shared):
+            side_effects.append("ran")
+
+        # Without clearing, stale_side would auto-discover onto any later
+        # flow built on `shared`. Clear it first.
+        clear_registry()
+
+        flow = Flow(shared)
+        results = flow.run()
+        self.assertEqual(results["shared"].state, StepState.SUCCEEDED)
+        self.assertNotIn("stale_side", results)
+        self.assertEqual(side_effects, [])
+
+    def test_registry_empty_after_clear(self):
+        @task
+        def throwaway():
+            return None
+
+        clear_registry()
+        from flowing import _TASK_REGISTRY
+        self.assertEqual(_TASK_REGISTRY, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A comparison of `flowing` against Prefect surfaced a set of defects — places where the API surface promised behavior the implementation didn't deliver, plus dead code. Fixes are scoped to flowing's declared purpose (a run-once DAG in an ephemeral container), **not** parity with an orchestration platform.

### Defects fixed

- **`timeout_s` was dead.** Declared on `TaskDef`, accepted by `@task`, never referenced in `_run_step` — the body ran unbounded. Now: a task with `timeout_s` set runs in a one-shot worker; overrunning the limit aborts the attempt as a retryable `TimeoutError` that consumes the `retry=` budget. Python can't kill the orphaned thread, so it runs until the container exits — acceptable for run-once use, and documented as such.
- **`fail_fast` parallel cancellation was cosmetic.** `for f in futures: f.cancel()` couldn't stop already-running siblings. Now uses `pool.shutdown(wait=False, cancel_futures=True)`; the real guarantee ("the next layer won't start") is stated explicitly in code and SKILL.md.
- **`summary()` was O(n²)** — rebuilt the task-def set per row. Built once now, and it also picks up auto-discovered detached tasks the old terminal-only walk missed.
- **Name-coupling footgun.** A task body's parameter must match its dependency's TaskDef name; a mismatch previously failed mid-run with a confusing `TypeError`. `flow.run()` now validates signatures at graph-build time and raises a clear `ValueError` naming both ends.
- **`_TASK_REGISTRY` footgun.** New `clear_registry()` helper lets tests/REPLs run independent flows without stale detached tasks leaking across them via auto-discovery.

### Dead code removed

- `traceback` and unused `functools.wraps` imports
- `StepState.PENDING`, `RUNNING`, `RETRYING` — never assignable (`_run_step` is synchronous, only returns terminal states)
- `_topo_sort()` — superseded by `Flow._build_layers`, never called
- `Flow._all_task_defs()` — folded into `summary()`

## Test plan

- [x] All 20 pre-existing tests pass unchanged
- [x] 8 new tests added (timeout enforcement + retry interaction, signature validation, `clear_registry`) — suite now 28, all green
- [x] `python3 -m unittest tests.test_flowing`
- [x] `@lat:` backlinks preserved; lat.md `orchestration.md` wiki links all still resolve

https://claude.ai/code/session_01YExnPSJKxrKXEDqBn1Vucc