### PR TITLE
feat(challenging): add continuity criterion to prose profile

### DIFF
--- a/challenging/references/prose.md
+++ b/challenging/references/prose.md
@@ -22,6 +22,7 @@
 3. **False balance**: Hedging to the point of saying nothing?
 4. **Explaining the subtext**: Telling the reader what to feel, or trusting the facts?
 5. **Delta test**: What does this piece add that didn't exist before?
+6. **Continuity**: Does each paragraph's last sentence set up the next paragraph's first sentence? Specifically watch for: a topic dominates paragraph N, then paragraph N+1 announces a decision about a DIFFERENT topic without bridging — reader hits a non-sequitur even if both topics are correct.
 
 ## System Prompt
 
@@ -38,6 +39,7 @@ Your job is NOT style critique. Your job:
 3. Does the piece say something worth saying? What's the delta over what already exists?
 4. Is the most important point leading, or is it buried?
 5. Does the piece explain its own subtext? (This kills writing. Flag it.)
+6. Does each paragraph's last sentence set up the next paragraph's first sentence? Specifically: if a topic dominates paragraph N and N+1 announces a decision about a DIFFERENT topic, the reader hits a non-sequitur even if both are correct. Flag missing bridges.
 
 Do NOT comment on tone, formatting, or style unless it creates genuine ambiguity.
 


### PR DESCRIPTION
*Filed by Muninn*

Adds a continuity criterion to the prose review profile. Caught a real reader-experience gap in a recent draft that the existing five criteria didn't flag.

## The failure mode

In a draft for muninn.austegard.com about model selection, paragraph 4 dominated on `gemini-3.5-flash` (new model, release date, API parameter quirks). Paragraph 5 then closed with "...flipped the default from Haiku to Lite." Reader hits a non-sequitur: they'd been building a mental model around 3.5 Flash for the last paragraph and the closer suddenly chose a different Gemini variant with no bridge. Both choices were correct; the prose was incoherent.

Existing prose criteria didn't catch it:
- Not a claims-audit issue (every claim true)
- Not a buried-lede issue (lede was fine)
- Not false balance (no hedging)
- Not subtext-explaining (no moralizing)
- Not a delta issue (delta was clear)

It was a missing bridge — a continuity gap that's a reader-experience problem, not a rule violation. Without a criterion for it, the critic shipped the draft as REVISE for other reasons and missed this one.

## Changes

`challenging/references/prose.md`:
- Adds criterion #6 "Continuity" to the Evaluation Criteria list
- Adds the equivalent #6 to the system prompt's job list

Wording targets the specific failure pattern: when a topic dominates paragraph N and paragraph N+1 announces a decision about a DIFFERENT topic, flag the missing bridge.

## Caveats

- Generic continuity ("does paragraph N flow to N+1?") is easy to over-apply — every essay has some flow, and the critic could spam findings. The criterion is scoped to the specific failure mode: same-domain, different-subject jumps.
- This is one round of evidence. Other failure modes may exist that this criterion doesn't catch. If it starts producing false positives (flagging legitimate topic shifts as bridge failures), the wording needs refinement.

## Out of scope

- No equivalent criterion added to `prose-register` — that profile is voice-only and continuity is a separate concern.
- No changes to other profiles (analysis, code, recommendation) — continuity is most salient for narrative-shaped writing.
