### PR TITLE
container-layer v0.2.1: fix PYTHON_INSTALL_PATHS for python3.11 containers

### DIFF
--- a/container-layer/CHANGELOG.md
+++ b/container-layer/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `container-layer` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.1] - 2026-05-17
+
+### Fixed
+
+- `PYTHON_INSTALL_PATHS` now lists python3.10 through python3.13 dist-packages
+  instead of only python3.12. The previous single entry missed containers using
+  3.11 (which is most of them), causing the diff-vs-baseline logic in
+  `_dedup_paths` to silently fall through to whole-tree snapshot — every layer
+  captured all of dist-packages instead of just newly-installed files.
+  Empirically verified against oaustegard/claude-workspace-fuse: cached "slim"
+  layer was 678MB compressed with 712M torch + 944M modular still embedded.
+
+### Added
+
+- Regression tests in `scripts/test_baseline_paths.py` lock in the new coverage
+  and assert the diff path is taken when a SNAPSHOT directive references a
+  baselined dir.
+
 ## [0.2.0] - 2026-05-17
 
 ### Added

--- a/container-layer/SKILL.md
+++ b/container-layer/SKILL.md
@@ -2,7 +2,7 @@
 name: container-layer
 description: Build and cache a personalized container environment from a Dockerfile-like spec. Supports both single-layer (one Containerfile -> one cached tarball) and multi-layer composition (compose [base, scientific, mojo, ...] into one container with each layer cached independently). Use when the user mentions "container layer", "Containerfile", "custom container", "environment setup", "cache my installs", "uv shim", "composable layers", or wants to persist package installations, skills, or environment config across ephemeral sessions. Also triggers when the user asks to snapshot, restore, or rebuild their environment, or wants to capture ad-hoc package installs into a reproducible spec.
 metadata:
-  version: 0.2.0
+  version: 0.2.1
 ---
 
 # Container Layer

--- a/container-layer/scripts/containerfile.py
+++ b/container-layer/scripts/containerfile.py
@@ -27,9 +27,19 @@ IGNORED_INSTRUCTIONS = {
     "STOPSIGNAL", "ONBUILD",
 }
 
-# Well-known paths that pip/uv install into
+# Well-known paths that pip/uv install into.
+# Lists all common Python versions so the diff-vs-baseline logic correctly
+# identifies new files in dist-packages regardless of which interpreter is
+# active. The previous single-entry list hardcoded python3.12, so containers
+# on python3.11 fell through to the "explicit SNAPSHOT, capture whole tree"
+# code path — every layer ended up snapshotting all of dist-packages instead
+# of just the files it installed. Verified empirically against the python3.11
+# container in oaustegard/claude-workspace-fuse.
 PYTHON_INSTALL_PATHS = [
+    "/usr/local/lib/python3.10/dist-packages",
+    "/usr/local/lib/python3.11/dist-packages",
     "/usr/local/lib/python3.12/dist-packages",
+    "/usr/local/lib/python3.13/dist-packages",
     "/usr/local/bin",
     "/home/claude/.local/lib",
     "/home/claude/.local/bin",

--- a/container-layer/scripts/test_baseline_paths.py
+++ b/container-layer/scripts/test_baseline_paths.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for the PYTHON_INSTALL_PATHS baseline fix (v0.2.1).
+
+Locks in the behavior that dist-packages for python3.10/3.11/3.12/3.13 are
+ALL recognized as baselined paths — so a SNAPSHOT directive that references
+any of them gets the diff-vs-baseline treatment instead of full-tree capture.
+
+Run:
+    cd container-layer
+    python3 -m scripts.test_baseline_paths
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from . import containerfile
+from .containerfile import (
+    PYTHON_INSTALL_PATHS,
+    ContainerfileExecutor,
+    snapshot_baseline,
+)
+
+
+class TestPythonInstallPathsCoverage(unittest.TestCase):
+    """PYTHON_INSTALL_PATHS must include every dist-packages version we run on."""
+
+    def test_python_3_10_through_3_13_dist_packages_present(self):
+        for v in ("3.10", "3.11", "3.12", "3.13"):
+            self.assertIn(
+                f"/usr/local/lib/python{v}/dist-packages",
+                PYTHON_INSTALL_PATHS,
+                f"missing python{v}/dist-packages — diff-vs-baseline won't fire on "
+                f"containers using this version",
+            )
+
+    def test_local_bin_still_listed(self):
+        self.assertIn("/usr/local/bin", PYTHON_INSTALL_PATHS)
+
+
+class TestBaselineCapturesNonExistentPaths(unittest.TestCase):
+    """snapshot_baseline returns an entry for every requested path, even
+    if the path doesn't exist — so _dedup_paths can later treat it as
+    baselined regardless of build-time presence."""
+
+    def test_missing_path_in_baseline_keys(self):
+        baseline = snapshot_baseline(["/nonexistent/path/here"])
+        self.assertIn("/nonexistent/path/here", baseline)
+        self.assertEqual(baseline["/nonexistent/path/here"], set())
+
+
+class TestDedupPathsDiffsBaselinedDirEvenWhenItGrows(unittest.TestCase):
+    """Regression test for the bug: with python3.11 in PYTHON_INSTALL_PATHS,
+    a SNAPSHOT directive on /usr/local/lib/python3.11/dist-packages should
+    trigger the diff path (only NEW files captured), not the whole-tree path."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(self.tmpdir, ignore_errors=True))
+
+    def _fake_baselined_dir_in_install_paths(self, simulate_path: str):
+        """Patch PYTHON_INSTALL_PATHS to include a tempdir we control,
+        so we can test the executor's baseline + diff path without
+        touching real /usr/local."""
+        self._patch_paths = simulate_path
+        self._orig = containerfile.PYTHON_INSTALL_PATHS
+        containerfile.PYTHON_INSTALL_PATHS = [simulate_path] + [
+            p for p in self._orig if not p.endswith("dist-packages")
+        ]
+        self.addCleanup(setattr, containerfile, "PYTHON_INSTALL_PATHS", self._orig)
+
+    def test_only_new_files_captured_in_baselined_dir(self):
+        simulated = str(self.tmpdir / "fake-dist-packages")
+        os.makedirs(simulated, exist_ok=True)
+        # Pre-existing "baseline" file
+        (Path(simulated) / "existing.py").write_text("# already there\n")
+
+        self._fake_baselined_dir_in_install_paths(simulated)
+
+        executor = ContainerfileExecutor()
+        # Capture baseline as the real executor would, before any RUN
+        executor._baseline = snapshot_baseline(containerfile.PYTHON_INSTALL_PATHS)
+        # Simulate a SNAPSHOT directive having added this path
+        executor.snapshot_paths.append(simulated)
+
+        # Simulate a RUN command adding new files into the same dir
+        (Path(simulated) / "added_by_run.py").write_text("# new\n")
+        (Path(simulated) / "another.py").write_text("# also new\n")
+
+        snapshotted = executor._dedup_paths()
+
+        # The diff path should pick up ONLY the new files, not the existing one
+        names = {os.path.basename(p) for p in snapshotted}
+        self.assertIn("added_by_run.py", names)
+        self.assertIn("another.py", names)
+        self.assertNotIn("existing.py", names)
+        # And it should be a list of individual files (diff), not the whole dir
+        self.assertNotIn(simulated, snapshotted)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Bug

\`PYTHON_INSTALL_PATHS\` in \`scripts/containerfile.py\` listed only \`/usr/local/lib/python3.12/dist-packages\`. The container-layer skill runs on containers using **python3.11** (current default base) and older bases on 3.10 — so the diff-vs-baseline logic in \`_dedup_paths()\` silently fell through to the "explicit SNAPSHOT, capture whole tree" path.

Net effect: every \`SNAPSHOT /usr/local/lib/python3.11/dist-packages\` directive captured the **entire directory** instead of just newly-installed files.

## Empirical evidence

[oaustegard/claude-workspace-fuse](https://github.com/oaustegard/claude-workspace-fuse) session \`a921423e\`, on the "slim" cached layer (\`d426fa3b19dd3f6c\`, 678MB compressed):

| Path | Size |
|---|---|
| \`dist-packages/torch\` | 712M |
| \`dist-packages/modular\` | 944M |
| \`/root/.julia\` (separate SNAPSHOT) | 996M |

The Containerfile producing this layer didn't install any of those. They were in dist-packages from the prior cached layer, and the broken baseline plus the explicit \`SNAPSHOT /usr/local/lib/python3.11/dist-packages\` combined to capture everything.

## Fix

List all common Python versions in \`PYTHON_INSTALL_PATHS\`:

\`\`\`python
PYTHON_INSTALL_PATHS = [
    \"/usr/local/lib/python3.10/dist-packages\",
    \"/usr/local/lib/python3.11/dist-packages\",
    \"/usr/local/lib/python3.12/dist-packages\",
    \"/usr/local/lib/python3.13/dist-packages\",
    \"/usr/local/bin\",
    \"/home/claude/.local/lib\",
    \"/home/claude/.local/bin\",
]
\`\`\`

Module-level constant, no other code-path changes. \`snapshot_baseline()\` handles non-existent paths gracefully (returns empty set), so listing versions that aren't present on a given container is harmless.

## Tests

4 new tests in \`scripts/test_baseline_paths.py\`:
- \`test_python_3_10_through_3_13_dist_packages_present\` — coverage assertion
- \`test_local_bin_still_listed\` — existing entries preserved
- \`test_missing_path_in_baseline_keys\` — \`snapshot_baseline\` handles absent paths
- \`test_only_new_files_captured_in_baselined_dir\` — **regression test for the fix**, simulates the exact failure mode

\`\`\`
$ python3 -m scripts.test_baseline_paths
Ran 4 tests in 0.003s
OK
\`\`\`

Existing v0.2.0 tests still green (\`scripts/test_named_layers.py\`, 12 tests).

## Version bump

0.2.0 → 0.2.1 (patch — bug fix only, no API changes).

## Expected impact

Once this lands and downstream containers rebuild:
- Per-layer tarballs shrink to the actual delta (typically tens of MB per addon vs hundreds before).
- Composable layer architecture from #650 + [oaustegard/claude-workspace#82](https://github.com/oaustegard/claude-workspace/pull/82) finally pays off — \`layer-scientific-<hash>\` won't drag in torch, \`layer-torch-cpu-<hash>\` won't drag in modular, etc.