### PR TITLE
Add surface routing to orchestration skills (native CC workflows vs custom)

### DIFF
--- a/convening-experts/SKILL.md
+++ b/convening-experts/SKILL.md
@@ -5,6 +5,25 @@ metadata:
   version: 1.0.3
 ---
 
+## SURFACE ROUTING — read first
+
+This skill hand-rolls subagent orchestration via raw Anthropic API calls. A
+managed runtime now does the same job. Which one to use depends on your surface:
+
+- **In Claude Code (incl. CCotw): use the native runtime, NOT this skill.** If you
+  can invoke `/deep-research`, trigger a run with the `workflow` keyword, set
+  `/effort ultracode`, or spawn Task subagents — do that instead. The runtime gives
+  16-concurrent / 1000-agent ceilings, an approval gate, adversarial cross-review,
+  and in-session resume that this skill would otherwise reimplement badly. Dynamic
+  workflows shipped in research preview (Claude Code v2.1.154+, 2026).
+- **In claude.ai chat or the bare API (no workflow runtime): use this skill.**
+  Parallel API instances over httpx is the only fan-out path here. `muninn_utils.dispatch`
+  (17 pre-built lenses) already implements this panel over orchestrating-agents' execution
+  model — prefer it over rebuilding the panel by hand. Proceed below.
+
+Discriminator: do you have a native subagent/Task tool or a workflow command? Yes
+→ native. No → this skill. Never reimplement the runtime where it already exists.
+
 # Convening Experts
 
 Convene domain experts and methodological specialists to solve problems through multi-round collaborative discussion. Experts build on each other's insights, challenge assumptions, and synthesize recommendations.

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -5,6 +5,20 @@ metadata:
   version: 1.3.2
 ---
 
+## NOT SUPERSEDED BY DYNAMIC WORKFLOWS — read first
+
+Claude Code's dynamic workflows orchestrate **subagents** (separate contexts,
+fan-out to 16-concurrent / 1000-agent). This skill is a **different primitive**:
+single-context control flow over YOUR OWN tool calls, with durable side-effects
+and checkpoint resume. The workflows runtime explicitly cannot touch the
+filesystem or shell directly — its agents do the work and the script only
+coordinates them. Flowing is the inverse: the script does the work.
+
+Use flowing for an in-context pipeline (3+ steps, branches, retries, validation,
+detached side-effects). Use a workflow when you need many subagents. They compose;
+they do not compete. Do not abandon flowing for a workflow — you would lose the
+durable side-effects and the cross-session checkpoint that hub-spoke depends on.
+
 # Flowing — Control Flow in Code, Not Prose
 
 When a procedure needs 3+ steps with branches, retries, or contracts, encode it as a DAG of Python tasks instead of prose imperatives. Prose like "first X, then Y, then if Z retry 3×" is read and generated past. A `@task` graph is structural: a step physically cannot run until its inputs are bound, and gates that fire on bad inputs can't be skipped.

--- a/orchestrating-agents/SKILL.md
+++ b/orchestrating-agents/SKILL.md
@@ -5,6 +5,23 @@ metadata:
   version: 0.4.0
 ---
 
+## SURFACE ROUTING — read first
+
+This skill hand-rolls subagent orchestration via raw Anthropic API calls. A
+managed runtime now does the same job. Which one to use depends on your surface:
+
+- **In Claude Code (incl. CCotw): use the native runtime, NOT this skill.** If you
+  can invoke `/deep-research`, trigger a run with the `workflow` keyword, set
+  `/effort ultracode`, or spawn Task subagents — do that instead. The runtime gives
+  16-concurrent / 1000-agent ceilings, an approval gate, adversarial cross-review,
+  and in-session resume that this skill would otherwise reimplement badly. Dynamic
+  workflows shipped in research preview (Claude Code v2.1.154+, 2026).
+- **In claude.ai chat or the bare API (no workflow runtime): use this skill.**
+  Parallel API instances over httpx is the only fan-out path here. Proceed below.
+
+Discriminator: do you have a native subagent/Task tool or a workflow command? Yes
+→ native. No → this skill. Never reimplement the runtime where it already exists.
+
 # Orchestrating Agents
 
 This skill enables programmatic API invocations for advanced workflows including parallel processing, task delegation, and multi-agent analysis using the Anthropic API.

--- a/orchestrating-skills/SKILL.md
+++ b/orchestrating-skills/SKILL.md
@@ -12,6 +12,23 @@ metadata:
   depends_on: []
 ---
 
+## SURFACE ROUTING — read first
+
+This skill hand-rolls subagent orchestration via raw Anthropic API calls. A
+managed runtime now does the same job. Which one to use depends on your surface:
+
+- **In Claude Code (incl. CCotw): use the native runtime, NOT this skill.** If you
+  can invoke `/deep-research`, trigger a run with the `workflow` keyword, set
+  `/effort ultracode`, or spawn Task subagents — do that instead. The runtime gives
+  16-concurrent / 1000-agent ceilings, an approval gate, adversarial cross-review,
+  and in-session resume that this skill would otherwise reimplement badly. Dynamic
+  workflows shipped in research preview (Claude Code v2.1.154+, 2026).
+- **In claude.ai chat or the bare API (no workflow runtime): use this skill.**
+  Parallel API instances over httpx is the only fan-out path here. Proceed below.
+
+Discriminator: do you have a native subagent/Task tool or a workflow command? Yes
+→ native. No → this skill. Never reimplement the runtime where it already exists.
+
 # Skill-Aware Orchestration
 
 Orchestrate complex multi-step tasks through a four-phase pipeline that eliminates


### PR DESCRIPTION
*Filed by Muninn*

Dynamic workflows shipped in Claude Code (research preview, v2.1.154+). They cover
the same job three of our orchestration skills hand-roll — but only on the Claude
Code surface. This adds surface-routing so a session reaches for the right tool.

**Redirect blocks** (CCotw → native runtime; claude.ai / bare API → this skill):
- `orchestrating-agents` — the direct overlap. Native `/deep-research`, the
  `workflow` keyword, `ultracode`, or Task subagents beat hand-rolled API fan-out
  on CC (concurrency ceilings, approval gate, adversarial cross-review, in-session
  resume). claude.ai has no workflow runtime, so the skill stays the only path here.
- `orchestrating-skills` — same redirect; the skill-typed context-routing layer has
  no native equivalent and stays local.
- `convening-experts` — the multi-round adversarial-panel pattern is now a native
  workflow quality pattern. Block also points at `muninn_utils.dispatch` (already
  absorbed this skill's value, 2026-03-07) on the local surface.

**Disambiguation block** (NOT a redirect):
- `flowing` — different primitive. Workflows orchestrate subagents; flowing is
  single-context control flow over your own tool calls + durable side-effects +
  cross-session checkpoint. The note exists so a future CC session does not wrongly
  abandon flowing for a workflow.

Authored under skill-language-compliance: imperative voice, each redirect lands on
a concrete invocation (not "consider"), social-proof grounding (version + ceilings),
two-armed on surface so it never tells claude.ai to drop the skill.

Source convo: dynamic-workflows docs review, 2026-05-28.