### PR TITLE
down-skilling v1.2.0: enforce example calibration (source-anchoring, length-matching, audit step)

### DIFF
--- a/down-skilling/CHANGELOG.md
+++ b/down-skilling/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `down-skilling` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2026-05-26
+
+### Added
+
+- **Source-anchoring** requirement in Example Quality Criteria. Every
+  concrete fact in an example output must trace to that example's
+  input; invented facts cause Haiku to copy the invention pattern at
+  runtime.
+- **Length-calibration** requirement in Example Quality Criteria.
+  Example output lengths must sit inside the stated output range —
+  rules don't override the example central tendency.
+- **"When the input could be abstract: model the silence"** subsection
+  with a worked example showing the input → output pattern that lets
+  Haiku acknowledge what the source omits rather than filling the gap.
+- **Tagged BAD/GOOD pair** is now the default negative-example
+  pattern for confabulation-prone tasks (rewriting, summarization,
+  NL→command). Updated the distribution-table row to reflect this.
+- **Activation step 5: audit your example set** — source-anchoring +
+  length-calibration check before delivering the prompt. Existing
+  Deliver step renumbered to 6.
+
+### Why
+
+Validated by experiments at
+[oaustegard/claude-workspace/experiments/haiku-assessment/](https://github.com/oaustegard/claude-workspace/tree/main/experiments/haiku-assessment).
+The un-calibrated voice-rewrite prompt produced architectural
+hallucination in 19/20 Haiku runs; the calibrated rerun produced 0/5.
+
 ## [1.1.0] - 2026-03-02
 
 ### Added

--- a/down-skilling/SKILL.md
+++ b/down-skilling/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   a smaller model with high reliability.
 metadata:
   author: Oskar Austegard and Opus
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Down-Skilling: Opus → Haiku Distillation
@@ -77,7 +77,23 @@ When triggered, perform these steps:
 4. **Generate 4-7 diverse examples** following the principles in
    [Example Design](#example-design) — this is the highest-leverage step
 
-5. **Deliver** the complete Haiku-ready prompt as a copyable artifact or
+5. **Audit your example set before delivering.** Two checks, both must pass:
+   - **Source-anchoring**: for each example output, every concrete fact
+     (named technology, number, comparison, quoted phrase) is inferrable
+     from that example's input. If you can't reproduce the output knowing
+     only the input, either add the detail to the input or remove it from
+     the output. Invented facts in examples cause Haiku to copy the
+     invention pattern at runtime.
+   - **Length calibration**: example output lengths sit inside the stated
+     output range. If your rule says "60–90 words" but your examples
+     average 35, the rule will not hold — Haiku follows the example
+     central tendency.
+
+   If either check fails, regenerate the offending examples before
+   delivering. Examples beat rules; misaligned examples beat aligned
+   rules.
+
+6. **Deliver** the complete Haiku-ready prompt as a copyable artifact or
    file, including system prompt and user prompt components as appropriate
 
 ## Prompt Architecture
@@ -189,7 +205,7 @@ to the reliability improvement. Use this distribution:
 | 1 | **Typical case** | The most common, straightforward input. Establishes the baseline pattern. |
 | 2 | **Second typical variant** | A different but common input — varies length, domain, or structure from #1. Prevents Haiku from over-fitting to a single pattern. |
 | 3 | **Edge case** | Unusual but valid input: empty fields, very long text, special characters, boundary conditions, ambiguous phrasing. |
-| 4 | **Negative/rejection case** | Input that should be rejected, handled differently, or produce an empty/default output. Shows Haiku what NOT to do. |
+| 4 | **Negative case (tagged BAD/GOOD pair)** | For tasks where Haiku could output something plausible-but-wrong (rewriting, summarization, NL→command, anything that rewards confident specificity), include an example pair tagged "BAD output:" and "GOOD output:" that demonstrates the *specific* failure mode you want to prevent for this task — invented architecture details, invented CLI flags, invented numbers, etc. A generic "bad output" example is much less effective than one that names the failure category Haiku is most likely to fall into. |
 | 5+ | **Tricky/boundary cases** | Inputs near decision boundaries where Haiku is most likely to fail. The cases you'd use for a test suite. |
 
 **Why the second typical case matters:** With only one typical example,
@@ -218,6 +234,52 @@ a chain-of-thought anchor, showing Haiku the reasoning pattern to follow.
 For classification and extraction tasks, reasoning should reference the
 specific rule numbers that drive the decision.
 
+### When the input could be abstract: model the silence
+
+Some tasks (rewriting, summarization, voice/register editing,
+explanation-from-source) take inputs where the source content is
+*itself* abstract — marketing copy, vague descriptions, high-level
+summaries. These tasks are uniquely prone to a failure mode where
+Haiku invents concrete details that *sound right for the domain* but
+aren't in the source.
+
+**Symptom:** an output that confidently mentions specifics — algorithm
+names, technology choices, percentile numbers, version comparisons —
+not present in the input.
+
+**Fix:** include an example pair where the input is genuinely abstract
+and the output **explicitly acknowledges what is unspecified**, rather
+than filling the gap with plausible-sounding inferences. Pattern:
+
+```xml
+<example>
+<input>
+"We're excited to release our new search backend. We think it's a
+massive upgrade over the old one."
+</input>
+<output>
+New search backend released. The announcement does not specify the
+underlying changes — whether they affect indexing, ranking, query
+parsing, or operational characteristics is not stated. Migration
+guidance will follow. The old search path remains available during
+transition.
+</output>
+<reasoning>
+The source provides only one factual claim ("released") and one
+unverifiable claim ("upgrade"). The output stays at the source's
+level of abstraction and explicitly names the categories of
+information the source omits, rather than inventing plausible
+specifics (algorithm changes, performance numbers, technology names).
+</reasoning>
+</example>
+```
+
+Pair this with the tagged BAD/GOOD negative example (row 4 in the
+distribution table above) that demonstrates the exact invention you
+want to prevent. On a voice-rewrite task, switching from un-anchored
+examples to this pattern dropped Haiku's architectural-hallucination
+rate from 95% to 0% (n=25 across two probes).
+
 ### Example Sizing Guidance
 
 | Task processing... | Recommended example budget |
@@ -240,6 +302,18 @@ drops sharply unless the task has a very large classification space.
 - Never include an example that contradicts your rules
 - Order examples from simplest to most complex — this progressive
   difficulty helps Haiku build up its understanding
+- **Source-anchor every concrete fact.** Each specific noun, number, or
+  claim in an example *output* must be inferrable from that example's
+  *input*. If your example output invents a plausible architectural
+  detail, Haiku will copy that invention pattern even when its real
+  input doesn't support it. Audit by covering the input and asking:
+  "could I have produced this output knowing only the input?" If not,
+  fix one or the other.
+- **Match example length to the stated output range.** Examples
+  outweigh rules on length. If your rules say "output 60–90 words" but
+  your examples average 35 words, Haiku will produce ~35 words.
+  Calibrate example output lengths to sit inside (or slightly above)
+  the stated output range.
 
 ## Delivery Format
 


### PR DESCRIPTION
## Summary

The skill already says *examples dominate rules*. It didn't give the example author a procedure to keep examples aligned with the rules they're supposed to demonstrate. This PR closes that gap.

Validated by experiments in
[oaustegard/claude-workspace experiments/haiku-assessment/](https://github.com/oaustegard/claude-workspace/tree/main/experiments/haiku-assessment).
The original probe (n=20 per cell) hit a Haiku failure mode where a down-skilled voice-rewrite prompt produced architectural hallucination in **19/20 runs** — because the example outputs in the prompt invented plausible-but-source-disconnected specifics (JWTs, Highcharts, server-side rendering), and Haiku faithfully copied the pattern. The calibrated rerun (T3b) with source-anchored, length-matched examples plus a tagged BAD example dropped the hallucination rate to **0/5**.

## Changes

**Example Quality Criteria** — two new bullets:
- **Source-anchor every concrete fact.** Each specific noun, number, or claim in an example output must be inferrable from that example's input.
- **Match example length to the stated output range.** Examples outweigh rules on length.

**New subsection: "When the input could be abstract: model the silence"** — worked example pattern for rewriting / summarization / voice tasks where the source content is itself abstract. Demonstrates the "acknowledge what the source omits" output style instead of filling the gap with plausible inferences.

**Distribution table — Negative-case row strengthened** — for confabulation-prone tasks, the negative example should be a tagged BAD/GOOD pair that demonstrates the *specific* failure mode for the task (invented architecture / invented CLI flags / invented numbers), not a generic bad output.

**Activation procedure — new step 5: "Audit your example set"** — apply source-anchoring and length-calibration checks before delivering. Existing Deliver step renumbered to 6.

**Version bump** 1.1.0 → 1.2.0. CHANGELOG updated.

## Validation

- n=20 baseline T3 (un-calibrated examples): 19/20 (95%) hallucinated architecture; 0/20 in 60–90 word range; avg 43 words.
- n=5 T3b (calibrated examples): 0/5 hallucinated; still 0/5 in range but avg moved to 52 words. Length problem partially solved by example calibration; hallucination problem fully solved.
- 5/6 archetypes in the broader probe (extraction, changelog, filter/sort, NL→gh CLI, copyedit) showed clean down-skilling wins; none regressed. The T7 case (vanilla Haiku hallucinated `--sort` and `--order` flags that don't exist in `gh pr list` 5/5 times) is the most actionable demonstration of why the tagged BAD/GOOD pattern matters.

## Test plan

- [x] Frontmatter still parses (yaml.safe_load); version reads as 1.2.0
- [x] All new sections present and reachable from anchors
- [x] No format inconsistencies introduced (existing bullet style, table format preserved)
- [x] Diff is additive — no existing rules removed or contradicted