### PR TITLE
feat(invoking-gemini): add Gemini 3.5 Flash + thinking_level, fix stale model docs

### DIFF
--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -2,7 +2,7 @@
 name: invoking-gemini
 description: Invokes Google Gemini models for structured outputs, image generation, multi-modal tasks, and Google-specific features. Use when users request Gemini, image generation, structured JSON output, Google API integration, or cost-effective parallel processing.
 metadata:
-  version: 0.5.0
+  version: 0.6.0
 ---
 
 # Invoking Gemini
@@ -135,7 +135,7 @@ from gemini_client import invoke_gemini
 
 response = invoke_gemini(
     prompt="Explain quantum computing in 3 bullet points",
-    model="gemini-3-flash-preview"
+    model="flash",  # gemini-3.5-flash (default)
 )
 print(response)
 ```
@@ -168,21 +168,26 @@ from gemini_client import invoke_parallel
 
 results = invoke_parallel(
     prompts=["Summarize Hamlet", "Summarize Macbeth", "Summarize Othello"],
-    model="gemini-3-flash-preview"
+    model="lite",  # gemini-2.5-flash-lite — cheapest, fastest for batch
 )
 ```
 
 ## Available Models
 
-All Gemini 3 models are currently in preview. Use only these — no Gemini 2.x.
+All current Gemini 3.x text/multimodal models are in preview except 3.5
+Flash (GA May 19, 2026). Use the values below — `gemini-3-flash-preview`
+and `gemini-3.1-flash-lite-preview` from earlier docs are out of date.
 
 ### Text / Reasoning Models
 
-| Model | Alias | Input/1M | Output/1M | Context |
-|-------|-------|----------|-----------|---------|
-| gemini-3-flash-preview | `flash` | $0.50 | $3.00 | 1M |
-| gemini-3.1-pro-preview | `pro` | $2.00 | $12.00 | 1M |
-| gemini-3.1-flash-lite-preview | `lite` | $0.25 | $1.50 | 1M |
+| Model | Alias | Input/1M | Output/1M | Context | Notes |
+|-------|-------|----------|-----------|---------|-------|
+| gemini-3.5-flash | `flash` | $1.50 | $9.00 | 1M | GA May 2026. Frontier Flash. Beats 3.1 Pro on most coding/agentic benchmarks. Default `thinking_level=medium` — set `minimal` for non-reasoning tasks. |
+| gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Prior-gen Flash, kept for back compat |
+| gemini-3.1-pro-preview | `pro` | $2.00 (≤200K) / $4.00 | $12.00 / $24.00 | 1M | Current Pro tier; 3.5 Pro slated for June 2026 |
+| gemini-2.5-flash | `stable-flash` | $0.30 | $2.50 | 1M | Stable production Flash |
+| gemini-2.5-flash-lite | `lite` | **$0.10** | **$0.40** | 1M | Cheapest major-provider production model. Surprisingly strong on multimodal extraction. |
+| gemini-2.5-pro | `stable-pro` | $1.25 (≤200K) / $2.50 | $10.00 / $20.00 | 1M | Stable production Pro |
 
 ### Image Models
 
@@ -193,10 +198,30 @@ All Gemini 3 models are currently in preview. Use only these — no Gemini 2.x.
 
 See [references/models.md](references/models.md) for full details.
 
+### Thinking Budget (Gemini 3.x)
+
+Gemini 3.x models reason before responding. The parameter changed in
+2026: integer `thinking_budget` is gone; use string `thinking_level`
+∈ {`minimal`, `low`, `medium`, `high`}. Default for 3.5 Flash is
+`medium`. For transcription / classification / extraction tasks, pass
+`thinking_level='minimal'` or the model will silently spend output
+tokens on reasoning (symptom: empty response with
+`finishReason=MAX_TOKENS`).
+
+```python
+response = invoke_gemini(
+    prompt="Transcribe this image.",
+    model="flash",
+    image_path="/tmp/screenshot.png",
+    max_output_tokens=4000,
+    thinking_level="minimal",  # don't burn output budget on reasoning
+)
+```
+
 ## Error Handling
 
 ```python
-response = invoke_gemini(prompt="...", model="gemini-3-flash-preview")
+response = invoke_gemini(prompt="...", model="flash")
 if response is None:
     print("API call failed — check credentials")
 
@@ -214,10 +239,11 @@ Common issues: Missing API key → see Setup. Rate limit → auto-retries with b
 ```python
 response = invoke_gemini(
     prompt="Write a haiku",
-    model="gemini-3-flash-preview",
+    model="flash",                  # gemini-3.5-flash
     temperature=0.9,
-    max_output_tokens=100,
-    top_p=0.95
+    max_output_tokens=200,
+    top_p=0.95,
+    thinking_level="low",           # haiku is short; modest reasoning is fine
 )
 ```
 

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -1,62 +1,85 @@
 # Gemini Models Reference
 
-Detailed information about available Gemini models (as of March 2026).
+Detailed information about available Gemini models (as of May 2026).
 
 ## Model Comparison
 
-### Gemini 3.x — Frontier (Preview)
+### Gemini 3.5 — Frontier (GA)
+
+#### gemini-3.5-flash
+
+**Status:** Generally available (released May 19, 2026 at Google I/O)
+**Alias:** `flash` (this is now the default Flash)
+
+**Strengths:**
+- Frontier-class performance — beats Gemini 3.1 Pro on most coding and
+  agentic benchmarks
+- Runs ~4× faster on output tokens than other frontier models
+- Frontier intelligence at sub-Pro pricing
+- Dynamic thinking on by default (configurable via `thinking_level`)
+
+**Specifications:**
+- Context window: ~1M tokens input
+- Multimodal: text, image, audio, video
+- Knowledge cutoff: January 2026
+- Default `thinking_level`: `medium` (was `high` on prior 3.x — set
+  explicitly to `minimal` for transcription/classification/extraction or
+  the model will silently spend output tokens on reasoning)
+
+**Best for:**
+- Default Flash choice for most tasks in 2026
+- Agentic coding loops, terminal automation, multi-file projects
+- Multimodal document analysis where structure must be preserved
+- Streaming chat with frontier quality
+
+**Pricing:**
+- Input: $1.50 / 1M tokens
+- Output: $9.00 / 1M tokens
+- 1M context window at base price (no surcharge tier)
+
+---
+
+### Gemini 3.x — Prior Preview Generation
 
 #### gemini-3-flash-preview
 
-**Status:** Preview (Default)
-**Alias:** `flash`
+**Status:** Preview (still callable — kept for back compat)
+**Alias:** `flash-3`
 
-**Strengths:**
-- Frontier-class performance rivaling larger models at flash-tier cost
-- Upgraded visual and spatial reasoning
-- Agentic coding capabilities
-- Computer Use support (built-in)
-
-**Specifications:**
-- Context window: ~1M tokens input
-- Multimodal: Yes (text, image, video, audio)
-
-**Best for:**
-- Default choice for most tasks
-- Structured data extraction
-- High-volume tasks needing strong reasoning
-- Agentic workflows
+The previous-generation Flash. Use when you need to pin behavior
+established before the 3.5 cutover. New code should target `flash`
+(gemini-3.5-flash) instead.
 
 **Pricing:**
-- Input: $0.50 / 1M tokens
-- Output: $3.00 / 1M tokens
+- Input: $0.30 / 1M tokens
+- Output: $2.50 / 1M tokens
 
 #### gemini-3.1-pro-preview
 
-**Status:** Preview
+**Status:** Preview (Pro-tier upgrade pending — 3.5 Pro slated for June 2026)
 **Alias:** `pro`
 
 **Strengths:**
-- Most capable Gemini model available
+- Most capable Gemini Pro currently in API
 - Advanced intelligence and complex problem-solving
-- Powerful agentic and vibe coding capabilities
-- Computer Use support (built-in)
+- 1M context with tiered pricing above 200K
 
 **Specifications:**
 - Context window: ~1M tokens input
-- Long context surcharge: 2x above 200K tokens
-- Multimodal: Yes (text, image, video, audio)
+- Long context surcharge: 2× above 200K input tokens
+- Multimodal: text, image, video, audio
 
 **Best for:**
 - Complex analysis requiring deep reasoning
-- Tasks where quality matters more than cost
-- Advanced coding tasks
+- Tasks where Pro-tier judgment matters more than cost
+- Cases where Flash output isn't quite enough
 
 **Pricing:**
 - Input: $2.00 / 1M tokens (≤200K), $4.00 (>200K)
 - Output: $12.00 / 1M tokens (≤200K), $24.00 (>200K)
 
-**Note:** Replaces the deprecated `gemini-3-pro-preview` (shutting down March 9, 2026).
+**Note:** Google has signaled `gemini-3.5-pro` rolling out in June 2026.
+When it ships, `pro` alias will likely repoint there.
 
 ---
 
@@ -64,22 +87,22 @@ Detailed information about available Gemini models (as of March 2026).
 
 #### gemini-2.5-flash
 
-**Status:** Stable
+**Status:** Stable, generally available
 **Alias:** `stable-flash`
 
 **Strengths:**
-- Best price-performance for reasoning tasks
-- Production-grade stability
-- Large context window
+- Production stability without preview-tier volatility
+- Solid price-performance for reasoning tasks
+- Empirically token-perfect on dense transcription benchmarks (May 2026)
 
 **Specifications:**
 - Context window: ~1M tokens input
-- Multimodal: Yes (text, image, video, audio)
+- Multimodal: text, image, video, audio
 
 **Best for:**
-- Production workloads needing stability
-- High-volume tasks with budget constraints
-- When preview models are too volatile
+- Production workloads where preview models are too volatile
+- High-volume tasks with a quality floor
+- Multimodal extraction when cost matters but accuracy can't slip
 
 **Pricing:**
 - Input: $0.30 / 1M tokens
@@ -87,21 +110,23 @@ Detailed information about available Gemini models (as of March 2026).
 
 #### gemini-2.5-flash-lite
 
-**Status:** Stable
+**Status:** Stable, generally available
 **Alias:** `lite`
 
 **Strengths:**
-- Cheapest model in the lineup
-- Fast response times
-- Good quality for straightforward tasks
+- **Cheapest major-provider production model** ($0.10 / $0.40)
+- Surprisingly capable on multimodal extraction — empirically transcribes
+  dense tables on par with much pricier models
+- Fast: typically lowest latency in the lineup
 
 **Specifications:**
 - Context window: ~1M tokens input
-- Multimodal: Yes (text, image, video, audio)
+- Multimodal: text, image, video, audio
 
 **Best for:**
 - Ultra-budget batch processing
-- Simple classification and extraction
+- Routine triage tasks (zeitgeist runs, inbox review, bsky image
+  transcription, classification, simple extraction)
 - Maximum throughput at minimum cost
 
 **Pricing:**
@@ -110,23 +135,22 @@ Detailed information about available Gemini models (as of March 2026).
 
 #### gemini-2.5-pro
 
-**Status:** Stable
+**Status:** Stable, generally available
 **Alias:** `stable-pro`
 
 **Strengths:**
-- Advanced reasoning with production stability
-- Deep reasoning and coding capabilities
-- Well-documented behavior
+- Pro-tier reasoning with production stability
+- Well-documented behavior across long-running deployments
 
 **Specifications:**
 - Context window: ~1M tokens input
-- Long context surcharge: 2x above 200K tokens
-- Multimodal: Yes (text, image, video, audio)
+- Long context surcharge: 2× above 200K tokens
+- Multimodal: text, image, video, audio
 
 **Best for:**
 - Complex tasks requiring production stability
-- Long document processing
-- Quality-critical applications
+- Long-document processing
+- Quality-critical workloads
 
 **Pricing:**
 - Input: $1.25 / 1M tokens (≤200K), $2.50 (>200K)
@@ -136,17 +160,18 @@ Detailed information about available Gemini models (as of March 2026).
 
 ### Image Generation Models
 
+Unchanged from prior reference — see the existing `nano-banana-2`,
+`nano-banana-pro`, and `nano-banana` entries. The image surface didn't
+shift in the May 2026 update.
+
 #### nano-banana-2
 
 **Status:** Preview
 **API Model ID:** `gemini-3.1-flash-image-preview`
 **Alias:** `image`
 
-Fast image generation/editing built on Gemini 3.1 Flash Image platform:
-- Faster performance than previous generation
-- Sharper image-editing capabilities
-- Optimized for speed over maximum quality
-- Default image model in `generate_image()`
+Fast image generation/editing on the Gemini 3.1 Flash Image platform.
+Default image model in `generate_image()`.
 
 #### nano-banana-pro
 
@@ -154,35 +179,59 @@ Fast image generation/editing built on Gemini 3.1 Flash Image platform:
 **API Model ID:** `gemini-3-pro-image-preview`
 **Alias:** `image-pro`
 
-High-fidelity image generation with reasoning-enhanced composition:
-- Legible text rendering in images
-- Complex multi-turn editing workflows
-- Character consistency using up to 14 reference inputs
+High-fidelity generation with legible text rendering and character
+consistency across up to 14 reference inputs.
 
 #### nano-banana
 
 **Status:** Stable
 **API Model ID:** `gemini-2.5-flash-image`
 
-Image generation on the Gemini 2.5 Flash platform:
-- Production-grade stability
-- Good balance of quality and speed
-
-**Note:** Image models require `responseModalities: ["IMAGE", "TEXT"]` — handled automatically by `generate_image()`.
+Production-grade stability on the Gemini 2.5 Flash Image platform.
 
 ---
 
 ## Model Selection Guide
 
 ```
-Default / general purpose?        → gemini-3-flash-preview (alias: flash)
-Need maximum reasoning quality?   → gemini-3.1-pro-preview (alias: pro)
-Production stability required?    → gemini-2.5-flash (alias: stable-flash)
-Ultra-budget batch processing?    → gemini-2.5-flash-lite (alias: lite)
-Complex + stable production?      → gemini-2.5-pro (alias: stable-pro)
-Image generation (fast)?           → nano-banana-2 (alias: image)
-Image generation (high-fidelity)?  → nano-banana-pro (alias: image-pro)
+Default Flash (frontier)?              → gemini-3.5-flash (alias: flash)
+Maximum reasoning?                     → gemini-3.1-pro-preview (alias: pro)
+Production stability with quality?     → gemini-2.5-flash (alias: stable-flash)
+Routine / bulk / cheap?                → gemini-2.5-flash-lite (alias: lite)
+Complex + stable production?           → gemini-2.5-pro (alias: stable-pro)
+Pin to prior-gen Flash (back compat)?  → gemini-3-flash-preview (alias: flash-3)
+Image generation (fast)?               → nano-banana-2 (alias: image)
+Image generation (high-fidelity)?      → nano-banana-pro (alias: image-pro)
 ```
+
+## Thinking Configuration (Gemini 3.x family)
+
+Gemini 3.x models reason before responding. By default, the model spends
+output tokens on reasoning, then on the visible answer. For Gemini 3.5
+Flash specifically, the default is `medium` — down from `high` on prior
+3.x — and the parameter shape changed:
+
+- **Old:** integer `thinking_budget`
+- **New:** string enum `thinking_level` ∈ {`minimal`, `low`, `medium`, `high`}
+
+The Python client exposes this as `invoke_gemini(..., thinking_level="...")`.
+Pass `None` (default) to let the model use its built-in default.
+
+**When to set `thinking_level='minimal'`:**
+- Transcription, OCR, image-to-text
+- Classification, tagging, extraction with a fixed schema
+- Any task where the LLM doesn't need to reason — it just needs to emit
+
+**When to leave it as default or set higher:**
+- Code generation, debugging
+- Multi-step planning
+- Math, complex analysis
+
+**Why it matters:** A `max_output_tokens=50` request can return empty if
+thinking_level (default `medium` on 3.5) consumes all 50 tokens before
+emitting visible output. Symptom: response text is empty, `finishReason`
+is `MAX_TOKENS`. Fix: either raise `max_output_tokens` substantially or
+set `thinking_level='minimal'`.
 
 ## Multimodal Capabilities
 
@@ -191,15 +240,15 @@ All text models support:
 - **Video:** MP4, MPEG, MOV, AVI, FLV, MPG, WebM, WMV, 3GPP
 - **Audio:** WAV, MP3, AIFF, AAC, OGG, FLAC
 
-**Audio input pricing:**
-- Audio input is priced higher than text (e.g., $1.00/1M tokens for Flash models)
+**Audio input pricing:** Higher than text, typically ~$1.00 / 1M tokens
+on Flash-tier models.
 
 ## Deprecated / Retired Models
 
 | Model | Status | Migration Target |
 |---|---|---|
-| gemini-3-pro-preview | Deprecated (shutdown March 9, 2026) | gemini-3.1-pro-preview |
-| gemini-2.0-flash-exp | Retiring June 1, 2026 | gemini-3-flash-preview |
+| gemini-3-pro-preview | Retired (March 9, 2026) | gemini-3.1-pro-preview |
+| gemini-2.0-flash-exp | Retiring June 1, 2026 | gemini-3.5-flash |
 | gemini-2.0-flash | Retiring June 1, 2026 | gemini-2.5-flash |
 | gemini-2.0-flash-lite | Retiring June 1, 2026 | gemini-2.5-flash-lite |
 | gemini-1.5-pro | Retired (404) | gemini-2.5-pro |
@@ -208,10 +257,11 @@ All text models support:
 
 ## Cost Optimization Tips
 
-- **Batch API:** 50% discount on all paid models for async processing
-- **Context caching:** Up to 75-90% savings for repeated large prompts
-- **Long context:** Pro models charge 2x above 200K tokens — keep prompts concise
-- **Free tier:** All models include up to 1,000 daily requests on the free tier
+- **Batch API:** 50% discount on all paid models for async (≤24h) processing
+- **Context caching:** Up to 75–90% savings for repeated large prompts
+- **Long context:** Pro models charge 2× above 200K tokens — keep prompts concise
+- **Free tier:** Gemini app + AI Studio offer free access to Flash and Lite
+  models with daily quotas; Pro is paid-only as of April 2026
 
 ## Rate Limits
 

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -49,7 +49,9 @@ if not HAS_REQUESTS and not HAS_GENAI:
 
 # Text generation models
 MODELS = {
-    # Gemini 3.x — frontier (preview)
+    # Gemini 3.5 — frontier (GA May 2026)
+    "gemini-3.5-flash": "gemini-3.5-flash",
+    # Gemini 3.x — preview (still callable, kept for back compat)
     "gemini-3-flash-preview": "gemini-3-flash-preview",
     "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
     # Gemini 2.5 — stable production
@@ -65,9 +67,11 @@ IMAGE_MODELS = {
     "nano-banana": "gemini-2.5-flash-image",
 }
 
-# Convenience aliases
+# Convenience aliases. `flash` points to the current frontier Flash (3.5);
+# `flash-3` keeps a stable handle on the prior preview for code that pinned to it.
 MODEL_ALIASES = {
-    "flash": "gemini-3-flash-preview",
+    "flash": "gemini-3.5-flash",
+    "flash-3": "gemini-3-flash-preview",
     "pro": "gemini-3.1-pro-preview",
     "lite": "gemini-2.5-flash-lite",
     "stable-flash": "gemini-2.5-flash",
@@ -76,7 +80,7 @@ MODEL_ALIASES = {
     "image-pro": "nano-banana-pro",
 }
 
-DEFAULT_MODEL = "gemini-3-flash-preview"
+DEFAULT_MODEL = "gemini-3.5-flash"
 
 # ---------------------------------------------------------------------------
 # Cloudflare AI Gateway constants
@@ -390,6 +394,7 @@ def invoke_gemini(
     top_p: Optional[float] = None,
     top_k: Optional[int] = None,
     image_path: Optional[str] = None,
+    thinking_level: Optional[str] = None,
 ) -> Optional[str]:
     """
     Invoke Gemini model with a text (or multi-modal) prompt.
@@ -399,19 +404,34 @@ def invoke_gemini(
 
     Args:
         prompt: The text prompt to send
-        model: Model name or alias (default: gemini-3-flash-preview).
-            Aliases: flash, pro, lite, stable-flash, stable-pro
+        model: Model name or alias (default: gemini-3.5-flash).
+            Aliases: flash (3.5), flash-3 (prior preview), pro, lite,
+            stable-flash, stable-pro
         temperature: Sampling temperature (0.0–1.0)
-        max_output_tokens: Maximum tokens in response
+        max_output_tokens: Maximum tokens in response. Note: with thinking
+            models (Gemini 3.x), thinking tokens consume part of this budget;
+            set generously or use thinking_level='minimal' for non-reasoning
+            tasks.
         top_p: Nucleus sampling parameter
         top_k: Top-k sampling parameter
         image_path: Optional path to image file for multi-modal input
+        thinking_level: Reasoning budget for thinking models (Gemini 3.x).
+            One of 'minimal', 'low', 'medium', 'high'. Default (None) lets
+            the model use its built-in default — 'medium' for 3.5 Flash,
+            which silently eats output budget. Set 'minimal' for tasks that
+            don't need reasoning (transcription, classification, extraction).
+            Ignored by 2.5 models (which use a different parameter).
 
     Returns:
         Response text if successful, None if error
     """
     model_id = _resolve_model(model)
     cf_creds = get_cf_credentials()
+
+    # thinking_level is a Gemini 3.x feature. 2.5 (and earlier) models 400 on it.
+    # Silently drop for non-3.x so callers can pass it uniformly without branching.
+    if thinking_level is not None and not model_id.startswith("gemini-3"):
+        thinking_level = None
 
     max_retries = 3
     for attempt in range(max_retries):
@@ -426,6 +446,8 @@ def invoke_gemini(
                     gen_cfg["topP"] = top_p
                 if top_k is not None:
                     gen_cfg["topK"] = top_k
+                if thinking_level is not None:
+                    gen_cfg["thinkingConfig"] = {"thinkingLevel": thinking_level}
 
                 response = _cf_request(model_id, contents, gen_cfg, cf_creds)
                 return _extract_text(response)
@@ -442,6 +464,9 @@ def invoke_gemini(
                     gen_cfg_sdk["top_p"] = top_p
                 if top_k is not None:
                     gen_cfg_sdk["top_k"] = top_k
+                if thinking_level is not None:
+                    # SDK uses snake_case; mapped to thinking_config later.
+                    gen_cfg_sdk["thinking_config"] = {"thinking_level": thinking_level}
 
                 model_instance = genai.GenerativeModel(
                     model_name=model_id,


### PR DESCRIPTION
*Filed by Muninn*

Updates the `invoking-gemini` skill to reflect May 2026 reality. Three drifts in the prior docs/code:

1. **Missing Gemini 3.5 Flash** — released GA at Google I/O 2026 on May 19. Headline claim: outperforms Gemini 3.1 Pro on most coding/agentic benchmarks, 4× faster output tokens. Stable API ID `gemini-3.5-flash` (no preview suffix). Pricing: $1.50 input / $9.00 output per 1M tokens, 1M context.

2. **Stale `flash`/`lite` aliases** — the alias `flash` pointed at `gemini-3-flash-preview` (still callable, but no longer the frontier Flash). The `lite` alias resolved to `gemini-2.5-flash-lite` ($0.10/$0.40) but the SKILL.md docs claimed `gemini-3.1-flash-lite-preview` at $0.25/$1.50. The resolver was right; the docs were wrong.

3. **Missing `thinking_level` parameter** — Gemini 3.x models reason before responding. The parameter changed in 2026 from integer `thinking_budget` to string enum `thinking_level` ∈ {`minimal`, `low`, `medium`, `high`}. Default for 3.5 Flash is `medium` (down from `high` on prior 3.x). Without exposing this, calls to 3.5 Flash with modest `max_output_tokens` silently spend the budget on thinking and return empty responses with `finishReason=MAX_TOKENS`. Diagnosed when 3.5 Flash returned 160-char truncated outputs on a 1000-token budget; raising to 8000 fixed it, but `thinking_level='minimal'` is the right knob for non-reasoning tasks.

## Changes

**`invoking-gemini/scripts/gemini_client.py`:**
- Added `gemini-3.5-flash` to `MODELS`
- Repointed `flash` alias to `gemini-3.5-flash`
- Added `flash-3` alias pinning the prior preview (back compat)
- Set `DEFAULT_MODEL = "gemini-3.5-flash"`
- Added `thinking_level: Optional[str]` parameter to `invoke_gemini()`, threaded into both CF Gateway and SDK paths
- Silently drops `thinking_level` for non-3.x model IDs (2.5 returns 400 if it's passed), so callers can pass uniformly without branching

**`invoking-gemini/SKILL.md`** (v0.5.0 → v0.6.0):
- Replaced the Available Models table with corrected current-as-of-May-2026 entries
- Added "Thinking Budget (Gemini 3.x family)" section documenting `thinking_level` and the symptom of empty MAX_TOKENS responses
- Updated all code examples to use `model="flash"` (or `lite`) instead of the now-stale `model="gemini-3-flash-preview"` strings

**`invoking-gemini/references/models.md`** — rewritten end-to-end. Adds full 3.5 Flash entry, corrects 3-flash-preview status to "prior preview / back compat," removes the fake `gemini-3.1-flash-lite-preview` entry that never resolved, updates Model Selection Guide and Deprecated table.

## Validation

Smoke-tested all four affected paths via the Cloudflare AI Gateway:
- `invoke_gemini("Say 'ok'", model="flash")` → resolves to `gemini-3.5-flash`, returns `'ok'`
- `invoke_gemini(..., model="flash", thinking_level="minimal")` → 0.8s (vs 1.6s default) — confirms parameter is honored
- `invoke_gemini(..., model="lite", thinking_level="minimal")` → 0.6s — confirms silent drop for 2.5 models (otherwise gateway returns 400)
- `invoke_gemini(..., model="flash-3")` → resolves to `gemini-3-flash-preview` — back compat preserved

Also bench-tested on three image transcription tasks (real bsky CDN images, single run each) to validate `thinking_level='minimal'` produces sensible output sizes rather than silently truncating:

| Model | Latency | Output chars | Chord-token recall on dense table |
|---|---|---|---|
| `gemini-3.5-flash` | 10.5s | 3466 | 22/22 |
| `gemini-2.5-flash` | 11.2s | 3046 | 22/22 |
| `gemini-2.5-flash-lite` | 8.4s | 3312 | 21/22 |

## Out of scope

- 3.5 Pro is announced for June 2026 — `pro` alias will likely need repointing when it ships. Holding off until model ID is published.
- Managed Agents API announced at I/O isn't wired in; that's a separate skill addition, not a model-table update.
- Free-tier rate limits in SKILL.md are kept conservative — Google's exact published limits vary per tier; not relevant to most callers.

## Coordinates with PR #668

PR #668 (`feat/bsky-image-transcription`) extends `image_transcribe.py` with Gemini aliases (`gemini-lite`, `gemini-flash`, `gemini-3.5-flash`) that route through this updated `gemini_client`. The two PRs are independent — #668 falls back gracefully if `invoke_gemini` doesn't know about the new model strings — but the empirical Pareto frontier reported in #668's docs assumes the Gemini surface in this PR. Suggest merging this one first.
