### PR TITLE
composing-html: --set escape hatch for body_html (fix multi-line JSON failure mode)

### DIFF
--- a/composing-html/CHANGELOG.md
+++ b/composing-html/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `composing-html` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-05-19
+
+### Added
+
+- `build.py build` now accepts `--set KEY=VALUE` and `--set KEY=@FILE` to
+  assign or override spec fields from the command line. `@FILE` loads the
+  file contents verbatim into the field, sidestepping JSON-string escaping
+  for multi-line HTML / CSS / JS bodies. `--spec` is now optional when
+  `--set` supplies every required field. `--set` overrides matching fields
+  from `--spec`.
+- Tests cover the new `--set` paths (inline values, file loads, override
+  semantics, bad syntax, missing files) and end-to-end CLI invocation.
+
+### Changed
+
+- SKILL.md reframes the freeform workflow around `--set body_html=@body.html`
+  as the recommended path for anything with a substantial body — the prior
+  "write spec.json" instruction was prone to producing invalid JSON when
+  models inlined multi-line HTML via heredoc. The spec-file path is now
+  positioned as best-fit for templates with typed slots, where JSON earns
+  its keep.
+
 ## [0.2.0] - 2026-05-09
 
 ### Other

--- a/composing-html/README.md
+++ b/composing-html/README.md
@@ -10,6 +10,8 @@ Thariq Shihipar's [*The Unreasonable Effectiveness of HTML*](https://claude.com/
 
 The worry near the end of that piece is real, though: ask an agent for HTML and you tend to get either tasteful but generic Claude-aesthetic boilerplate, or an over-engineered SPA. This skill is the narrow defense — a fixed, opinionated chrome (typography, color tokens, layout primitives, base interactions) so the agent spends its output budget on the *content*, not on re-deriving what a card or a badge looks like for the hundredth time.
 
+For the longer rationale, see *[The unreasonable effectiveness of HTML, and the skill that tries not to ruin it](https://muninn.austegard.com/blog/the-unreasonable-effectiveness-of-html-and-the-skill-that-tries-not-to-ruin-it.html)* on muninn.austegard.com.
+
 See [`SKILL.md`](SKILL.md) for the full inventory and workflow. See [`CHANGELOG.md`](CHANGELOG.md) for version history.
 
 ## Two workflows

--- a/composing-html/README.md
+++ b/composing-html/README.md
@@ -1,0 +1,89 @@
+# composing-html
+
+Compose single-file HTML artifacts without hand-writing page chrome. The composer supplies `<!DOCTYPE>`, `<head>`, inlined CSS, `base.js`, design tokens, masthead, and colophon. You supply the body.
+
+The artifact is one file, no CDN, no build step, no server — the agent hands it over and it just opens.
+
+## Inspiration
+
+Thariq Shihipar's [*The Unreasonable Effectiveness of HTML*](https://claude.com/blog/using-claude-code-the-unreasonable-effectiveness-of-html) on the Anthropic blog argues HTML is the better artifact format than markdown for agent output: it carries tables, CSS, SVG, embedded code, live interactions, spatial layout, and images, and a single file is shareable and interactive in ways a markdown plan isn't. People will open and read an HTML file they wouldn't read as a hundred-line markdown plan.
+
+The worry near the end of that piece is real, though: ask an agent for HTML and you tend to get either tasteful but generic Claude-aesthetic boilerplate, or an over-engineered SPA. This skill is the narrow defense — a fixed, opinionated chrome (typography, color tokens, layout primitives, base interactions) so the agent spends its output budget on the *content*, not on re-deriving what a card or a badge looks like for the hundredth time.
+
+See [`SKILL.md`](SKILL.md) for the full inventory and workflow. See [`CHANGELOG.md`](CHANGELOG.md) for version history.
+
+## Two workflows
+
+### freeform — the default
+
+Most artifacts. One slot — `body_html` — for the page body. Use `--set body_html=@body.html` so multi-line HTML, quotes, and `&`/`<` characters don't fight JSON-string escaping:
+
+```sh
+python scripts/build.py build freeform \
+  --set title='My Page' \
+  --set body_html=@body.html \
+  --out artifact.html
+```
+
+`--set KEY=VALUE` assigns a literal string; `--set KEY=@FILE` loads file contents verbatim. Repeatable across all spec fields.
+
+### templates — when the shape repeats
+
+Twenty-one templates for recurring artifact shapes: PR reviews, status reports, incident postmortems, slide decks, design systems, flowcharts, kanban boards, prompt tuners, and more. Each has typed slots the template reasons over (`pr_review.findings[].severity`, `slide_deck.slides[].kind`).
+
+```sh
+python scripts/build.py list                                   # all templates
+python scripts/build.py describe pr_review                     # required keys + JSON skeleton
+python scripts/build.py build pr_review --spec spec.json --out review.html
+```
+
+Reach for a template only when the same artifact shape recurs across artifacts (same status report week after week, PR reviews across many PRs). For one-offs, `freeform` is less friction.
+
+## What you get for free
+
+| Layer | What it covers |
+|---|---|
+| **Tokens** | Color (`--clay`, `--slate`, `--ivory`, `--ok/warn/err/info`, gray ramp), typography (`--serif`, `--sans`, `--mono`), geometry (radii, borders, shadows) |
+| **Layout** | `.page` / `.page--wide` / `.page--narrow`, `.grid--2|3|4`, `.stack`, `.row`, `.card`, `.rule` |
+| **Components** | `.eyebrow`, `.badge--{ok,warn,err,info,clay}`, `.kbd`, `.bullets`, styled `<code>` / `<pre><code>` / `<details>` |
+| **Interactions** | Tabs, drag-to-reorder (with cross-zone drops), live parameter bindings (`--bind-*` CSS variables driven by `<input>` + `data-bind`), auto copy buttons on every code block |
+| **Chrome** | DOCTYPE, head, masthead (`eyebrow` + `<h1>` + subtitle), inlined CSS + JS, colophon |
+
+Everything is inlined into the output file. Nothing fetches at view time.
+
+## When to reach for it
+
+- "Compare options side-by-side" → `exploration.comparison_grid`
+- HTML version of a report or review → `report.status_report` or `review.pr_review`
+- "Make me a deck" → `deck.slide_deck` (arrow-key + space navigation)
+- Flowchart, module map, design system reference → `diagram.*`, `review.module_map`, `design.design_system`
+- Prototype with live-tunable parameters → `prototype.animation_sandbox`
+- "An HTML artifact" / "a single self-contained HTML file" → `freeform`
+
+## When to skip
+
+Ad-hoc HTML snippets that don't need page chrome — forms emailed inline, widgets embedded in someone else's page, three-line examples in a chat reply. The skill is the chrome; if you don't need the chrome, you don't need the skill.
+
+## Pitfall to avoid
+
+Inlining multi-line HTML into a JSON heredoc:
+
+```sh
+# ❌ This produces invalid JSON — strings can't contain raw newlines or unescaped quotes
+cat > spec.json <<EOF
+{ "body_html": "<section>
+  <h2>Multi-line</h2>
+</section>" }
+EOF
+```
+
+Use `--set body_html=@body.html` instead, or assemble the spec in Python with `json.dump(spec, f)` so escaping is automatic.
+
+## Tests
+
+```sh
+python tests/test_smoke.py            # no pytest required
+python -m pytest tests -q             # with pytest
+```
+
+Covers every template with a representative spec plus explicit security regressions (HTML escaping, script-tag breakout, attribute injection, CSS-color injection, spec mutation) and the `--set` CLI paths.

--- a/composing-html/SKILL.md
+++ b/composing-html/SKILL.md
@@ -2,7 +2,7 @@
 name: composing-html
 description: Composes single-file HTML artifacts (PR review writeups, status reports, incident postmortems, slide decks, design systems, prototypes, flowcharts, module maps, feature explainers, kanban boards, prompt tuners) from a small JSON spec instead of hand-written HTML/CSS/JS. Use when the user asks to "compare options side-by-side", requests an HTML version of a report or review or deck, asks for a flowchart, status update, postmortem, design system reference, interactive prototype, custom editor — or explicitly says "HTML artifact", "single HTML file", "self-contained HTML". Skip for ad-hoc HTML snippets (forms, emails, embedded widgets) where there's no template fit.
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # composing-html
@@ -19,15 +19,57 @@ near the end.
 
 ## Default workflow: freeform
 
+`freeform` gives you the whole chrome with one content slot — `body_html` —
+for the page body. Reach for it first. Reach for a template only when the
+structure repeats across artifacts (see [Templates](#templates-shortcuts-for-repeat-structure)
+near the end).
+
+There are two ways to invoke it. **Use the `--set` flow for anything with a
+substantial body** — it sidesteps the JSON-string escaping that bites
+heredoc-style spec writing (newlines, quotes, `<`/`&` inside multi-line
+HTML).
+
+### Recommended: HTML in a file, metadata via `--set`
+
 ```
-1. python scripts/build.py describe freeform     # see the body_html slot
-2. write spec.json with body_html: "<your HTML using the inventory below>"
-3. python scripts/build.py build freeform --spec spec.json --out artifact.html
+1. Write the body to a .html file directly (no JSON, no escaping).
+2. python scripts/build.py build freeform \
+       --set title='My Page' \
+       --set subtitle='Optional subhead' \
+       --set body_html=@body.html \
+       --out artifact.html
 ```
 
-`freeform` gives you the whole chrome with one slot — `body_html` — for the
-content you actually care about. Reach for it first. Reach for a template
-only when the structure repeats across artifacts (see below).
+`--set KEY=VALUE` assigns a literal string; `--set KEY=@FILE` loads the file
+contents verbatim into that spec field. Repeat for any field. Works for
+`body_html`, `extra_css`, `extra_js`, `eyebrow`, `page_class`, and the same
+`*_html` fields in any other template (`summary_html`, `intro_html`,
+`details_html`, …).
+
+### Spec-file workflow (best for structured templates)
+
+```
+1. python scripts/build.py describe <template>     # required keys + skeleton
+2. write spec.json
+3. python scripts/build.py build <template> --spec spec.json --out artifact.html
+```
+
+For templates with typed slots (`pr_review.findings[]`, `slide_deck.slides[]`,
+`status_report.metrics[]`), the spec file is the right shape — the template
+reasons over the structure. For `freeform`, the spec is mostly a thin config
+wrapper around one HTML string; the `--set` flow above is usually less
+friction.
+
+You can mix both: small `spec.json` for metadata, `--set body_html=@body.html`
+for the heavy bit. `--set` overrides any matching field from `--spec`.
+
+### Pitfall: don't inline multi-line HTML into a JSON heredoc
+
+`cat > spec.json <<EOF { "body_html": "<multi\nline>\n..." } EOF` does not
+produce valid JSON — JSON strings can't contain raw newlines or unescaped
+quotes. Either:
+- use `--set body_html=@body.html` (recommended), or
+- assemble the spec in Python with `json.dump(spec, f)` so escaping is automatic.
 
 ## Inventory
 
@@ -171,6 +213,11 @@ Otherwise: `freeform`.
 `describe` prints a valid-JSON starter skeleton you can edit in place. For
 worked examples, see `references/templates.md` — but only after picking a
 template; reading it cold wastes context.
+
+For templates with prose-heavy `*_html` slots (e.g. `summary_html`,
+`intro_html`, `details_html`), the same `--set KEY=@FILE` mechanism from the
+freeform workflow applies — load the prose from a `.html` file rather than
+escaping it into the JSON spec.
 
 There are 21 templates, grouped into 9 categories plus `freeform`:
 

--- a/composing-html/scripts/build.py
+++ b/composing-html/scripts/build.py
@@ -5,12 +5,20 @@ Usage
 -----
   build.py list                                     # all templates, one line each
   build.py describe <template>                      # parameter reference for one template
-  build.py build <template> [--spec FILE|-] [--out FILE]
-                                                    # render HTML; spec from FILE or stdin
+  build.py build <template> [--spec FILE|-] [--set K=V ...] [--out FILE]
+                                                    # render HTML; spec from FILE, stdin,
+                                                    # and/or --set overrides
 
 The "build" command reads a JSON spec, runs it through the named template's
 builder, and emits a single self-contained HTML document. With no --out, the
 result is written to stdout.
+
+--set lets you supply or override a spec field from the command line, including
+loading the value from a file via the @PATH suffix:
+
+  build.py build freeform --set title='My Page' --set body_html=@body.html --out out.html
+
+This sidesteps JSON-string escaping for multi-line HTML/CSS/JS bodies.
 
 Templates live in scripts/templates/. Each module registers via the @register
 decorator. See SKILL.md for the workflow.
@@ -94,23 +102,75 @@ def cmd_describe(args) -> int:
     return 0
 
 
+def _apply_set(spec: dict, set_args: list[str]) -> int:
+    """Mutate spec from --set KEY=VALUE / KEY=@FILE entries.
+
+    Escape hatch for fields whose content fights JSON-string escaping
+    (multi-line HTML, CSS, JS). Lets the caller keep the spec lean and
+    point at raw files for the heavy bits.
+
+    Syntax:
+      --set body_html=@body.html        # spec['body_html'] = file contents
+      --set title='My Page'             # spec['title']     = 'My Page'
+
+    Returns 0 on success, 2 on error.
+    """
+    for entry in set_args or []:
+        if "=" not in entry:
+            print(f"--set expects KEY=VALUE or KEY=@FILE, got: {entry!r}", file=sys.stderr)
+            return 2
+        key, _, val = entry.partition("=")
+        key = key.strip()
+        if not key:
+            print(f"--set missing key in: {entry!r}", file=sys.stderr)
+            return 2
+        if val.startswith("@"):
+            path = val[1:]
+            if not path:
+                print(f"--set {key}=@ requires a file path", file=sys.stderr)
+                return 2
+            try:
+                spec[key] = Path(path).read_text(encoding="utf-8")
+            except OSError as e:
+                print(f"--set {key}=@{path}: {e}", file=sys.stderr)
+                return 2
+        else:
+            spec[key] = val
+    return 0
+
+
 def cmd_build(args) -> int:
     name = args.template
     if name not in REGISTRY:
         print(f"unknown template: {name}", file=sys.stderr)
         return 2
 
-    if args.spec == "-" or not args.spec:
-        raw = sys.stdin.read()
+    # Spec is optional when every required field can be supplied via --set.
+    if args.spec == "-":
+        raw_text = sys.stdin.read()
+    elif args.spec:
+        raw_text = Path(args.spec).read_text(encoding="utf-8")
     else:
-        raw = Path(args.spec).read_text(encoding="utf-8")
-    if not raw.strip():
-        print("empty spec", file=sys.stderr)
-        return 2
-    try:
-        spec = json.loads(raw)
-    except json.JSONDecodeError as e:
-        print(f"spec is not valid JSON: {e}", file=sys.stderr)
+        raw_text = ""
+
+    if raw_text.strip():
+        try:
+            spec = json.loads(raw_text)
+        except json.JSONDecodeError as e:
+            print(f"spec is not valid JSON: {e}", file=sys.stderr)
+            return 2
+        if not isinstance(spec, dict):
+            print("spec must be a JSON object (dict)", file=sys.stderr)
+            return 2
+    else:
+        spec = {}
+
+    rc = _apply_set(spec, args.set or [])
+    if rc != 0:
+        return rc
+
+    if not spec:
+        print("empty spec (no --spec content and no --set entries)", file=sys.stderr)
         return 2
 
     builder = REGISTRY[name]["build"]
@@ -140,7 +200,15 @@ def main(argv: list[str] | None = None) -> int:
 
     pb = sub.add_parser("build", help="Render a template using the given spec.")
     pb.add_argument("template")
-    pb.add_argument("--spec", "-s", default="-", help="Path to JSON spec, or '-' for stdin (default).")
+    pb.add_argument("--spec", "-s", default=None,
+                    help="Path to JSON spec, or '-' for stdin. Optional if every "
+                         "required field is supplied via --set.")
+    pb.add_argument("--set", action="append", default=[],
+                    metavar="KEY=VALUE",
+                    help="Set or override a spec field. 'KEY=VALUE' assigns the "
+                         "literal string; 'KEY=@FILE' loads the file contents. "
+                         "Repeatable. Avoids JSON-string escaping for multi-line "
+                         "HTML/CSS/JS (e.g. --set body_html=@body.html).")
     pb.add_argument("--out", "-o", default=None, help="Write HTML to this file (default: stdout).")
     pb.set_defaults(fn=cmd_build)
 

--- a/composing-html/tests/test_smoke.py
+++ b/composing-html/tests/test_smoke.py
@@ -324,6 +324,124 @@ def test_describe_emits_valid_json():
 
 
 # --------------------------------------------------------------------------- #
+# --set CLI override behavior                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_apply_set_inline_value():
+    from build import _apply_set
+    spec = {}
+    rc = _apply_set(spec, ["title=Hello", "subtitle=World"])
+    assert rc == 0
+    assert spec == {"title": "Hello", "subtitle": "World"}
+
+
+def test_apply_set_preserves_equals_in_value():
+    """KEY=VALUE uses str.partition('='), so '=' inside the value survives."""
+    from build import _apply_set
+    spec = {}
+    rc = _apply_set(spec, ["extra_css=.x { content: 'a=b'; }"])
+    assert rc == 0
+    assert spec["extra_css"] == ".x { content: 'a=b'; }"
+
+
+def test_apply_set_loads_file_with_at_prefix():
+    """KEY=@FILE loads the file's raw contents — newlines, quotes, all OK."""
+    import tempfile
+    from build import _apply_set
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "body.html"
+        body = '<section>\n  "multi-line" & <em>special</em> content\n</section>'
+        p.write_text(body, encoding="utf-8")
+        spec = {}
+        rc = _apply_set(spec, [f"body_html=@{p}"])
+        assert rc == 0
+        assert spec["body_html"] == body
+        # The whole point: content can include newlines and quotes that
+        # would otherwise need careful JSON-string escaping.
+        assert "\n" in spec["body_html"]
+        assert '"' in spec["body_html"]
+
+
+def test_apply_set_overrides_existing_field():
+    from build import _apply_set
+    spec = {"title": "from-json", "extra_css": "/* old */"}
+    rc = _apply_set(spec, ["title=from-set"])
+    assert rc == 0
+    assert spec == {"title": "from-set", "extra_css": "/* old */"}
+
+
+def test_apply_set_rejects_bad_syntax():
+    from build import _apply_set
+    spec = {}
+    rc = _apply_set(spec, ["no_equals_sign"])
+    assert rc == 2
+    rc = _apply_set({}, ["=missing-key"])
+    assert rc == 2
+
+
+def test_apply_set_rejects_missing_file():
+    from build import _apply_set
+    spec = {}
+    rc = _apply_set(spec, ["body_html=@/tmp/definitely-does-not-exist-xyz.html"])
+    assert rc == 2
+
+
+def test_cli_build_with_only_set_and_no_spec():
+    """End-to-end: --set alone (no --spec) renders a valid page."""
+    import subprocess
+    import tempfile
+    cli = ROOT / "scripts" / "build.py"
+    with tempfile.TemporaryDirectory() as td:
+        body = Path(td) / "body.html"
+        body.write_text(
+            '<section><h2>Multi-line</h2>\n<p>Has "quotes" & <em>tags</em>.</p></section>',
+            encoding="utf-8",
+        )
+        out = Path(td) / "out.html"
+        result = subprocess.run(
+            [sys.executable, str(cli), "build", "freeform",
+             "--set", "title=No-spec demo",
+             "--set", f"body_html=@{body}",
+             "--out", str(out)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"CLI failed: {result.stderr}"
+        rendered = out.read_text(encoding="utf-8")
+        assert "<!doctype html>" in rendered.lower()
+        assert "Multi-line" in rendered
+        assert '"quotes"' in rendered
+        assert "No-spec demo" in rendered  # title made it through
+
+
+def test_cli_build_set_overrides_spec_file():
+    """When --spec and --set both supply the same key, --set wins."""
+    import subprocess
+    import tempfile
+    cli = ROOT / "scripts" / "build.py"
+    with tempfile.TemporaryDirectory() as td:
+        spec = Path(td) / "spec.json"
+        spec.write_text(
+            json.dumps({"title": "from-spec", "body_html": "<p>spec body</p>"}),
+            encoding="utf-8",
+        )
+        body = Path(td) / "body.html"
+        body.write_text("<p>set body wins</p>", encoding="utf-8")
+        out = Path(td) / "out.html"
+        result = subprocess.run(
+            [sys.executable, str(cli), "build", "freeform",
+             "--spec", str(spec),
+             "--set", f"body_html=@{body}",
+             "--out", str(out)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"CLI failed: {result.stderr}"
+        rendered = out.read_text(encoding="utf-8")
+        assert "set body wins" in rendered
+        assert "spec body" not in rendered
+        assert "from-spec" in rendered  # title from spec was kept
+
+
+# --------------------------------------------------------------------------- #
 # direct entrypoint                                                           #
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
*Filed by Muninn*

## Problem

When Sonnet (or any model) reaches for the `freeform` template, the natural next move is `cat > spec.json <<EOF { ... "body_html": "<multi-line HTML> ..." } EOF`. That produces invalid JSON — JSON strings can't contain raw newlines or unescaped quotes — and the first build fails. The transcript Oskar sent shows Sonnet falling into exactly this trap and eventually routing around it by writing a Python script to call `json.dump`.

Sonnet's follow-up question was sharper: for `freeform` specifically, what does the JSON wrapper buy us? The body is just one string field plus a handful of config keys, and we pay all the JSON-escape overhead for none of the structural benefits JSON gives the other 20 templates.

## Fix

Two complementary changes:

**1. `build.py` — `--set KEY=VALUE | KEY=@FILE` flag.**
- `--set title='My Page'` assigns a literal string.
- `--set body_html=@body.html` loads the file contents verbatim into the field.
- Repeatable. Sidesteps JSON-string escaping entirely.
- `--spec` is now optional when `--set` supplies every required field.
- `--set` overrides matching fields from `--spec`, so mixed mode (small JSON spec for metadata, `--set body_html=@body.html` for the heavy bit) works.

**2. `SKILL.md` — lead with the `--set` workflow.**
- Recommended path: write `body.html` directly, pass metadata via `--set`. No escaping concerns.
- Spec-file path repositioned as best-fit for templates with typed slots (`pr_review.findings[]`, `slide_deck.slides[]`, etc.) where JSON earns its keep.
- Explicit pitfall section calling out the multi-line-HTML-in-JSON-heredoc trap, with the recommended fix.
- `--set KEY=@FILE` documented as applying to any `*_html` slot in any template (`summary_html`, `intro_html`, `details_html`, …).

## Tests

22/22 passing (14 existing + 8 new). New tests cover:
- Inline `--set KEY=VALUE` assignment
- `=` inside the value survives (`partition('=')`)
- `KEY=@FILE` file loading with newlines + quotes
- `--set` overriding existing spec fields
- Bad syntax rejected (`rc=2`)
- Missing file rejected (`rc=2`)
- End-to-end CLI: build with only `--set` (no `--spec`)
- End-to-end CLI: `--set` overrides matching `--spec` field

## Compat

`--set` is purely additive. Old workflow (`build.py build freeform --spec spec.json --out out.html`) is unchanged. Stdin via `--spec -` still works. The only nominal behavior change: omitting both `--spec` and `--set` now errors with `empty spec (no --spec content and no --set entries)` instead of `empty spec` — clearer message, same exit code.

## Version bump

0.2.0 → 0.3.0.
