### PR TITLE
bm25 v0.1.1: use uv pip for install

### DIFF
--- a/bm25/CHANGELOG.md
+++ b/bm25/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 — 2026-05-18
+
+Setup uses `uv pip install --system --break-system-packages bm25s` instead of plain pip. Matches the convention across sibling skills (tree-sitting, container-layer, etc.); sub-second install on a warm uv cache. Updated SKILL.md, README, and the script's missing-dependency error message accordingly. No behavior change.
+
 ## 0.1.0 — 2026-05-18
 
 Initial release. Stateless BM25 search wrapper around xhluca/bm25s.

--- a/bm25/README.md
+++ b/bm25/README.md
@@ -8,7 +8,7 @@ See `SKILL.md` for the full reference.
 ## Quick start
 
 ```bash
-pip install bm25s --break-system-packages
+uv pip install --system --break-system-packages bm25s
 
 BM25=/mnt/skills/user/bm25/scripts/bm25.py
 

--- a/bm25/SKILL.md
+++ b/bm25/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   "search this corpus", "find content about X", "which files are most about
   Y", or multi-word concept queries against a known body of text.
 metadata:
-  version: 0.1.0
+  version: 0.1.1
 ---
 
 # bm25
@@ -21,10 +21,10 @@ invocation, no persistence.
 ## Setup
 
 ```bash
-pip install bm25s --break-system-packages
+uv pip install --system --break-system-packages bm25s
 ```
 
-That's the entire dependency.
+Install is sub-second on a warm uv cache. That's the entire dependency.
 
 ## Usage
 

--- a/bm25/scripts/bm25.py
+++ b/bm25/scripts/bm25.py
@@ -35,7 +35,7 @@ from pathlib import Path
 try:
     import bm25s
 except ImportError:
-    sys.stderr.write("bm25s not installed. Run: pip install bm25s --break-system-packages\n")
+    sys.stderr.write("bm25s not installed. Run: uv pip install --system --break-system-packages bm25s\n")
     sys.exit(2)
 
 


### PR DESCRIPTION
Switches the bm25 skill from `pip install bm25s --break-system-packages` to `uv pip install --system --break-system-packages bm25s`, matching the convention used across sibling skills (tree-sitting, container-layer, coding-mojo, etc.). uv is sub-second on a warm cache.

Touched:
- `bm25/SKILL.md` — Setup section; version bumped 0.1.0 → 0.1.1
- `bm25/README.md` — quick-start
- `bm25/scripts/bm25.py` — missing-dependency stderr message
- `bm25/CHANGELOG.md` — 0.1.1 entry

No behavior change. AST parse + Django smoke test (1962 files, 1.4s build, ranked queries) both green after the edit.