### PR TITLE
container-layer v0.2.2: baseline /usr/{bin,lib,share} for apt-install layers (closes #652)

### DIFF
--- a/container-layer/CHANGELOG.md
+++ b/container-layer/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `container-layer` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.2] - 2026-05-17
+
+### Fixed
+
+- `PYTHON_INSTALL_PATHS` now includes `/usr/bin`, `/usr/lib`, `/usr/share` so
+  apt-install layers get the diff-vs-baseline treatment instead of whole-tree
+  capture. `_exec_run` already auto-adds these three paths to `snapshot_paths`
+  when it sees `apt-get install`, but before this fix they weren't baselined,
+  so any layer with `apt-get install <one tiny package>` ballooned by ~600MB
+  compressed (the full `/usr/{bin,lib,share}` trees). Verified empirically
+  against the libfuse2 install in oaustegard/claude-workspace-fuse: layer
+  jumped from 940MB → 1625MB compressed. Closes oaustegard/claude-skills#652.
+
+### Notes
+
+- Despite the name, `PYTHON_INSTALL_PATHS` is no longer python-only. Kept the
+  name for backwards compatibility with any external importer; consider
+  renaming to `BASELINED_PATHS` in a future major bump.
+- `snapshot_baseline()` walks these dirs at build-time. `/usr/lib` is the
+  largest (~2GB raw) — adds a few seconds to baseline capture. Acceptable
+  for build-time; negligible vs. the layer-restore time it saves.
+
 ## [0.2.1] - 2026-05-17
 
 ### Other

--- a/container-layer/SKILL.md
+++ b/container-layer/SKILL.md
@@ -2,7 +2,7 @@
 name: container-layer
 description: Build and cache a personalized container environment from a Dockerfile-like spec. Supports both single-layer (one Containerfile -> one cached tarball) and multi-layer composition (compose [base, scientific, mojo, ...] into one container with each layer cached independently). Use when the user mentions "container layer", "Containerfile", "custom container", "environment setup", "cache my installs", "uv shim", "composable layers", or wants to persist package installations, skills, or environment config across ephemeral sessions. Also triggers when the user asks to snapshot, restore, or rebuild their environment, or wants to capture ad-hoc package installs into a reproducible spec.
 metadata:
-  version: 0.2.1
+  version: 0.2.2
 ---
 
 # Container Layer

--- a/container-layer/scripts/containerfile.py
+++ b/container-layer/scripts/containerfile.py
@@ -27,20 +27,34 @@ IGNORED_INSTRUCTIONS = {
     "STOPSIGNAL", "ONBUILD",
 }
 
-# Well-known paths that pip/uv install into.
-# Lists all common Python versions so the diff-vs-baseline logic correctly
-# identifies new files in dist-packages regardless of which interpreter is
-# active. The previous single-entry list hardcoded python3.12, so containers
-# on python3.11 fell through to the "explicit SNAPSHOT, capture whole tree"
-# code path — every layer ended up snapshotting all of dist-packages instead
-# of just the files it installed. Verified empirically against the python3.11
-# container in oaustegard/claude-workspace-fuse.
+# Well-known paths that pip/uv/apt install into.
+# `_dedup_paths` uses these as baseline keys so that auto-tracked snapshot
+# paths (from RUN commands) get the diff-vs-baseline treatment instead of
+# whole-tree capture.
+#
+# Lists all common Python versions so the diff logic works regardless of
+# which interpreter is active. The single-entry list pre-0.2.1 hardcoded
+# python3.12, so containers on python3.11 captured all of dist-packages
+# instead of just newly-installed files.
+#
+# /usr/{bin,lib,share} are here so `apt-get install` layers diff correctly
+# — `_exec_run` auto-adds these to snapshot_paths on any apt invocation
+# (one .deb pulls in shared libs / headers / docs sprawled across all
+# three). Pre-0.2.2 they fell into the whole-tree path: adding `zstd`
+# to a layer captured ~3GB raw → ~600MB compressed.
+#
+# Despite the name, this list is no longer Python-only. Kept the name for
+# backwards-compat with any external importer; consider renaming to
+# BASELINED_PATHS in a future major bump.
 PYTHON_INSTALL_PATHS = [
     "/usr/local/lib/python3.10/dist-packages",
     "/usr/local/lib/python3.11/dist-packages",
     "/usr/local/lib/python3.12/dist-packages",
     "/usr/local/lib/python3.13/dist-packages",
     "/usr/local/bin",
+    "/usr/bin",
+    "/usr/lib",
+    "/usr/share",
     "/home/claude/.local/lib",
     "/home/claude/.local/bin",
 ]

--- a/container-layer/scripts/test_baseline_paths.py
+++ b/container-layer/scripts/test_baseline_paths.py
@@ -39,6 +39,23 @@ class TestPythonInstallPathsCoverage(unittest.TestCase):
     def test_local_bin_still_listed(self):
         self.assertIn("/usr/local/bin", PYTHON_INSTALL_PATHS)
 
+    def test_system_apt_target_dirs_present(self):
+        """`_exec_run` auto-snapshots /usr/{bin,lib,share} on apt installs.
+        These must be in PYTHON_INSTALL_PATHS too, else the apt-install path
+        falls back to whole-tree capture (regression: 678MB layer ballooned
+        to 1625MB when a single libfuse2 apt-install fired the auto-snapshot
+        before these entries were added)."""
+        for p in ("/usr/bin", "/usr/lib", "/usr/share"):
+            self.assertIn(
+                p, PYTHON_INSTALL_PATHS,
+                f"missing {p} — apt-install layers will whole-tree-capture this dir",
+            )
+
+    def test_user_local_bin_present(self):
+        """Sanity: dot-local paths for non-root installs still listed."""
+        self.assertIn("/home/claude/.local/lib", PYTHON_INSTALL_PATHS)
+        self.assertIn("/home/claude/.local/bin", PYTHON_INSTALL_PATHS)
+
 
 class TestBaselineCapturesNonExistentPaths(unittest.TestCase):
     """snapshot_baseline returns an entry for every requested path, even


### PR DESCRIPTION
## Bug

`_exec_run` already auto-snapshots `/usr/{bin,lib,share}` when it sees `apt-get install`:

```python
if re.search(r'\bapt(-get)?\s+install\b', cmd):
    self.snapshot_paths.extend(["/usr/lib", "/usr/bin", "/usr/share"])
```

But pre-v0.2.2 those three paths weren't in `PYTHON_INSTALL_PATHS`. So in `_dedup_paths`:

```python
if p in baselined:
    # diff against baseline — small delta
else:
    # capture whole tree
```

`/usr/bin` etc. fell into the `else` branch → entire ~3GB raw / ~600MB compressed full trees got captured for every apt install, regardless of how small the package was.

## Empirical evidence

`oaustegard/claude-workspace-fuse` session `a921423e`: adding one `apt-get install libfuse2 fuse` (both packages already in base image, so functionally a no-op) jumped the cached "slim" layer from 940MB → 1625MB compressed. The diff was 100% `/usr/{bin,lib,share}` whole-tree contents.

Same risk in [oaustegard/claude-workspace#84](https://github.com/oaustegard/claude-workspace/pull/84) which added `apt-get install zstd` to `layers/Containerfile.scientific` — without this fix, scientific layer would balloon by ~600MB on next rebuild.

## Fix

Add `/usr/bin`, `/usr/lib`, `/usr/share` to `PYTHON_INSTALL_PATHS`. Now any apt-install layer gets correct delta-snapshotting via the existing diff logic.

## Tests

`scripts/test_baseline_paths.py` gains two tests:
- `test_system_apt_target_dirs_present` — locks in the three new entries with a comment pointing at the regression
- `test_user_local_bin_present` — sanity guard on the `/home/claude/.local` paths

All 6 baseline + 12 named-layers tests pass:
```
$ python3 -m scripts.test_baseline_paths && python3 -m scripts.test_named_layers
Ran 6 tests in 0.748s OK
Ran 12 tests in 0.003s OK
```

## Notes

- **Name is now misleading.** Despite `PYTHON_INSTALL_PATHS`, the list covers system paths too. Kept the name to avoid breaking external importers; a `BASELINED_PATHS` rename can land in a future major bump if anyone cares. Documented in the inline comment.
- **Build-time cost.** `snapshot_baseline()` walks each baselined dir. `/usr/lib` is the biggest (~2GB raw) — adds a few seconds to baseline capture. Negligible vs. the layer-restore time it saves; acceptable for build-time.
- Closes #652.