### PR TITLE
flowing v1.3.2: add human-facing README.md

### DIFF
--- a/flowing/CHANGELOG.md
+++ b/flowing/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `flowing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3.2] - 2026-05-14
+
+### Added
+
+- **`README.md`** — human-facing overview for browsing the skill on GitHub, missing until now. Frames the problem (prose imperatives get generated past; a `@task` graph is structural), summarizes the three control-flow primitives, maps the file layout by audience, and points to sibling orchestration skills. Complements `SKILL.md` (agent instructions) and `references/reference.md` (agent reference).
+
 ## [1.3.1] - 2026-05-14
 
 ### Other

--- a/flowing/README.md
+++ b/flowing/README.md
@@ -1,0 +1,68 @@
+# flowing
+
+A lightweight DAG workflow runner for Claude's ephemeral containers. Declare steps, wire dependencies, run once — control flow lives in code, not in prose imperatives.
+
+## The problem it solves
+
+Multi-step procedures are usually written as prose: *"first fetch X, then validate Y, then if Z retry up to 3 times, otherwise skip ahead."* An LLM reads and **generates past** prose like that — the gate is a suggestion, not a wall. Skipped validation, retries that never happen, branches taken on stale state.
+
+A `@task` graph is **structural** instead. A step physically cannot run until its inputs are bound to its parameters. A gate that fires on missing or bad input can't be stepped over. The runner owns branching, retrying, validating, failure propagation, and parallelism; the LLM only supplies judgment at the leaves.
+
+```python
+from flowing import task, Flow
+
+@task
+def fetch_data():
+    return {"items": [1, 2, 3]}
+
+@task(depends_on=[fetch_data])
+def process(fetch_data):          # param name matches the dep's name
+    return sum(fetch_data["items"])
+
+@task(depends_on=[process])
+def store(process):
+    print(f"Result: {process}")
+
+Flow(store).run()                 # topo-sorts into layers, parallel within a layer
+```
+
+## Control-flow primitives
+
+The distinctive part — branches and contracts as graph structure, not `if` statements buried in task bodies.
+
+| Primitive | What it does | Use for |
+|---|---|---|
+| `when=` | Predicate over dep values; falsy → task SKIPPED, skip cascades to dependents | Branch selection in the topology |
+| `validate=` | Checks dep values before the body runs; raise → FAILED with **no retry** | Enforceable input contracts between steps |
+| `retry_until=` | Predicate over the return value; falsy → retry, consuming the `retry=` budget | Self-correcting LLM steps (generate → check → regenerate) |
+
+`retry_until=` is distinct from `retry=` alone: `retry=` only retries on a raised exception, `retry_until=` retries on *output shape*.
+
+## Also handles
+
+- **Parallel execution** — independent tasks in a layer run on a thread pool.
+- **Resume** — `run()` → fix → `resume()` re-runs from the failure point, keeping succeeded tasks cached. `override()` injects a corrected value for a step resolved out-of-band.
+- **Detached side-effects** — `detached=True` tasks (memory writes, notifications) run after the main DAG and never block it on failure.
+- **`timeout_s=`**, **`retry=`** with exponential backoff, **`fail_fast=`**.
+
+## Layout
+
+| File | Audience | Contents |
+|---|---|---|
+| [`SKILL.md`](SKILL.md) | Claude | Trigger, mental model, quick start, the three primitives, when / when-not-to-use |
+| [`references/reference.md`](references/reference.md) | Claude | Full API — every `@task` parameter, `Flow` methods, resume/override, detached auto-discovery, signature gotchas |
+| [`scripts/flowing.py`](scripts/flowing.py) | — | The runner itself (no third-party dependencies) |
+| [`tests/test_flowing.py`](tests/test_flowing.py) | — | 28 tests — `python3 -m unittest tests.test_flowing` |
+| [`CHANGELOG.md`](CHANGELOG.md) | — | Version history |
+
+## When to reach for it
+
+Use it when a procedure has branches that matter, steps with input contracts, an LLM step that needs to converge, 3+ operations that can parallelize, or a pipeline where late failures shouldn't waste early work.
+
+Skip it for a single sequential operation (just call the function), for a next step that needs open-ended *reasoning* about the prior result rather than a predicate (use a think loop), or for async / distributed workflows (this is single-container, thread-pool based).
+
+## Complements
+
+- **[orchestrating-agents](../orchestrating-agents)** — parallel API instances and delegated sub-tasks. `flowing` orders and gates work *within* one container; orchestrating-agents fans work *out* across many.
+- **[tiling-tree](../tiling-tree)** — MECE partitioning of a problem space. Tiling-tree decides *what* the branches are; `flowing` enforces the execution order once they exist.
+- **[tracking-todos](../tracking-todos)** — a human-legible checklist for loose, evolving work. `flowing` is for procedures whose shape is known up front and worth encoding as a graph.

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -2,7 +2,7 @@
 name: flowing
 description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also covers parallel execution, checkpoint resume, detached side-effects.
 metadata:
-  version: 1.3.1
+  version: 1.3.2
 ---
 
 # Flowing — Control Flow in Code, Not Prose


### PR DESCRIPTION
## Summary

`flowing` had no `README.md`. 51 of 81 skills in this repo carry a hand-authored README for the GitHub-browsing audience (the `.github/scripts/generate-readme.py` fallback only emits name + description). The recent restructure in #647 split the *agent-facing* docs cleanly across `SKILL.md` (instructions) and `references/reference.md` (reference), but left no *human-facing* overview — this fills that gap.

The README:
- Frames the problem — prose imperatives get read and generated past; a `@task` graph is structural, so gates can't be stepped over.
- Summarizes the three control-flow primitives (`when=` / `validate=` / `retry_until=`) in a table.
- Maps the file layout by audience (SKILL.md → Claude, references/ → Claude, README → human).
- Links sibling orchestration skills (`orchestrating-agents`, `tiling-tree`, `tracking-todos`) with the distinction between them.

Docs only — `flowing.py` untouched, 28 tests still green.

## Test plan

- [x] All intra-skill links resolve (`SKILL.md`, `references/reference.md`, `scripts/flowing.py`, `tests/test_flowing.py`, `CHANGELOG.md`)
- [x] Sibling-skill links (`../orchestrating-agents`, `../tiling-tree`, `../tracking-todos`) point to existing dirs
- [x] `metadata.version` bumped 1.3.1 → 1.3.2; CHANGELOG entry added

https://claude.ai/code/session_01YExnPSJKxrKXEDqBn1Vucc