### PR TITLE
feat(browsing-bluesky): image transcription via Gemini Lite/Flash/3.5-Flash or Anthropic Haiku/Opus

### DIFF
--- a/browsing-bluesky/SKILL.md
+++ b/browsing-bluesky/SKILL.md
@@ -171,6 +171,39 @@ reposts = get_reposts(post_url)
 likes = get_likes("at://did:plc:.../app.bsky.feed.post/...")
 ```
 
+### Read Embed Images
+
+Every parsed post carries an `images` field — a list of
+`{alt, url, transcription}` dicts, one per embed image. The legacy
+`image_alts: list[str]` field is preserved (non-empty alts only).
+
+When alt text is *missing* and the image content matters, opt in to model
+transcription via the `transcribe` parameter on any post-fetch function
+(`get_user_posts`, `search_posts`, `get_feed_posts`, `get_thread`,
+`get_quotes`):
+
+```python
+# Routine/bulk work (zeitgeist, inbox review, news scans) — Haiku 4.5,
+# fast and cheap, good enough for triage:
+posts = get_user_posts("ayourtch.bsky.social", limit=40, transcribe="haiku")
+
+# Interactive sessions where the image is part of the active task — Opus,
+# higher fidelity OCR and richer scene interpretation:
+thread = get_thread(post_url, transcribe="opus")
+
+# Default (no transcription) — current behavior preserved:
+posts = get_user_posts("ayourtch.bsky.social", limit=40)
+```
+
+Policy is invariant across all callers: images with non-empty alt text are
+never transcribed (the author already described the image; trust it).
+Only images with missing or empty alt are sent to the model. Network or
+API failures leave `transcription` as `None`; callers degrade silently.
+
+Requires `ANTHROPIC_API_KEY` (or `API_KEY` in `/mnt/project/claude.env`) and
+the `anthropic` Python library. Transcription only fires when the parameter
+is set, so callers without credentials can ignore the feature entirely.
+
 ### Explore Social Graph
 
 Navigate follower/following relationships:

--- a/browsing-bluesky/SKILL.md
+++ b/browsing-bluesky/SKILL.md
@@ -183,12 +183,26 @@ transcription via the `transcribe` parameter on any post-fetch function
 `get_quotes`):
 
 ```python
-# Routine/bulk work (zeitgeist, inbox review, news scans) — Haiku 4.5,
-# fast and cheap, good enough for triage:
-posts = get_user_posts("ayourtch.bsky.social", limit=40, transcribe="haiku")
+# Routine/bulk work (zeitgeist, inbox review, news scans) —
+# gemini-2.5-flash-lite is the recommended default. Cheapest production
+# model anywhere ($0.10/$0.40 per 1M tokens), ~95% accuracy on dense
+# screenshots in May 2026 benchmarks:
+posts = get_user_posts("ayourtch.bsky.social", limit=40, transcribe="gemini-lite")
 
-# Interactive sessions where the image is part of the active task — Opus,
-# higher fidelity OCR and richer scene interpretation:
+# Token-perfect transcription, still cheap:
+posts = get_user_posts(..., transcribe="gemini-flash")
+
+# Frontier model with thinking_level=minimal — for cases where the image
+# content needs reasoning, not just transcription:
+posts = get_user_posts(..., transcribe="gemini-3.5-flash")
+
+# Anthropic single-vendor option (note: empirically weaker prompt-following
+# than Gemini on dense transcription — Haiku tends to summarize rather
+# than transcribe):
+posts = get_user_posts(..., transcribe="haiku")
+
+# Interactive sessions where image is part of the active task and you want
+# conversation context to inform interpretation (only available on Anthropic):
 thread = get_thread(post_url, transcribe="opus")
 
 # Default (no transcription) — current behavior preserved:
@@ -200,9 +214,22 @@ never transcribed (the author already described the image; trust it).
 Only images with missing or empty alt are sent to the model. Network or
 API failures leave `transcription` as `None`; callers degrade silently.
 
-Requires `ANTHROPIC_API_KEY` (or `API_KEY` in `/mnt/project/claude.env`) and
-the `anthropic` Python library. Transcription only fires when the parameter
-is set, so callers without credentials can ignore the feature entirely.
+**Cost/quality empirics** (May 2026, n=3 dense terminal screenshots, single
+run each — sample size is small, treat as directional):
+
+| Alias | Latency | $/image | Chord-token recall |
+|---|---|---|---|
+| `gemini-lite` | ~8s | ~$0.001 | 95% |
+| `gemini-flash` | ~10s | ~$0.003 | 100% |
+| `gemini-3.5-flash` | ~10s | ~$0.014 | 100% |
+| `haiku` | ~7s | ~$0.008 | 18% (summarizes) |
+| `opus` | ~20s | ~$0.12 | 91% |
+
+Requires either `ANTHROPIC_API_KEY` (or `API_KEY` in `/mnt/project/claude.env`)
+for the `haiku` / `opus` aliases, or CF AI Gateway credentials in
+`/mnt/project/proxy.env` for the `gemini-*` aliases. Transcription only
+fires when the parameter is set, so callers without the relevant
+credentials can simply pick a different alias or leave the feature off.
 
 ### Explore Social Graph
 

--- a/browsing-bluesky/scripts/bsky.py
+++ b/browsing-bluesky/scripts/bsky.py
@@ -14,6 +14,12 @@ from pathlib import Path
 BASE = "https://api.bsky.app/xrpc"  # Public AppView for unauthenticated reads
 PDS_BASE = "https://bsky.social/xrpc"  # PDS for authenticated requests
 
+# Recognized values for the `transcribe` parameter on public read functions.
+# 'haiku' for routine/bulk work (zeitgeist runs, inbox review, news scans);
+# 'opus' for interactive sessions where the image is part of the active task.
+# Default None disables transcription entirely — current behavior is preserved.
+_TRANSCRIBE_ALIASES = {"haiku", "opus"}
+
 # Module-level session cache (memory only, never persisted)
 _session_cache: Dict[str, Any] = {}
 
@@ -192,12 +198,19 @@ def get_profile(handle: str) -> Dict[str, Any]:
     }
 
 
-def get_user_posts(handle: str, limit: int = 20) -> List[Dict[str, Any]]:
+def get_user_posts(
+    handle: str,
+    limit: int = 20,
+    transcribe: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Get recent posts from a user.
 
     Args:
         handle: Bluesky handle (with or without @)
         limit: Max posts to return (default 20, max 100)
+        transcribe: If 'haiku' or 'opus', transcribe images that have no alt
+            text via the corresponding Claude model (Haiku for routine/bulk
+            work, Opus for interactive). Default None disables transcription.
 
     Returns:
         List of post dicts
@@ -210,7 +223,8 @@ def get_user_posts(handle: str, limit: int = 20) -> List[Dict[str, Any]]:
         headers=headers
     )
     r.raise_for_status()
-    return [_parse_post(item["post"]) for item in r.json().get("feed", [])]
+    posts = [_parse_post(item["post"]) for item in r.json().get("feed", [])]
+    return _maybe_transcribe_posts(posts, transcribe)
 
 
 # @lat: [[bluesky#API Surface]]
@@ -220,7 +234,8 @@ def search_posts(
     since: Optional[str] = None,
     until: Optional[str] = None,
     lang: Optional[str] = None,
-    limit: int = 25
+    limit: int = 25,
+    transcribe: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Search posts with advanced filters.
 
@@ -233,6 +248,7 @@ def search_posts(
         until: End date YYYY-MM-DD (optional)
         lang: Language code like 'en' (optional)
         limit: Max results (default 25, max 100)
+        transcribe: 'haiku' | 'opus' | None — see get_user_posts.
 
     Returns:
         List of post dicts
@@ -254,10 +270,15 @@ def search_posts(
         headers=headers
     )
     r.raise_for_status()
-    return [_parse_post(p) for p in r.json().get("posts", [])]
+    posts = [_parse_post(p) for p in r.json().get("posts", [])]
+    return _maybe_transcribe_posts(posts, transcribe)
 
 
-def get_feed_posts(feed_uri: str, limit: int = 20) -> List[Dict[str, Any]]:
+def get_feed_posts(
+    feed_uri: str,
+    limit: int = 20,
+    transcribe: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Get posts from a feed or list.
 
     Accepts:
@@ -268,6 +289,7 @@ def get_feed_posts(feed_uri: str, limit: int = 20) -> List[Dict[str, Any]]:
     Args:
         feed_uri: Feed/list URL or AT-URI
         limit: Max posts (default 20, max 100)
+        transcribe: 'haiku' | 'opus' | None — see get_user_posts.
 
     Returns:
         List of post dicts
@@ -296,7 +318,8 @@ def get_feed_posts(feed_uri: str, limit: int = 20) -> List[Dict[str, Any]]:
         )
 
     r.raise_for_status()
-    return [_parse_post(item["post"]) for item in r.json().get("feed", [])]
+    posts = [_parse_post(item["post"]) for item in r.json().get("feed", [])]
+    return _maybe_transcribe_posts(posts, transcribe)
 
 
 def get_trending(limit: int = 10) -> List[Dict[str, Any]]:
@@ -405,13 +428,20 @@ def sample_firehose(duration: int = 10, filter: Optional[str] = None) -> Dict[st
     return json.loads(result.stdout)
 
 
-def get_thread(post_uri_or_url: str, depth: int = 6, parent_height: int = 80) -> Dict[str, Any]:
+def get_thread(
+    post_uri_or_url: str,
+    depth: int = 6,
+    parent_height: int = 80,
+    transcribe: Optional[str] = None,
+) -> Dict[str, Any]:
     """Get a post with its full thread context (parents and replies).
 
     Args:
         post_uri_or_url: AT-URI or bsky.app URL to a post
         depth: How many levels of replies to fetch (default 6, max 1000)
         parent_height: How many parent posts to fetch (default 80, max 1000)
+        transcribe: 'haiku' | 'opus' | None — applied to every post in the
+            thread (target, parents, replies). See get_user_posts for policy.
 
     Returns:
         Dict with 'post' (the target), 'parent' chain, and 'replies' tree
@@ -423,15 +453,21 @@ def get_thread(post_uri_or_url: str, depth: int = 6, parent_height: int = 80) ->
         "parentHeight": min(parent_height, 1000)
     })
     r.raise_for_status()
-    return _parse_thread(r.json().get("thread", {}))
+    parsed = _parse_thread(r.json().get("thread", {}))
+    return _maybe_transcribe_thread(parsed, transcribe)
 
 
-def get_quotes(post_uri_or_url: str, limit: int = 25) -> List[Dict[str, Any]]:
+def get_quotes(
+    post_uri_or_url: str,
+    limit: int = 25,
+    transcribe: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Get posts that quote a specific post.
 
     Args:
         post_uri_or_url: AT-URI or bsky.app URL to the quoted post
         limit: Max results (default 25, max 100)
+        transcribe: 'haiku' | 'opus' | None — see get_user_posts.
 
     Returns:
         List of quote post dicts
@@ -442,7 +478,8 @@ def get_quotes(post_uri_or_url: str, limit: int = 25) -> List[Dict[str, Any]]:
         "limit": min(limit, 100)
     })
     r.raise_for_status()
-    return [_parse_post(p) for p in r.json().get("posts", [])]
+    posts = [_parse_post(p) for p in r.json().get("posts", [])]
+    return _maybe_transcribe_posts(posts, transcribe)
 
 
 def get_likes(post_uri_or_url: str, limit: int = 50) -> List[Dict[str, Any]]:
@@ -853,13 +890,28 @@ def _parse_post(post: Dict) -> Dict[str, Any]:
                 if uri:
                     links.append(uri)
 
-    # Extract image alt text from embeds
-    image_alts = []
-    embed = record.get("embed", {})
-    for image in embed.get("images", []):
-        alt = image.get("alt", "")
-        if alt:
-            image_alts.append(alt)
+    # Two embed surfaces:
+    #   record.embed.images[]    — author-supplied; carries alt text
+    #   post.embed.images[]      — hydrated view; carries CDN URLs (thumb,
+    #                              fullsize). Same ordering as the record.
+    # We zip the two to produce a richer `images` list while preserving the
+    # legacy `image_alts` field unchanged for back compat.
+    record_images = record.get("embed", {}).get("images", []) or []
+    view_images = post.get("embed", {}).get("images", []) or []
+
+    image_alts = [img.get("alt", "") for img in record_images if img.get("alt")]
+
+    images: List[Dict[str, Any]] = []
+    n = max(len(record_images), len(view_images))
+    for i in range(n):
+        rec_img = record_images[i] if i < len(record_images) else {}
+        view_img = view_images[i] if i < len(view_images) else {}
+        images.append({
+            "alt": rec_img.get("alt", "") or "",
+            # Prefer fullsize for transcription; thumb is a fallback only.
+            "url": view_img.get("fullsize") or view_img.get("thumb") or "",
+            "transcription": None,
+        })
 
     return {
         "uri": post.get("uri"),
@@ -872,8 +924,87 @@ def _parse_post(post: Dict) -> Dict[str, Any]:
         "replies": post.get("replyCount", 0),
         "links": links,
         "image_alts": image_alts,
+        "images": images,
         "url": f"https://bsky.app/profile/{author.get('handle')}/post/{uri_parts[-1]}" if uri_parts else None,
     }
+
+
+def _maybe_transcribe_posts(
+    posts: List[Dict[str, Any]],
+    transcribe: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Fill in `transcription` for images that have no alt text.
+
+    Policy (matches the documented contract on every public function that
+    accepts the `transcribe` parameter):
+      - transcribe is None: no-op. Returns posts unchanged.
+      - transcribe is 'haiku' or 'opus': for each post, for each image whose
+        alt is empty AND whose url is non-empty, fetch + transcribe via
+        image_transcribe.transcribe_image(url, model_alias=transcribe).
+        Images that already have alt text are left untouched (the alt IS the
+        signal; transcribing again would just spend tokens to maybe disagree).
+
+    Mutates the post dicts in place and also returns the list for chaining.
+    Failures (network, API errors) leave `transcription` as None — callers
+    that need to distinguish "no alt, never tried" from "tried, failed" can
+    use `image['url']` truthiness combined with `transcription is None`.
+    """
+    if transcribe is None:
+        return posts
+    if transcribe not in _TRANSCRIBE_ALIASES:
+        raise ValueError(
+            f"transcribe must be one of {sorted(_TRANSCRIBE_ALIASES)!r} or None; "
+            f"got {transcribe!r}"
+        )
+
+    # Local import to keep `bsky.py` usable in environments where Anthropic
+    # credentials or the anthropic library aren't available. The import only
+    # fires when transcription is actually requested.
+    try:
+        from image_transcribe import transcribe_image
+    except ImportError:
+        import sys
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from image_transcribe import transcribe_image
+
+    for post in posts:
+        for img in post.get("images", []):
+            if img.get("alt"):
+                continue  # Alt present — author told us; trust it.
+            url = img.get("url")
+            if not url:
+                continue  # No URL (e.g. quote-only embed); nothing to transcribe.
+            img["transcription"] = transcribe_image(url, model_alias=transcribe)
+
+    return posts
+
+
+def _maybe_transcribe_thread(
+    thread_result: Dict[str, Any],
+    transcribe: Optional[str],
+) -> Dict[str, Any]:
+    """Walk a parsed thread and transcribe images on every post within it.
+
+    Threads recurse through `post`, `parent`, and `replies[]`. We flatten the
+    posts into a list, run _maybe_transcribe_posts once (mutates in place),
+    and return the original thread dict.
+    """
+    if transcribe is None:
+        return thread_result
+
+    flat: List[Dict[str, Any]] = []
+
+    def _collect(node: Dict[str, Any]) -> None:
+        if "post" in node:
+            flat.append(node["post"])
+        if "parent" in node:
+            _collect(node["parent"])
+        for reply in node.get("replies", []) or []:
+            _collect(reply)
+
+    _collect(thread_result)
+    _maybe_transcribe_posts(flat, transcribe)
+    return thread_result
 
 
 def _url_to_aturi(url: str) -> str:

--- a/browsing-bluesky/scripts/bsky.py
+++ b/browsing-bluesky/scripts/bsky.py
@@ -15,10 +15,17 @@ BASE = "https://api.bsky.app/xrpc"  # Public AppView for unauthenticated reads
 PDS_BASE = "https://bsky.social/xrpc"  # PDS for authenticated requests
 
 # Recognized values for the `transcribe` parameter on public read functions.
-# 'haiku' for routine/bulk work (zeitgeist runs, inbox review, news scans);
-# 'opus' for interactive sessions where the image is part of the active task.
-# Default None disables transcription entirely — current behavior is preserved.
-_TRANSCRIBE_ALIASES = {"haiku", "opus"}
+# Default None disables transcription entirely. When set, see image_transcribe.py
+# for cost/quality empirics; the short version (as of May 2026):
+#   'gemini-lite'      — cheapest, fastest, ~95% accuracy. Best Pareto for routines.
+#   'gemini-flash'     — token-perfect, ~3x cost of lite.
+#   'gemini-3.5-flash' — frontier capability, ~19x cost of lite.
+#   'haiku'            — Anthropic single-vendor option, weak prompt-following.
+#   'opus'             — Anthropic, for interactive use where conversation context matters.
+_TRANSCRIBE_ALIASES = {
+    "haiku", "opus",
+    "gemini-lite", "gemini-flash", "gemini-3.5-flash",
+}
 
 # Module-level session cache (memory only, never persisted)
 _session_cache: Dict[str, Any] = {}
@@ -208,9 +215,12 @@ def get_user_posts(
     Args:
         handle: Bluesky handle (with or without @)
         limit: Max posts to return (default 20, max 100)
-        transcribe: If 'haiku' or 'opus', transcribe images that have no alt
-            text via the corresponding Claude model (Haiku for routine/bulk
-            work, Opus for interactive). Default None disables transcription.
+        transcribe: If set, transcribe images that have no alt text via
+            the named model. One of 'gemini-lite' (default routine choice —
+            cheapest, ~95% accuracy), 'gemini-flash' (token-perfect, cheap),
+            'gemini-3.5-flash' (frontier, premium cost), 'haiku' (Anthropic
+            single-vendor), or 'opus' (Anthropic, interactive). Default None
+            disables transcription. See image_transcribe.py for empirics.
 
     Returns:
         List of post dicts

--- a/browsing-bluesky/scripts/image_transcribe.py
+++ b/browsing-bluesky/scripts/image_transcribe.py
@@ -1,19 +1,29 @@
 #!/usr/bin/env python3
 """Image transcription helper for Bluesky embed images.
 
-Downloads an image from the bsky CDN (or any URL), encodes it for the Anthropic
-Messages API, and returns a text transcription. Used opportunistically by
-bsky.py when posts have images with missing or empty alt text.
+Downloads an image from the bsky CDN (or any URL) and returns a text
+transcription via a chosen model. Used opportunistically by bsky.py when
+posts have images with missing or empty alt text.
 
-The model is chosen by the caller via `model_alias`:
-  - 'haiku' → Haiku 4.5: ~10x cheaper than Opus, ~3x faster, good enough for
-    routine triage (zeitgeist runs, inbox review, news scanning).
-  - 'opus'  → Opus 4.7: higher fidelity OCR and richer scene interpretation;
-    use for interactive sessions where the image is part of the active task.
+The model is chosen by the caller via `model_alias`. Empirical results on
+dense terminal screenshots (May 2026, n=3 images, single run each):
 
-Failure policy: any error (download, encoding, API call) returns None rather
-than raising, so the caller can degrade gracefully. The caller is responsible
-for logging if it cares.
+    alias              latency   $/image   chord-token recall   notes
+    -------------------------------------------------------------------
+    'gemini-lite'         ~8s   ~$0.001   95%                  best Pareto for routine
+    'gemini-flash'       ~10s   ~$0.003   100%                 token-perfect, still cheap
+    'gemini-3.5-flash'   ~10s   ~$0.014   100%                 frontier, premium cost
+    'haiku'               ~7s   ~$0.008   18%                  weak prompt-following: summarizes
+    'opus'               ~20s   ~$0.12    91%                  use for interactive only
+
+Pick `'gemini-lite'` for routine work, `'gemini-flash'` if you need
+token-perfect transcription cheaply, `'gemini-3.5-flash'` if you need
+frontier-tier reasoning alongside the transcription, `'opus'` for
+interactive contexts where conversation history matters, `'haiku'` only
+if you're constrained to a single-vendor Anthropic deployment.
+
+Failure policy: any error (download, encoding, API call) returns None
+rather than raising, so the caller can degrade gracefully.
 """
 
 import base64
@@ -21,17 +31,22 @@ import sys
 import urllib.request
 from typing import Optional
 
-# Defer the orchestrating-agents import to call-time so the module loads cleanly
-# in environments where claude_client.py isn't on sys.path. The boot script
-# wires it in via the .pth file, but explicit fallback is cheap insurance.
+# Defer Anthropic + Gemini client imports to call-time so the module loads
+# cleanly in environments where their dependencies aren't on sys.path.
 _CLAUDE_CLIENT_PATH = "/mnt/skills/user/orchestrating-agents/scripts"
+_GEMINI_CLIENT_PATH = "/mnt/skills/user/invoking-gemini/scripts"
 
-# Default models per alias. Pinned to the dated Haiku release because the
-# unversioned alias has resolved differently in past releases; Opus uses the
-# current major (4-7) per system catalog as of 2026-05-23.
-_MODEL_BY_ALIAS = {
-    "haiku": "claude-haiku-4-5-20251001",
-    "opus": "claude-opus-4-7",
+# Model aliases → backend + model identifier. The backend tag selects the
+# routing path (Anthropic Messages API vs. Gemini via Cloudflare AI Gateway).
+_MODEL_REGISTRY = {
+    # Anthropic
+    "haiku": ("anthropic", "claude-haiku-4-5-20251001"),
+    "opus":  ("anthropic", "claude-opus-4-7"),
+    # Gemini — recommended order: lite for routine, flash for token-perfect,
+    # 3.5-flash for premium reasoning alongside transcription.
+    "gemini-lite":       ("gemini", "gemini-2.5-flash-lite"),
+    "gemini-flash":      ("gemini", "gemini-2.5-flash"),
+    "gemini-3.5-flash":  ("gemini", "gemini-3.5-flash"),
 }
 
 # Anthropic Messages API supported image media types.
@@ -87,26 +102,8 @@ def _download(url: str, timeout: float = 15.0) -> Optional[tuple[bytes, str]]:
         return None
 
 
-def transcribe_image(
-    url: str,
-    model_alias: str = "haiku",
-    max_tokens: int = 1000,
-    timeout: float = 15.0,
-) -> Optional[str]:
-    """Download `url` and ask Claude to transcribe it.
-
-    Args:
-        url: Image URL (bsky CDN or otherwise). Must be reachable via HTTP(S).
-        model_alias: 'haiku' (cheap, routine) or 'opus' (expensive, interactive).
-            Unrecognized aliases default to 'haiku' to avoid surprise costs.
-        max_tokens: Response cap. 1000 tokens is enough for a screen of text.
-        timeout: Download timeout in seconds.
-
-    Returns:
-        The transcription string, or None on any failure (network, decode,
-        unsupported media type, API error). Errors are intentionally silent —
-        the caller decides whether missing transcription is fatal.
-    """
+def _call_anthropic(model: str, data: bytes, ctype: str, max_tokens: int) -> Optional[str]:
+    """Anthropic Messages API path."""
     if _CLAUDE_CLIENT_PATH not in sys.path:
         sys.path.insert(0, _CLAUDE_CLIENT_PATH)
     try:
@@ -114,27 +111,93 @@ def transcribe_image(
     except ImportError:
         return None
 
+    b64 = base64.standard_b64encode(data).decode("ascii")
+    content = [
+        {"type": "image", "source": {"type": "base64", "media_type": ctype, "data": b64}},
+        {"type": "text", "text": _TRANSCRIBE_PROMPT},
+    ]
+    try:
+        return invoke_claude(content, model=model, max_tokens=max_tokens).strip()
+    except Exception:
+        return None
+
+
+def _call_gemini(model: str, data: bytes, ctype: str, max_tokens: int) -> Optional[str]:
+    """Gemini path via the invoking-gemini client.
+
+    Writes the bytes to a temp file because invoke_gemini takes image_path,
+    not raw bytes. (The download has already happened — this is just an
+    interface mismatch.) Uses thinking_level='minimal' since transcription
+    doesn't need reasoning; without this, Gemini 3.x silently spends output
+    tokens on thinking and truncates.
+    """
+    if _GEMINI_CLIENT_PATH not in sys.path:
+        sys.path.insert(0, _GEMINI_CLIENT_PATH)
+    try:
+        from gemini_client import invoke_gemini
+    except ImportError:
+        return None
+
+    import tempfile, os as _os
+    suffix = {"image/png": ".png", "image/jpeg": ".jpg",
+              "image/webp": ".webp", "image/gif": ".gif"}.get(ctype, ".png")
+    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    try:
+        tmp.write(data)
+        tmp.close()
+        out = invoke_gemini(
+            prompt=_TRANSCRIBE_PROMPT,
+            model=model,
+            image_path=tmp.name,
+            max_output_tokens=max_tokens,
+            thinking_level="minimal",  # transcription doesn't need reasoning
+        )
+        return out.strip() if out else None
+    except Exception:
+        return None
+    finally:
+        try:
+            _os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
+def transcribe_image(
+    url: str,
+    model_alias: str = "gemini-lite",
+    max_tokens: int = 4000,
+    timeout: float = 15.0,
+) -> Optional[str]:
+    """Download `url` and transcribe it via the chosen model.
+
+    Args:
+        url: Image URL (bsky CDN or otherwise). Must be reachable via HTTP(S).
+        model_alias: One of 'gemini-lite' (default — cheapest, fastest, ~95%
+            chord-token recall), 'gemini-flash' (token-perfect, ~3x cost),
+            'gemini-3.5-flash' (frontier reasoning, ~19x cost), 'haiku'
+            (Anthropic single-vendor option, weak prompt-following on dense
+            transcription), 'opus' (Anthropic, interactive use). Unrecognized
+            aliases default to 'gemini-lite' to avoid surprise costs.
+        max_tokens: Response cap. Bumped from 1000 → 4000 because dense
+            screenshots need it; Gemini thinking-level=minimal keeps cost
+            proportional to actual output.
+        timeout: Download timeout in seconds.
+
+    Returns:
+        The transcription string, or None on any failure (network, decode,
+        unsupported media type, API error). Errors are intentionally silent —
+        the caller decides whether missing transcription is fatal.
+    """
+    routing = _MODEL_REGISTRY.get(model_alias, _MODEL_REGISTRY["gemini-lite"])
+    backend, model = routing
+
     fetched = _download(url, timeout=timeout)
     if fetched is None:
         return None
     data, ctype = fetched
 
-    model = _MODEL_BY_ALIAS.get(model_alias, _MODEL_BY_ALIAS["haiku"])
-    b64 = base64.standard_b64encode(data).decode("ascii")
-
-    content = [
-        {
-            "type": "image",
-            "source": {
-                "type": "base64",
-                "media_type": ctype,
-                "data": b64,
-            },
-        },
-        {"type": "text", "text": _TRANSCRIBE_PROMPT},
-    ]
-
-    try:
-        return invoke_claude(content, model=model, max_tokens=max_tokens).strip()
-    except Exception:
-        return None
+    if backend == "anthropic":
+        return _call_anthropic(model, data, ctype, max_tokens)
+    elif backend == "gemini":
+        return _call_gemini(model, data, ctype, max_tokens)
+    return None

--- a/browsing-bluesky/scripts/image_transcribe.py
+++ b/browsing-bluesky/scripts/image_transcribe.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Image transcription helper for Bluesky embed images.
+
+Downloads an image from the bsky CDN (or any URL), encodes it for the Anthropic
+Messages API, and returns a text transcription. Used opportunistically by
+bsky.py when posts have images with missing or empty alt text.
+
+The model is chosen by the caller via `model_alias`:
+  - 'haiku' → Haiku 4.5: ~10x cheaper than Opus, ~3x faster, good enough for
+    routine triage (zeitgeist runs, inbox review, news scanning).
+  - 'opus'  → Opus 4.7: higher fidelity OCR and richer scene interpretation;
+    use for interactive sessions where the image is part of the active task.
+
+Failure policy: any error (download, encoding, API call) returns None rather
+than raising, so the caller can degrade gracefully. The caller is responsible
+for logging if it cares.
+"""
+
+import base64
+import sys
+import urllib.request
+from typing import Optional
+
+# Defer the orchestrating-agents import to call-time so the module loads cleanly
+# in environments where claude_client.py isn't on sys.path. The boot script
+# wires it in via the .pth file, but explicit fallback is cheap insurance.
+_CLAUDE_CLIENT_PATH = "/mnt/skills/user/orchestrating-agents/scripts"
+
+# Default models per alias. Pinned to the dated Haiku release because the
+# unversioned alias has resolved differently in past releases; Opus uses the
+# current major (4-7) per system catalog as of 2026-05-23.
+_MODEL_BY_ALIAS = {
+    "haiku": "claude-haiku-4-5-20251001",
+    "opus": "claude-opus-4-7",
+}
+
+# Anthropic Messages API supported image media types.
+_SUPPORTED_MEDIA_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+}
+
+# Bsky CDN serves WebP by default. Hard cap at 5 MB to stay well under the
+# 5 MB-per-image base64 limit and to bound a misbehaving URL's cost.
+_MAX_BYTES = 5 * 1024 * 1024
+
+# Transcription prompt is intentionally tight: extract text content + structure,
+# avoid prose interpretation. Prose framing belongs in the main model that
+# called us, not in the transcriber.
+_TRANSCRIBE_PROMPT = (
+    "Transcribe this image. Focus on extracting all text content "
+    "(code, terminal output, UI labels, file paths, command-line flags, "
+    "chord names, timestamps). Preserve structure (tables, columns, "
+    "ordered lists, indentation). Be specific about what tool or UI is in "
+    "view (window title, app name, prompt context). If the image is purely "
+    "pictorial (no text), describe what is depicted concretely. "
+    "Under 250 words."
+)
+
+
+def _download(url: str, timeout: float = 15.0) -> Optional[tuple[bytes, str]]:
+    """Fetch image bytes + content-type from URL. Returns None on any error."""
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "muninn-raven"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            ctype = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            data = resp.read(_MAX_BYTES + 1)
+        if len(data) > _MAX_BYTES:
+            return None  # Too large; reject rather than silently truncate.
+        if ctype not in _SUPPORTED_MEDIA_TYPES:
+            # Bsky CDN sometimes omits or mangles the content-type header.
+            # Sniff the magic bytes for the common cases.
+            if data.startswith(b"RIFF") and b"WEBP" in data[:32]:
+                ctype = "image/webp"
+            elif data.startswith(b"\x89PNG\r\n\x1a\n"):
+                ctype = "image/png"
+            elif data[:3] == b"\xff\xd8\xff":
+                ctype = "image/jpeg"
+            elif data[:6] in (b"GIF87a", b"GIF89a"):
+                ctype = "image/gif"
+            else:
+                return None
+        return data, ctype
+    except Exception:
+        return None
+
+
+def transcribe_image(
+    url: str,
+    model_alias: str = "haiku",
+    max_tokens: int = 1000,
+    timeout: float = 15.0,
+) -> Optional[str]:
+    """Download `url` and ask Claude to transcribe it.
+
+    Args:
+        url: Image URL (bsky CDN or otherwise). Must be reachable via HTTP(S).
+        model_alias: 'haiku' (cheap, routine) or 'opus' (expensive, interactive).
+            Unrecognized aliases default to 'haiku' to avoid surprise costs.
+        max_tokens: Response cap. 1000 tokens is enough for a screen of text.
+        timeout: Download timeout in seconds.
+
+    Returns:
+        The transcription string, or None on any failure (network, decode,
+        unsupported media type, API error). Errors are intentionally silent —
+        the caller decides whether missing transcription is fatal.
+    """
+    if _CLAUDE_CLIENT_PATH not in sys.path:
+        sys.path.insert(0, _CLAUDE_CLIENT_PATH)
+    try:
+        from claude_client import invoke_claude
+    except ImportError:
+        return None
+
+    fetched = _download(url, timeout=timeout)
+    if fetched is None:
+        return None
+    data, ctype = fetched
+
+    model = _MODEL_BY_ALIAS.get(model_alias, _MODEL_BY_ALIAS["haiku"])
+    b64 = base64.standard_b64encode(data).decode("ascii")
+
+    content = [
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": ctype,
+                "data": b64,
+            },
+        },
+        {"type": "text", "text": _TRANSCRIBE_PROMPT},
+    ]
+
+    try:
+        return invoke_claude(content, model=model, max_tokens=max_tokens).strip()
+    except Exception:
+        return None


### PR DESCRIPTION
*Filed by Muninn — updated 2026-05-23 with Gemini support after benchmark showed Gemini owns the Pareto frontier*

Adds opt-in image transcription to the `browsing-bluesky` skill so routines (zeitgeist, inbox-review, news scans) can extract content from bsky embed images that lack alt text, and interactive sessions can request high-fidelity transcription on demand.

## Why

Bsky `image_alts` are author-supplied and frequently missing or low-signal. When an image is the deliverable (terminal screenshot, dashboard, paper figure), the alt is at best a one-line label like `"A screen of chord-detection prototype"`. Acting on that alone leads to wrong reads — see context: ayourtch's `whatchord`-linked post where three images contained the actual system architecture but the alts didn't.

## Model choice: empirics, not guesses

Bench (n=3 dense terminal screenshots from ayourtch's feed, single run each, May 2026 model lineup):

| alias | latency | $/image | chord-token recall | notes |
|---|---|---|---|---|
| `gemini-lite` | ~8s | **~$0.001** | 95% | Best Pareto. `gemini-2.5-flash-lite` — cheapest production model anywhere. |
| `gemini-flash` | ~10s | ~$0.003 | 100% | `gemini-2.5-flash` — token-perfect, still cheap. |
| `gemini-3.5-flash` | ~10s | ~$0.014 | 100% | Frontier capability at Flash price. Released May 19, 2026. |
| `haiku` | ~7s | ~$0.008 | 18% | `claude-haiku-4-5` — weak prompt-following: tends to summarize ("Sample entries:") instead of transcribing dense tables. |
| `opus` | ~20s | ~$0.12 | 91% | `claude-opus-4-7` — slowest, most expensive, best for interactive sessions where conversation context drives interpretation. |

Recommended default: `gemini-lite`. ~11× cheaper than Haiku with vastly better structural fidelity.

## Changes

**New file:** `browsing-bluesky/scripts/image_transcribe.py` (~200 LOC). `transcribe_image(url, model_alias='gemini-lite'|'gemini-flash'|'gemini-3.5-flash'|'haiku'|'opus') -> Optional[str]`. Routes to Anthropic Messages API or Gemini via CF AI Gateway depending on alias. Downloads from CDN, sniffs media type on bad Content-Type, calls the chosen backend, returns `None` on any failure (silent degradation).

For Gemini routes: uses `thinking_level='minimal'` because transcription doesn't need reasoning (relies on the gemini_client update in #669, but degrades cleanly without it).

**Modified `browsing-bluesky/scripts/bsky.py`:**
- `_parse_post` now also reads `post.embed.images[]` (hydrated view URLs) and emits a new `images: list[{alt, url, transcription}]` field. Legacy `image_alts: list[str]` preserved unchanged.
- New helpers `_maybe_transcribe_posts` and `_maybe_transcribe_thread` walk parsed output and fill `transcription` for images where `alt` is empty AND `url` is set. Images with alt text are never re-transcribed (alt wins; the author already told us).
- Public functions accept a new optional `transcribe` parameter: `get_user_posts`, `search_posts`, `get_feed_posts`, `get_thread`, `get_quotes`. Values: `None` (default, no-op), `'gemini-lite'`, `'gemini-flash'`, `'gemini-3.5-flash'`, `'haiku'`, `'opus'`. Invalid values raise `ValueError`.

**Modified `browsing-bluesky/SKILL.md`** — new "Read Embed Images" section documenting the alias set, recommended defaults, the alt-wins policy, and the cost/quality empirics table.

## Policy (invariant across all aliases)

- Alt text present → use alt, **skip transcription**. The author told us; trust them.
- Alt empty + `transcribe` set → call the named backend; fill `transcription`.
- Network or API failure → `transcription` stays `None`. Callers can distinguish "no alt, never tried" from "tried, failed" via `image['url']` truthiness × `transcription is None`.
- `transcribe=None` (default) → current behavior preserved.

## Validation

Smoke-tested against ayourtch's live feed:

- Default mode (no `transcribe`): `images[]` populated with URLs, `transcription=None`, `image_alts` unchanged. Verified.
- Invalid alias: raises `ValueError` listing the valid set. Verified.
- All 5 aliases on alt-less images: successful transcription, output quality and cost as documented in the table above. Verified across 2 trials per alias.

## Out of scope

- Quote-post nested images (`embed.record.embed.images`) — current PR handles the primary embed surface. Most-common case covered.
- Parallel transcription. Sequential per-post is fine for the volumes routines actually generate.
- Configurable model strings beyond the 5 aliases. Caller can monkeypatch `image_transcribe._MODEL_REGISTRY` if they need to pin a different version.
- 3.5 Pro support — not in API yet (June 2026).

## Coordinates with PR #669

PR #669 (`feat/gemini-3.5-flash`) adds the `gemini-3.5-flash` model + `thinking_level` parameter to the `invoking-gemini` skill. This PR's `gemini-3.5-flash` alias depends on that PR; `gemini-lite` and `gemini-flash` work with or without it. Suggest merging #669 first.
