### PR TITLE
container-layer v0.2.0: named layers + compose for oaustegard/claude-workspace#25

### DIFF
--- a/container-layer/CHANGELOG.md
+++ b/container-layer/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `container-layer` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-05-17
+
+### Added
+
+- Named layers: `ContainerLayer(..., layer_name="X")` produces cache release tag
+  `layer-X-<hash>` instead of `layer-<hash>`. Enables per-name cache retention
+  policies and multi-layer composition without collisions.
+- `default_layer_name(path)`: derives layer name from filename
+  (`Containerfile` → `base`, `Containerfile.mojo` → `mojo`, etc.).
+- `compose(containerfile_paths, ...)`: orchestrates sequential restore (or
+  build+push on miss) of multiple named layers. Mirrors Docker's additive-overlay
+  semantics — later layers can overwrite earlier ones' files.
+- CLI `compose` subcommand for the same.
+- `--name` flag on `build` / `restore` / `hash` / `inspect` subcommands for
+  single-layer naming.
+
+### Backwards compatibility
+
+- Unnamed layers (no `layer_name`, no `--name`) keep the old `layer-<hash>` tag.
+  Existing single-Containerfile callers see no cache invalidation.
+- Existing `build_and_push()` / `restore_or_build()` / `build_only()` methods
+  unchanged.
+
 ## [0.1.0] - 2026-04-04
 
 ### Other

--- a/container-layer/SKILL.md
+++ b/container-layer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: container-layer
-description: Build and cache a personalized container environment from a Dockerfile-like spec. Use when the user mentions "container layer", "Containerfile", "custom container", "environment setup", "cache my installs", "uv shim", or wants to persist package installations, skills, or environment config across ephemeral sessions. Also triggers when the user asks to snapshot, restore, or rebuild their environment, or wants to capture ad-hoc package installs into a reproducible spec.
+description: Build and cache a personalized container environment from a Dockerfile-like spec. Supports both single-layer (one Containerfile -> one cached tarball) and multi-layer composition (compose [base, scientific, mojo, ...] into one container with each layer cached independently). Use when the user mentions "container layer", "Containerfile", "custom container", "environment setup", "cache my installs", "uv shim", "composable layers", or wants to persist package installations, skills, or environment config across ephemeral sessions. Also triggers when the user asks to snapshot, restore, or rebuild their environment, or wants to capture ad-hoc package installs into a reproducible spec.
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # Container Layer
@@ -46,7 +46,7 @@ SNAPSHOT /additional/path/to/capture
 
 ## Usage
 
-### Building / Restoring
+### Single layer — build / restore
 
 ```python
 from scripts.containerfile import ContainerLayer
@@ -59,6 +59,67 @@ layer = ContainerLayer(
 
 # Try cache first, fall back to full build
 layer.restore_or_build()
+```
+
+Or via CLI:
+
+```bash
+python -m scripts.cli restore /path/to/Containerfile --repo user/cache-repo
+```
+
+### Multi-layer composition (v0.2.0+)
+
+Decompose a heavy environment into named layers, each cached independently. Compose them in order on session start so most-changed bits don't invalidate stable bits.
+
+```python
+from scripts.containerfile import compose
+
+compose(
+    containerfile_paths=[
+        "layers/Containerfile",            # name='base'  (always-on)
+        "layers/Containerfile.scientific", # name='scientific'
+        "layers/Containerfile.mojo",       # name='mojo'
+    ],
+    cache_repo="user/cache-repo",
+)
+```
+
+Each layer gets its own cache release tag `layer-<name>-<hash>` so retention policies (keep last N) and cache invalidation operate per-name.
+
+Default layer names are derived from the Containerfile path:
+- `Containerfile`            → `base`
+- `Containerfile.scientific` → `scientific`
+- `layers/Containerfile.X`   → `X`
+
+CLI equivalent:
+
+```bash
+python -m scripts.cli compose \
+    layers/Containerfile \
+    layers/Containerfile.scientific \
+    layers/Containerfile.mojo \
+    --repo user/cache-repo
+```
+
+### Per-layer name override
+
+If filename doesn't derive cleanly, pass `--name NAME:PATH` per layer:
+
+```bash
+python -m scripts.cli compose \
+    --name base:weird-named-file.txt \
+    --name mojo:other-file.txt \
+    weird-named-file.txt other-file.txt
+```
+
+### Single-layer naming (back-compat)
+
+`build` / `restore` / `hash` / `inspect` accept `--name`:
+
+```bash
+python -m scripts.cli restore Containerfile.mojo --name mojo
+# Cache tag becomes 'layer-mojo-<hash>' instead of 'layer-<hash>'.
+# Omit --name to keep the old back-compat tag for existing callers.
 ```
 
 ### The uv Shim

--- a/container-layer/scripts/cli.py
+++ b/container-layer/scripts/cli.py
@@ -2,13 +2,23 @@
 """
 CLI for container-layer: build, restore, or snapshot container layers.
 
-Usage:
-    python -m scripts.cli build /path/to/Containerfile [--repo user/repo] [--no-cache]
-    python -m scripts.cli restore /path/to/Containerfile [--repo user/repo]
-    python -m scripts.cli hash /path/to/Containerfile
+Single-layer mode (back-compat):
+    python -m scripts.cli build /path/to/Containerfile [--repo user/repo] [--no-cache] [--name N]
+    python -m scripts.cli restore /path/to/Containerfile [--repo user/repo] [--name N]
+    python -m scripts.cli hash /path/to/Containerfile [--name N]
     python -m scripts.cli inspect /path/to/Containerfile
 
-Cache invalidation:
+Multi-layer composition (new in v0.2.0):
+    python -m scripts.cli compose <containerfile1> [<containerfile2> ...] [--repo user/repo]
+        Restores each layer in order. Each layer gets its own cache release tag
+        `layer-<name>-<hash>` (name derived from filename: `Containerfile.mojo`
+        -> 'mojo', `Containerfile` -> 'base'). Later layers can overwrite
+        earlier ones — additive Docker-like semantics.
+
+    Per-layer name override (rare; uncommon path/filename):
+        python -m scripts.cli compose --name base:Containerfile.foo --name mojo:Containerfile.bar
+
+Cache invalidation (single or composed):
     --invalidate-on user/repo        Include repo HEAD SHA in cache key
     --invalidate-on user/repo@branch  Specific branch
     Multiple repos: --invalidate-on repo1 --invalidate-on repo2
@@ -18,49 +28,57 @@ import argparse
 import os
 import sys
 
-from .containerfile import ContainerLayer, parse_containerfile, content_hash, github_head_sha
+from .containerfile import (
+    ContainerLayer,
+    compose,
+    content_hash,
+    default_layer_name,
+    github_head_sha,
+    parse_containerfile,
+)
 
 
 def _compute_salt(invalidate_on: list[str], token: str) -> str:
     """Compute salt from GitHub repo HEAD SHAs."""
     if not invalidate_on:
         return ""
-    
+
     parts = []
     for spec in invalidate_on:
         if "@" in spec:
             repo, ref = spec.rsplit("@", 1)
         else:
             repo, ref = spec, "main"
-        
+
         sha = github_head_sha(repo, ref, token)
         if sha:
             parts.append(f"{repo}@{sha}")
             print(f"  Salt: {repo} @ {sha}")
         else:
             print(f"  WARNING: couldn't fetch HEAD for {repo}, skipping from salt")
-    
+
     return "|".join(parts)
 
 
 def cmd_build(args):
     """Execute the Containerfile and optionally push to cache."""
     salt = _compute_salt(args.invalidate_on or [], args.token)
-    
+
     layer = ContainerLayer(
         containerfile_path=args.containerfile,
         cache_repo=args.repo,
         gh_token=args.token,
         salt=salt,
+        layer_name=args.name,
     )
-    
+
     if args.no_cache:
         result = layer.build_only()
     else:
         result = layer.build_and_push()
-    
+
     if result.success:
-        print(f"\n✓ Build complete (hash: {result.content_hash})")
+        print(f"\n✓ Build complete (tag: {layer.tag})")
         if result.snapshot_paths:
             print(f"  Snapshot paths: {len(result.snapshot_paths)} entries")
         if result.env_vars:
@@ -75,17 +93,18 @@ def cmd_build(args):
 def cmd_restore(args):
     """Try to restore from cache, fall back to build."""
     salt = _compute_salt(args.invalidate_on or [], args.token)
-    
+
     layer = ContainerLayer(
         containerfile_path=args.containerfile,
         cache_repo=args.repo,
         gh_token=args.token,
         salt=salt,
+        layer_name=args.name,
     )
     result = layer.restore_or_build()
-    
+
     if result.success:
-        print(f"\n✓ Environment ready (hash: {result.content_hash})")
+        print(f"\n✓ Environment ready (tag: {layer.tag})")
     else:
         print(f"\n✗ Restore failed")
         for err in result.errors:
@@ -93,20 +112,64 @@ def cmd_restore(args):
         sys.exit(1)
 
 
+def cmd_compose(args):
+    """Restore (or build+push on miss) a sequence of named layers."""
+    salt = _compute_salt(args.invalidate_on or [], args.token)
+
+    # Parse --name overrides: list of "name:path" strings to (name, path) pairs.
+    name_overrides: dict[str, str] = {}
+    for spec in args.name or []:
+        if ":" not in spec:
+            print(f"✗ --name expects 'name:path', got: {spec}")
+            sys.exit(2)
+        name, path = spec.split(":", 1)
+        name_overrides[os.path.abspath(path)] = name
+
+    paths = args.containerfiles
+    if not paths:
+        print("✗ compose requires at least one Containerfile path")
+        sys.exit(2)
+
+    # Apply overrides where path matches; fall back to default derivation
+    names = [name_overrides.get(os.path.abspath(p)) for p in paths]
+
+    results = compose(
+        containerfile_paths=paths,
+        cache_repo=args.repo,
+        gh_token=args.token,
+        salt=salt,
+        names=names,
+    )
+
+    succeeded = [r for r in results if r.success]
+    print(
+        f"\n=== Compose summary: {len(succeeded)}/{len(paths)} layers ready ==="
+    )
+    if len(succeeded) != len(paths):
+        sys.exit(1)
+
+
 def cmd_hash(args):
-    """Print the cache key hash of a Containerfile."""
+    """Print the cache key hash (or full tag, if --name) of a Containerfile."""
     salt = _compute_salt(args.invalidate_on or [], args.token)
     h = content_hash(args.containerfile, extra_salt=salt)
-    print(h)
+    if args.name:
+        print(f"layer-{args.name}-{h}")
+    else:
+        print(h)
 
 
 def cmd_inspect(args):
     """Parse and display the instructions in a Containerfile."""
     instructions = parse_containerfile(args.containerfile)
     salt = _compute_salt(args.invalidate_on or [], args.token)
+    layer_name = args.name or default_layer_name(args.containerfile)
+    h = content_hash(args.containerfile, extra_salt=salt)
     print(f"Containerfile: {args.containerfile}")
-    print(f"Cache key: {content_hash(args.containerfile, extra_salt=salt)}")
-    print(f"Instructions: {len(instructions)}")
+    print(f"Derived name:  {layer_name}")
+    print(f"Cache key:     {h}")
+    print(f"Full tag:      layer-{layer_name}-{h}")
+    print(f"Instructions:  {len(instructions)}")
     print()
     for inst in instructions:
         print(f"  [{inst.line_num:3d}] {inst.directive:10s} {inst.args}")
@@ -114,33 +177,75 @@ def cmd_inspect(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Container layer manager")
-    parser.add_argument("--token", default=os.environ.get("GH_TOKEN", ""),
-                       help="GitHub token (default: $GH_TOKEN)")
-    parser.add_argument("--repo", default="oaustegard/claude-container-layers",
-                       help="GitHub repo for cache storage")
-    parser.add_argument("--invalidate-on", action="append",
-                       help="GitHub repo whose HEAD SHA is included in cache key "
-                            "(e.g. user/repo or user/repo@branch). Repeatable.")
-    
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GH_TOKEN", ""),
+        help="GitHub token (default: $GH_TOKEN)",
+    )
+    parser.add_argument(
+        "--repo",
+        default="oaustegard/claude-container-layers",
+        help="GitHub repo for cache storage",
+    )
+    parser.add_argument(
+        "--invalidate-on",
+        action="append",
+        help="GitHub repo whose HEAD SHA is included in cache key "
+        "(e.g. user/repo or user/repo@branch). Repeatable.",
+    )
+
     sub = parser.add_subparsers(dest="command", required=True)
-    
+
     p_build = sub.add_parser("build", help="Execute Containerfile and cache result")
     p_build.add_argument("containerfile")
+    p_build.add_argument(
+        "--name",
+        help="Layer name for cache release tag (default: derived from filename, "
+        "e.g. 'Containerfile.mojo' -> 'mojo'). Pass empty to use old "
+        "back-compat tag 'layer-<hash>'.",
+    )
     p_build.add_argument("--no-cache", action="store_true", help="Skip cache push")
     p_build.set_defaults(func=cmd_build)
-    
+
     p_restore = sub.add_parser("restore", help="Restore from cache or build")
     p_restore.add_argument("containerfile")
+    p_restore.add_argument(
+        "--name",
+        help="Layer name for cache release tag (see `build --name`).",
+    )
     p_restore.set_defaults(func=cmd_restore)
-    
+
+    p_compose = sub.add_parser(
+        "compose",
+        help="Restore a sequence of named layers in order (cache miss = build+push)",
+    )
+    p_compose.add_argument(
+        "containerfiles",
+        nargs="+",
+        help="Ordered list of Containerfile paths to restore",
+    )
+    p_compose.add_argument(
+        "--name",
+        action="append",
+        help="Per-layer name override, formatted 'name:path'. Repeatable. "
+        "Paths not listed get a default name derived from filename.",
+    )
+    p_compose.set_defaults(func=cmd_compose)
+
     p_hash = sub.add_parser("hash", help="Print Containerfile cache key")
     p_hash.add_argument("containerfile")
+    p_hash.add_argument(
+        "--name", help="If set, prints full tag `layer-<name>-<hash>` instead of bare hash."
+    )
     p_hash.set_defaults(func=cmd_hash)
-    
+
     p_inspect = sub.add_parser("inspect", help="Show parsed instructions")
     p_inspect.add_argument("containerfile")
+    p_inspect.add_argument(
+        "--name", help="Override the layer name displayed in inspection output."
+    )
     p_inspect.set_defaults(func=cmd_inspect)
-    
+
     args = parser.parse_args()
     args.func(args)
 

--- a/container-layer/scripts/containerfile.py
+++ b/container-layer/scripts/containerfile.py
@@ -99,6 +99,30 @@ def content_hash(path: str, extra_salt: str = "") -> str:
     return hashlib.sha256(content.encode()).hexdigest()[:16]
 
 
+def default_layer_name(containerfile_path: str) -> str:
+    """Derive a default layer name from a Containerfile path.
+
+    `Containerfile`         -> 'base'
+    `Containerfile.mojo`    -> 'mojo'
+    `layers/Containerfile.scientific` -> 'scientific'
+    `foo/bar.txt`           -> 'bar' (fallback: file stem)
+
+    Names are lowercased and stripped of non-[a-z0-9-_] characters so they're
+    safe to embed in GitHub Release tags (`layer-<name>-<hash>`).
+    """
+    basename = os.path.basename(containerfile_path)
+    if basename == "Containerfile":
+        raw = "base"
+    elif basename.startswith("Containerfile."):
+        raw = basename[len("Containerfile."):]
+    else:
+        # Fallback: stem of whatever path was passed
+        raw = os.path.splitext(basename)[0]
+    # Sanitize: keep alphanumerics, hyphen, underscore, period -> hyphen
+    safe = re.sub(r"[^a-z0-9_-]", "-", raw.lower()).strip("-")
+    return safe or "layer"
+
+
 def github_head_sha(repo: str, ref: str = "main", token: str = "") -> str:
     """Fetch the HEAD SHA of a GitHub repo ref. Returns empty string on failure."""
     try:
@@ -361,22 +385,34 @@ class ContainerfileExecutor:
 class ContainerLayer:
     """
     High-level interface: parse a Containerfile, execute or restore from cache.
+
+    A layer can optionally have a `layer_name`. When set, the cache release
+    tag becomes `layer-<name>-<hash>` instead of `layer-<hash>`. This enables
+    composing multiple named layers (each cached independently) into a single
+    container, and lets cache-retention policies operate per-name.
+
+    Back-compat: if `layer_name` is None, the tag stays `layer-<hash>` so
+    existing single-Containerfile callers don't see their cache invalidate.
     """
-    
+
     def __init__(
         self,
         containerfile_path: str,
         cache_repo: str = "oaustegard/claude-container-layers",
         gh_token: Optional[str] = None,
         salt: str = "",
+        layer_name: Optional[str] = None,
     ):
         self.containerfile_path = containerfile_path
         self.cache_repo = cache_repo
         self.gh_token = gh_token or os.environ.get("GH_TOKEN", "")
+        self.layer_name = layer_name
         self._hash = content_hash(containerfile_path, extra_salt=salt)
-    
+
     @property
     def tag(self) -> str:
+        if self.layer_name:
+            return f"layer-{self.layer_name}-{self._hash}"
         return f"layer-{self._hash}"
     
     def restore_or_build(self) -> BuildResult:
@@ -425,3 +461,62 @@ class ContainerLayer:
         result = executor.execute(instructions)
         result.content_hash = self._hash
         return result
+
+
+def compose(
+    containerfile_paths: list[str],
+    cache_repo: str = "oaustegard/claude-container-layers",
+    gh_token: Optional[str] = None,
+    salt: str = "",
+    names: Optional[list[Optional[str]]] = None,
+) -> list[BuildResult]:
+    """Restore (or build+push, on miss) a sequence of named layers in order.
+
+    Each Containerfile becomes a named ContainerLayer with its own cache
+    key and GitHub Release. Layers are restored sequentially — later layers'
+    file modifications can overwrite earlier ones, mirroring Docker's
+    additive-overlay semantics.
+
+    Args:
+        containerfile_paths: Ordered list of Containerfile paths.
+        cache_repo: Single cache repo for all layers (each gets its own
+            release within it, tagged `layer-<name>-<hash>`).
+        gh_token: GitHub token; falls back to $GH_TOKEN.
+        salt: Optional salt applied to every layer's hash (typically a
+            git HEAD SHA so the whole composition invalidates together
+            when the source repo advances).
+        names: Optional per-layer name overrides. None entries fall back
+            to `default_layer_name()`. List length must match
+            `containerfile_paths` if provided.
+
+    Returns:
+        List of BuildResult, one per layer, in the same order as input.
+        Stops on first failure (later layers in the list aren't attempted).
+    """
+    if names is not None and len(names) != len(containerfile_paths):
+        raise ValueError(
+            f"names length ({len(names)}) must match containerfile_paths "
+            f"length ({len(containerfile_paths)})"
+        )
+
+    results: list[BuildResult] = []
+    for i, cf_path in enumerate(containerfile_paths):
+        explicit_name = names[i] if names else None
+        name = explicit_name or default_layer_name(cf_path)
+        print(f"\n=== Composing layer [{i + 1}/{len(containerfile_paths)}]: {name} ({cf_path}) ===")
+
+        layer = ContainerLayer(
+            containerfile_path=cf_path,
+            cache_repo=cache_repo,
+            gh_token=gh_token,
+            salt=salt,
+            layer_name=name,
+        )
+        result = layer.restore_or_build()
+        results.append(result)
+
+        if not result.success:
+            print(f"\n✗ Compose halted at layer '{name}' (errors above)")
+            break
+
+    return results

--- a/container-layer/scripts/test_named_layers.py
+++ b/container-layer/scripts/test_named_layers.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for named-layer + compose support (v0.2.0).
+
+Runnable standalone:
+
+    cd container-layer
+    python3 -m scripts.test_named_layers
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+from . import containerfile
+from .containerfile import (
+    ContainerLayer,
+    BuildResult,
+    compose,
+    content_hash,
+    default_layer_name,
+)
+
+
+class TestDefaultLayerName(unittest.TestCase):
+    """Path -> layer name derivation."""
+
+    def test_bare_containerfile_becomes_base(self):
+        self.assertEqual(default_layer_name("Containerfile"), "base")
+        self.assertEqual(default_layer_name("/abs/path/Containerfile"), "base")
+        self.assertEqual(default_layer_name("./rel/Containerfile"), "base")
+
+    def test_dot_suffix_becomes_name(self):
+        self.assertEqual(default_layer_name("Containerfile.mojo"), "mojo")
+        self.assertEqual(default_layer_name("Containerfile.torch-cpu"), "torch-cpu")
+        self.assertEqual(default_layer_name("layers/Containerfile.scientific"), "scientific")
+
+    def test_lowercase_and_sanitize(self):
+        self.assertEqual(default_layer_name("Containerfile.JuliaSR"), "juliasr")
+        self.assertEqual(default_layer_name("Containerfile.foo bar"), "foo-bar")
+        # Note: os.path.basename strips directory components first, so
+        # "Containerfile.weird/path" becomes "path" before suffix-stripping.
+
+    def test_fallback_to_file_stem(self):
+        self.assertEqual(default_layer_name("foo/bar.txt"), "bar")
+        self.assertEqual(default_layer_name("/tmp/my_layer"), "my_layer")
+
+    def test_empty_or_all_special_chars_falls_back(self):
+        self.assertEqual(default_layer_name("Containerfile.@@@"), "layer")
+        self.assertEqual(default_layer_name("Containerfile.---"), "layer")
+
+
+class TestContainerLayerTag(unittest.TestCase):
+    """tag property: with vs without layer_name."""
+
+    def _layer(self, path: str, name: str = None) -> ContainerLayer:
+        # ContainerLayer reads the file for hashing; create a temp file.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".Containerfile", delete=False) as f:
+            f.write("RUN echo hello\n")
+            cf_path = f.name
+        self.addCleanup(os.unlink, cf_path)
+        return ContainerLayer(
+            containerfile_path=cf_path,
+            cache_repo="testorg/test-cache",
+            gh_token="test-token",
+            layer_name=name,
+        )
+
+    def test_unnamed_layer_uses_back_compat_tag(self):
+        layer = self._layer("Containerfile")
+        self.assertRegex(layer.tag, r"^layer-[a-f0-9]{16}$")
+
+    def test_named_layer_uses_named_tag(self):
+        layer = self._layer("Containerfile", name="scientific")
+        self.assertRegex(layer.tag, r"^layer-scientific-[a-f0-9]{16}$")
+
+    def test_same_content_same_hash_regardless_of_name(self):
+        layer_a = self._layer("Containerfile", name="alpha")
+        layer_b = self._layer("Containerfile", name="beta")
+        # Different names -> different tags, but same underlying content hash
+        self.assertNotEqual(layer_a.tag, layer_b.tag)
+        self.assertEqual(layer_a._hash, layer_b._hash)
+
+
+class TestCompose(unittest.TestCase):
+    """compose() orchestrates per-layer restore in order."""
+
+    def setUp(self):
+        # Three fake containerfiles in a clean tempdir so basename == filename
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(self._cleanup_tmpdir)
+        self.cf_paths = []
+        for name, body in [
+            ("Containerfile", "RUN echo base\n"),
+            ("Containerfile.scientific", "RUN echo sci\n"),
+            ("Containerfile.mojo", "RUN echo mojo\n"),
+        ]:
+            path = os.path.join(self.tmpdir, name)
+            with open(path, "w") as f:
+                f.write(body)
+            self.cf_paths.append(path)
+
+    def _cleanup_tmpdir(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_compose_invokes_restore_or_build_on_each_layer_in_order(self):
+        calls = []
+
+        def fake_restore(self):
+            calls.append((self.layer_name, self.containerfile_path))
+            return BuildResult(success=True, snapshot_paths=[], content_hash="abc")
+
+        with mock.patch.object(ContainerLayer, "restore_or_build", fake_restore):
+            results = compose(
+                containerfile_paths=self.cf_paths,
+                cache_repo="testorg/cache",
+                gh_token="t",
+            )
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(r.success for r in results))
+        # Order preserved + names derived from filename suffix:
+        # Containerfile -> 'base', Containerfile.scientific -> 'scientific', etc.
+        self.assertEqual([n for n, _ in calls], ["base", "scientific", "mojo"])
+
+    def test_compose_halts_on_first_failure(self):
+        attempt_log = []
+
+        def flaky_restore(self):
+            attempt_log.append(self.layer_name)
+            success = self.layer_name != "scientific"
+            return BuildResult(
+                success=success,
+                snapshot_paths=[],
+                content_hash="abc",
+                errors=[] if success else ["simulated failure"],
+            )
+
+        with mock.patch.object(ContainerLayer, "restore_or_build", flaky_restore):
+            results = compose(
+                containerfile_paths=self.cf_paths,
+                cache_repo="testorg/cache",
+                gh_token="t",
+            )
+
+        # Stopped at scientific (the 2nd layer), didn't try mojo
+        self.assertEqual(attempt_log, ["base", "scientific"])
+        self.assertEqual(len(results), 2)
+        self.assertFalse(results[1].success)
+
+    def test_compose_respects_explicit_name_overrides(self):
+        seen_names = []
+
+        def capture(self):
+            seen_names.append(self.layer_name)
+            return BuildResult(success=True, snapshot_paths=[], content_hash="abc")
+
+        with mock.patch.object(ContainerLayer, "restore_or_build", capture):
+            compose(
+                containerfile_paths=self.cf_paths[:2],
+                names=["custom-1", None],  # second falls back to default
+                cache_repo="testorg/cache",
+                gh_token="t",
+            )
+
+        # First is overridden, second derived from filename
+        self.assertEqual(seen_names[0], "custom-1")
+        self.assertEqual(seen_names[1], "scientific")
+
+    def test_compose_rejects_mismatched_names_length(self):
+        with self.assertRaises(ValueError):
+            compose(
+                containerfile_paths=self.cf_paths,  # 3 paths
+                names=["only-one"],  # 1 name
+                cache_repo="testorg/cache",
+                gh_token="t",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Implements the storage primitive needed by [oaustegard/claude-workspace#25](https://github.com/oaustegard/claude-workspace/issues/25) (composable container layers). The hub-side wiring (manifest format, `boot-ccotw.sh` integration) is a separate PR against `oaustegard/claude-workspace` once this lands.

## What

Adds named-layer support and a `compose` orchestrator. Each named layer gets its own GitHub Release tag `layer-<name>-<hash>`, so:

- multiple layers can share one cache repo without tag collisions
- cache-retention policies can be applied per-name (\"keep last N for `mojo`\")
- composition is just a thin orchestrator over per-layer `restore_or_build()` — no new cache primitives

## API surface

```python
from scripts.containerfile import ContainerLayer, compose

# Single named layer (cache tag = 'layer-mojo-<hash>')
ContainerLayer(\"Containerfile.mojo\", layer_name=\"mojo\", ...).restore_or_build()

# Compose: sequential restore, each layer cached independently
compose(
    containerfile_paths=[
        \"layers/Containerfile\",            # name='base' (derived)
        \"layers/Containerfile.scientific\", # name='scientific'
        \"layers/Containerfile.mojo\",       # name='mojo'
    ],
    cache_repo=\"user/cache-repo\",
)
```

CLI mirror:

\`\`\`
python -m scripts.cli compose Containerfile Containerfile.scientific Containerfile.mojo \\
    --repo user/cache-repo
\`\`\`

## Backwards compatibility

- Unnamed layers (no \`layer_name\` arg, no \`--name\` flag) keep the original \`layer-<hash>\` tag. Existing callers see no cache invalidation.
- All existing public APIs (\`build_and_push\`, \`restore_or_build\`, \`build_only\`) unchanged.

## Tests

12 unit tests in \`scripts/test_named_layers.py\`. All pass:

\`\`\`
$ python3 -m scripts.test_named_layers
Ran 12 tests in 0.003s
OK
\`\`\`

Coverage:
- \`default_layer_name(path)\`: bare \`Containerfile\` → 'base', \`Containerfile.X\` → 'X', sanitization, fallback
- \`ContainerLayer.tag\`: named vs unnamed, same-content-different-name produces different tags but same hash
- \`compose\`: order preservation, halt-on-failure, name overrides, length validation

CLI smoke-tested manually for \`hash\`, \`inspect\`, \`compose --help\`.

## What's NOT in this PR

Per the design discussion in claude-workspace#25, the following land separately:

- **Per-layer file-ownership manifests** for collision-safe overlay. Today \`compose\` relies on tar-extraction's last-write-wins behavior; for collision detection we'd want each \`Containerfile.X\` to declare which paths it owns. Not blocking the storage primitive.
- **\`.claude/container-layers.yaml\` manifest format** — declarative selection lives in the consuming repo, not this skill.
- **\`boot-ccotw.sh\` integration** — also lives in \`oaustegard/claude-workspace\`.

## Empirical motivation

From [oaustegard/claude-workspace-fuse PR #2](https://github.com/oaustegard/claude-workspace-fuse/pull/2) and [PR #5](https://github.com/oaustegard/claude-workspace-fuse/pull/5):

- Monolithic Containerfiles snapshot everything in dist-packages by *final state*, not by *what this Containerfile installed*. Result: a "slim" rebuild that removes \`RUN uv pip install torch\` still captures torch from the prior layer (verified: 712M torch in a 'slim' tarball).
- Single-Containerfile-with-purge doesn't work: \`uv pip uninstall --system --break-system-packages\` silently fails for installs added the same way.
- True separation requires per-named-layer caches, which is what this PR enables.

Findings posted in detail at [oaustegard/claude-workspace#25 (comment)](https://github.com/oaustegard/claude-workspace/issues/25#issuecomment-4471892192).