### PR TITLE
bm25 v0.1.2: session-local disk cache

### DIFF
--- a/bm25/CHANGELOG.md
+++ b/bm25/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2 — 2026-05-18
+
+Added a session-local disk cache at `/home/claude/.bm25-cache/<key>/`. Across `bash_tool` invocations the in-memory retriever evaporates at process exit, so repeat queries against the same corpus would otherwise rebuild from scratch. The cache key hashes the resolved corpus path plus the include/exclude globs plus max-file-bytes, so any input change invalidates naturally. Verified on Django (1,962 files): 1.5s rebuild → 40ms load. `--no-cache` bypasses both load and save for the rare "I mutated the corpus mid-session" case.
+
+The cache lives in `/home/claude/`, which is ephemeral, so it expires at the session boundary — same lifetime as the corpus state itself, no cross-session staleness problem.
+
 ## 0.1.1 — 2026-05-18
 
 Setup uses `uv pip install --system --break-system-packages bm25s` instead of plain pip. Matches the convention across sibling skills (tree-sitting, container-layer, etc.); sub-second install on a warm uv cache. Updated SKILL.md, README, and the script's missing-dependency error message accordingly. No behavior change.

--- a/bm25/README.md
+++ b/bm25/README.md
@@ -17,13 +17,17 @@ python3 $BM25 'github.com/django/django' 'atomic transaction'
 python3 $BM25 project 'RAG scaling laws'
 ```
 
-## Why stateless
+## Caching
 
-Index builds are fast — Django (2,909 .py files) indexes in ~8 seconds,
-small repos in well under a second. Caching the index would cost more in
-invalidation logic than it saves. Within a single invocation, the index
-is held in memory, so passing multiple queries on the command line (or
-using `--interactive`) amortizes the build cost across queries.
+The skill maintains a session-local cache at `/home/claude/.bm25-cache/<key>/`.
+The key hashes the inputs that determine the index (resolved corpus path,
+include/exclude globs, max file size), so any change naturally invalidates.
+First invocation against a corpus builds and saves; subsequent invocations
+load in ~50ms instead of rebuilding in seconds.
+
+`/home/claude/` is ephemeral, so the cache and the rest of the session
+state expire together — no cross-session invalidation problem. Use
+`--no-cache` to bypass if you've mutated the corpus mid-session.
 
 ## Pairing with other skills
 

--- a/bm25/SKILL.md
+++ b/bm25/SKILL.md
@@ -10,13 +10,14 @@ description: >-
   "search this corpus", "find content about X", "which files are most about
   Y", or multi-word concept queries against a known body of text.
 metadata:
-  version: 0.1.1
+  version: 0.1.2
 ---
 
 # bm25
 
-Ranked content search over any text corpus. One CLI, one in-memory index per
-invocation, no persistence.
+Ranked content search over any text corpus. One CLI, in-memory BM25 index
+per process, with a session-local disk cache so repeat invocations against
+the same corpus load in tens of milliseconds instead of rebuilding.
 
 ## Setup
 
@@ -77,6 +78,7 @@ python3 $BM25 ./repo 'auth flow' --json
 | `--json` | | Machine-readable output |
 | `--interactive` / `-i` | | REPL mode for ad-hoc querying within one session |
 | `--stats` | | Print discover + index timings as JSON |
+| `--no-cache` | | Bypass the session-local index cache; build in-memory only |
 
 With no `--include`, a default set of text/code extensions is indexed (Python,
 JS/TS, Go, Rust, Markdown, JSON, YAML, etc.). Standard noise dirs are skipped
@@ -102,12 +104,19 @@ you specifically want BM25's length-normalized scoring.
 
 ## Design notes
 
-- **Stateless by design.** Every call rebuilds. Build is fast enough
-  (Django, 2,909 files: ~8s; bm25s itself, 85 files: <1s) that caching
-  costs more in invalidation tax than it saves.
-- **Reuse within a session.** The retriever stays in memory between queries
-  in one invocation. Pass multiple queries positionally, or use
-  `--interactive`, to amortize the index build across queries.
+- **Session-local disk cache** at `/home/claude/.bm25-cache/<key>/`. The
+  key is a hash of `(resolved_corpus_path, include_globs, exclude_globs,
+  max_file_bytes)` — any change invalidates naturally. First invocation
+  builds and saves; subsequent invocations against the same corpus and
+  filters load in tens of milliseconds. The cache lives in `/home/claude`,
+  which is ephemeral, so it expires at the session boundary — same
+  lifetime as the corpus state itself, no cross-session staleness.
+  ~5–35MB per cached index, depending on corpus size.
+- **`--no-cache`** bypasses both load and save — useful only if you've
+  mutated the corpus mid-session (rare) or want to confirm a rebuild matches.
+- **Reuse within a single invocation.** The retriever stays in memory
+  between queries in one process. Passing multiple queries positionally,
+  or using `--interactive`, amortizes any rebuild cost across queries.
 - **No AST awareness.** Chunking is per-file. For symbol-level results in
   code, combine with `tree-sitting` queries on the same paths.
 - **Tokenizer.** Default `bm25s.tokenize` with stopwords disabled — over a
@@ -135,11 +144,19 @@ QUERY: csrf middleware
 ```
 bm25.py CLI
   ├── resolve_corpus(spec)         → local Path (downloads tarball if github.com/...)
-  ├── discover_files(root, filters) → iterates (relpath, text)
-  ├── CorpusIndex                  → bm25s.BM25.index() over docs
+  ├── cache_key(...)               → 16-hex sha256 of inputs that determine the index
+  ├── CorpusIndex.load(cache_dir)  → returns cached index if present, else None
+  ├── CorpusIndex.build(...)       → walks files, tokenizes, indexes with bm25s
+  ├── CorpusIndex.save(cache_dir)  → persists to /home/claude/.bm25-cache/<key>/
   ├── query(q, k)                  → ranked (doc_idx, score) pairs
   └── best_snippet(doc, q, lines)  → pick line w/ most query-term hits + context
 ```
 
-No state outside the process. No files written. No network beyond optional
-tarball fetch on `github.com/...` corpora.
+Cache contents per directory:
+- `bm25/` — bm25s.BM25.save() output (NumPy arrays + vocab)
+- `corpus.pkl` — pickled `{paths, docs}` so we can render snippets without
+  re-reading the source files
+- `manifest.json` — corpus root, files count, built_at timestamp
+
+No network beyond optional tarball fetch on `github.com/...` corpora. No
+state outside `/home/claude/`, which is ephemeral.

--- a/bm25/scripts/bm25.py
+++ b/bm25/scripts/bm25.py
@@ -22,14 +22,17 @@ Examples:
 """
 import argparse
 import fnmatch
+import hashlib
 import json
 import os
+import pickle
 import re
 import sys
 import tarfile
 import tempfile
 import time
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 try:
@@ -131,28 +134,112 @@ def resolve_corpus(spec: str) -> Path:
 
 # ---------- index ----------
 
-class CorpusIndex:
-    """In-memory BM25 index over a corpus. Stateless across invocations."""
+CACHE_ROOT = Path('/home/claude/.bm25-cache')
 
-    def __init__(self, corpus_root: Path, include, exclude, max_bytes=2_000_000):
-        self.root = corpus_root
-        self.paths = []      # parallel to docs
-        self.docs = []
+
+def cache_key(corpus_root: Path, include, exclude, max_bytes: int) -> str:
+    """Stable 16-hex hash of the inputs that fully determine an index.
+
+    Same key → identical index. Changing any of: corpus root path,
+    include/exclude globs, or max_bytes → new key → cache miss → rebuild.
+    """
+    h = hashlib.sha256()
+    h.update(str(corpus_root.resolve()).encode())
+    h.update(b'|')
+    h.update(','.join(sorted(include)).encode())
+    h.update(b'|')
+    h.update(','.join(sorted(exclude)).encode())
+    h.update(b'|')
+    h.update(str(max_bytes).encode())
+    return h.hexdigest()[:16]
+
+
+class CorpusIndex:
+    """In-memory BM25 index over a corpus. Optional session-local disk cache.
+
+    The cache lives at /home/claude/.bm25-cache/<key>/ which is ephemeral
+    (dies with the container session). The key is a hash of the index-
+    determining inputs (corpus path + filters + size cap), so changing any
+    of those naturally invalidates. Same key + same session → load in
+    ~100–300ms instead of rebuilding in seconds.
+    """
+
+    def __init__(self, root: Path, paths, docs, retriever, build_s: float, source: str):
+        self.root = root
+        self.paths = paths
+        self.docs = docs
+        self.retriever = retriever
+        self.build_s = build_s
+        self.source = source  # 'built' or 'cache'
+
+    @classmethod
+    def build(cls, corpus_root: Path, include, exclude, max_bytes: int):
+        """Walk the corpus, tokenize, index. Returns a new CorpusIndex."""
         t0 = time.time()
+        paths, docs = [], []
         for rel, text in discover_files(corpus_root, include, exclude, max_bytes):
-            self.paths.append(rel)
-            self.docs.append(text)
-        self.discover_s = time.time() - t0
-        t0 = time.time()
-        tokens = bm25s.tokenize(self.docs, stopwords=None, show_progress=False)
-        self.retriever = bm25s.BM25()
-        self.retriever.index(tokens, show_progress=False)
-        self.index_s = time.time() - t0
+            paths.append(rel)
+            docs.append(text)
+        tokens = bm25s.tokenize(docs, stopwords=None, show_progress=False)
+        retriever = bm25s.BM25()
+        retriever.index(tokens, show_progress=False)
+        return cls(corpus_root, paths, docs, retriever, time.time() - t0, source='built')
+
+    def save(self, cache_dir: Path):
+        """Persist to disk so the next invocation can load instead of rebuild."""
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        self.retriever.save(str(cache_dir / 'bm25'))
+        with open(cache_dir / 'corpus.pkl', 'wb') as f:
+            pickle.dump({'paths': self.paths, 'docs': self.docs}, f)
+        with open(cache_dir / 'manifest.json', 'w') as f:
+            json.dump({
+                'corpus_root': str(self.root),
+                'files_count': len(self.paths),
+                'built_at': datetime.now(timezone.utc).isoformat(),
+                'build_s': round(self.build_s, 3),
+            }, f, indent=2)
+
+    @classmethod
+    def load(cls, cache_dir: Path, corpus_root: Path):
+        """Try to load a cached index. Returns CorpusIndex on success, None on any failure."""
+        try:
+            mf_path = cache_dir / 'manifest.json'
+            if not mf_path.exists():
+                return None
+            t0 = time.time()
+            retriever = bm25s.BM25.load(str(cache_dir / 'bm25'))
+            with open(cache_dir / 'corpus.pkl', 'rb') as f:
+                corp = pickle.load(f)
+            with open(mf_path) as f:
+                manifest = json.load(f)
+            idx = cls(corpus_root, corp['paths'], corp['docs'], retriever,
+                      time.time() - t0, source='cache')
+            idx.manifest = manifest
+            return idx
+        except Exception:
+            return None
 
     def query(self, q: str, k: int = 10):
         tokens = bm25s.tokenize([q], stopwords=None, show_progress=False)
         idxs, scores = self.retriever.retrieve(tokens, k=min(k, len(self.docs)), show_progress=False)
         return [(int(i), float(s)) for i, s in zip(idxs[0], scores[0])]
+
+
+def get_or_build_index(corpus_root: Path, include, exclude, max_bytes: int, use_cache: bool):
+    """Cache-aware index lookup. Returns (CorpusIndex, cache_dir_or_None, key)."""
+    key = cache_key(corpus_root, include, exclude, max_bytes)
+    cache_dir = CACHE_ROOT / key
+    if use_cache:
+        loaded = CorpusIndex.load(cache_dir, corpus_root)
+        if loaded is not None:
+            return loaded, cache_dir, key
+    idx = CorpusIndex.build(corpus_root, include, exclude, max_bytes)
+    if use_cache:
+        try:
+            idx.save(cache_dir)
+        except Exception as e:
+            sys.stderr.write(f"[bm25] warn: failed to write cache ({e}); continuing\n")
+    return idx, (cache_dir if use_cache else None), key
 
 
 # ---------- snippet extraction ----------
@@ -213,19 +300,34 @@ def main():
     ap.add_argument('--json', action='store_true', help='machine-readable output')
     ap.add_argument('--interactive', '-i', action='store_true', help='REPL: query, q, query, q, ... (one corpus, many queries)')
     ap.add_argument('--stats', action='store_true', help='print discover/index timings')
+    ap.add_argument('--no-cache', action='store_true',
+                    help='bypass the session-local index cache at /home/claude/.bm25-cache/')
     args = ap.parse_args()
 
     if not args.queries and not args.interactive:
         ap.error('provide queries as positional args, or use --interactive')
 
     root = resolve_corpus(args.corpus)
-    sys.stderr.write(f"[bm25] indexing {root} ...\n")
-    idx = CorpusIndex(root, args.include, args.exclude, args.max_file_bytes)
-    sys.stderr.write(f"[bm25] indexed {len(idx.docs)} files in {idx.discover_s + idx.index_s:.2f}s "
-                     f"(walk {idx.discover_s:.2f}s, index {idx.index_s:.2f}s)\n")
+    idx, cache_dir, key = get_or_build_index(
+        root, args.include, args.exclude, args.max_file_bytes,
+        use_cache=not args.no_cache,
+    )
+    if idx.source == 'cache':
+        manifest = getattr(idx, 'manifest', {})
+        built_at = manifest.get('built_at', '?')
+        sys.stderr.write(f"[bm25] cache HIT  {key} ({len(idx.docs)} files, "
+                         f"loaded in {idx.build_s:.2f}s, built {built_at})\n")
+    else:
+        if cache_dir is not None:
+            sys.stderr.write(f"[bm25] cache MISS {key} → built {len(idx.docs)} files in {idx.build_s:.2f}s, saved to {cache_dir}\n")
+        else:
+            sys.stderr.write(f"[bm25] no-cache: built {len(idx.docs)} files in {idx.build_s:.2f}s\n")
     if args.stats:
-        print(json.dumps({'files': len(idx.docs), 'walk_s': round(idx.discover_s, 3),
-                          'index_s': round(idx.index_s, 3)}, indent=2))
+        print(json.dumps({
+            'files': len(idx.docs), 'source': idx.source,
+            'build_or_load_s': round(idx.build_s, 3),
+            'cache_key': key, 'cache_dir': str(cache_dir) if cache_dir else None,
+        }, indent=2))
 
     for q in args.queries:
         hits = idx.query(q, k=args.top_k)


### PR DESCRIPTION
**Replaces #659**, which closed when its base branch (`claude/bm25-uv-install`) was deleted on #658's merge. Same commit, rebased onto current main.

## Why

Each `bash_tool` invocation spawns a new Python process, so the in-memory retriever evaporates at process exit. The previous claim that "within a single Python process the retriever stays in memory" was true but applied only to a single CLI invocation — across follow-up turns, repeat queries against the same corpus rebuilt from scratch.

## How

Session-local cache at `/home/claude/.bm25-cache/<key>/`. The key is `sha256(resolved_corpus_path | sorted_include_globs | sorted_exclude_globs | max_file_bytes)[:16]`. Any change to those inputs naturally invalidates. `/home/claude/` is ephemeral, so cache lifetime = corpus state lifetime — no cross-session invalidation problem.

Cache contents per directory:
- `bm25/` — `bm25s.BM25.save()` output (NumPy arrays + vocab)
- `corpus.pkl` — pickled `{paths, docs}` so snippets render without re-reading source files
- `manifest.json` — corpus root, file count, built_at timestamp

## Verification

Tested on Django (1,962 files post-`--exclude tests/*`):

| Run | Result | Time |
|-----|--------|------|
| First | MISS — built, saved | 1.47s |
| Second | HIT — loaded | 0.04s (~37x) |
| Different `--exclude` | MISS (new key) — built 4,285 files | 3.11s |
| `--no-cache` | built without saving | 1.49s |

Cache size: ~19MB per Django-scale index.

## Escape hatch

`--no-cache` bypasses both load and save. For the rare "I mutated the corpus mid-session" case or to verify rebuild parity.

## Touched

- `bm25/SKILL.md` — version 0.1.1 → 0.1.2, replaced "Stateless by design" notes with cache semantics, added `--no-cache` to options table, updated architecture
- `bm25/README.md` — replaced "Why stateless" with "Caching" section
- `bm25/scripts/bm25.py` — refactored `CorpusIndex` into build/save/load methods, added `cache_key()` and `get_or_build_index()`, added `--no-cache` flag, surfaced cache HIT/MISS in stderr
- `bm25/CHANGELOG.md` — 0.1.2 entry