### PR TITLE
invoking-gemini: Nano Banana 2/Pro GA — keep -preview IDs on Developer API surface

### DIFF
--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -1,5 +1,16 @@
 # invoking-gemini - Changelog
 
+## 2026-05-28
+- Nano Banana 2 (`gemini-3.1-flash-image-preview`) and Nano Banana Pro
+  (`gemini-3-pro-image-preview`) reached GA on Vertex / Gemini Enterprise.
+- Kept the `-preview` model IDs: the Gemini Developer API surface this client
+  uses still serves both under `-preview` (GA IDs without the suffix are
+  Vertex-only and 404 here). Verified against the live image-generation docs.
+- Documented capabilities: 512/1K/2K GA + 4K preview, up to 14 reference
+  images, Search + Image-Search grounding (3.1 Flash), thinking_level control.
+- Noted video-as-input is a Vertex preview only; not available on the Developer API.
+
+
 All notable changes to the `invoking-gemini` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.6.0] - 2026-05-23

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -160,34 +160,59 @@ When it ships, `pro` alias will likely repoint there.
 
 ### Image Generation Models
 
-Unchanged from prior reference — see the existing `nano-banana-2`,
-`nano-banana-pro`, and `nano-banana` entries. The image surface didn't
-shift in the May 2026 update.
+**Updated 2026-05-28:** Nano Banana 2 and Nano Banana Pro reached general
+availability — announced GA on Vertex AI / Gemini Enterprise Agent Platform,
+where the GA model IDs drop the suffix (`gemini-3.1-flash-image`,
+`gemini-3-pro-image`).
+
+⚠️ This client calls the **Gemini Developer API**
+(`generativelanguage.googleapis.com`, via the CF `google-ai-studio` gateway),
+NOT Vertex. On the Developer API both models are **still served under the
+`-preview` model IDs** (verified against the live image-generation docs,
+2026-05-28). Do NOT drop the `-preview` suffix on this surface — the GA IDs are
+a Vertex-only convention and 404 here.
 
 #### nano-banana-2
 
-**Status:** Preview
+**Status:** GA on Vertex; Developer API still serves it as `-preview` (this client's surface)
 **API Model ID:** `gemini-3.1-flash-image-preview`
 **Alias:** `image`
 
-Fast image generation/editing on the Gemini 3.1 Flash Image platform.
-Default image model in `generate_image()`.
+Fast generation/editing on the Gemini 3.1 Flash Image platform. Default image
+model in `generate_image()`. Capabilities on the Developer API:
+- Output resolutions: 512 (0.5K), 1K, 2K generally available; 4K in preview.
+  512 is 3.1-Flash-only.
+- Up to 14 reference images (up to 10 high-fidelity objects + up to 4 characters).
+- Grounding with Google Search, plus Image Search grounding (3.1-Flash-only) —
+  cannot search for images of people.
+- Thinking: `thinking_level` is {`minimal` (default), `high`}; thinking cannot be
+  fully disabled and thinking tokens are billed.
+- Extra aspect ratios over 2.5 Flash Image: 1:4, 4:1, 1:8, 8:1.
+
+Note: the GA announcement's "video file as input prompt" capability is a Vertex
+preview feature. The Developer API does NOT accept video or audio input for
+image generation — don't route video here.
 
 #### nano-banana-pro
 
-**Status:** Preview
+**Status:** GA on Vertex; Developer API still serves it as `-preview` (this client's surface)
 **API Model ID:** `gemini-3-pro-image-preview`
 **Alias:** `image-pro`
 
-High-fidelity generation with legible text rendering and character
-consistency across up to 14 reference inputs.
+High-fidelity generation on the Gemini 3 Pro Image platform — legible stylized
+text rendering and professional asset production via advanced "thinking."
+Capabilities:
+- Output resolutions: 1K, 2K generally available; 4K in preview.
+- Up to 14 reference images (up to 6 high-fidelity objects + up to 5 characters).
+- Thinking always on (cannot be disabled).
 
 #### nano-banana
 
-**Status:** Stable
+**Status:** Stable, GA (unchanged)
 **API Model ID:** `gemini-2.5-flash-image`
 
-Production-grade stability on the Gemini 2.5 Flash Image platform.
+Production-grade stability on the Gemini 2.5 Flash Image platform. Works best
+with up to 3 input images.
 
 ---
 

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -60,7 +60,12 @@ MODELS = {
     "gemini-2.5-pro": "gemini-2.5-pro",
 }
 
-# Image generation models — display name → actual API model ID
+# Image generation models — display name -> actual API model ID.
+# NOTE (2026-05-28): Nano Banana 2 / Pro went GA on Vertex (IDs there drop
+# the suffix: gemini-3.1-flash-image / gemini-3-pro-image). This client uses
+# the Gemini Developer API (google-ai-studio gateway), where both are STILL
+# served under the -preview IDs below (verified against the live docs).
+# Do NOT drop -preview here — the GA IDs are Vertex-only and 404 on this surface.
 IMAGE_MODELS = {
     "nano-banana-2": "gemini-3.1-flash-image-preview",
     "nano-banana-pro": "gemini-3-pro-image-preview",


### PR DESCRIPTION
*Filed by Muninn*

Nano Banana 2 and Nano Banana Pro went GA (announced 2026-05-28). Updating the invoking-gemini menu — but **not** the way the announcement reads at first glance.

**Key finding (verified, not assumed):** the GA model IDs in the Google Cloud post (`gemini-3.1-flash-image`, `gemini-3-pro-image`) are the **Vertex / Gemini Enterprise** convention. This skill's `gemini_client.py` calls the **Gemini Developer API** (`generativelanguage.googleapis.com`) through the CF `google-ai-studio` gateway. The live Developer-API image-generation docs (fetched 2026-05-28) **still serve both models under the `-preview` IDs** in every code sample. Dropping the suffix would 404 image-gen on our surface.

So:
- `IMAGE_MODELS` IDs **unchanged** — `-preview` is still correct here. Added a comment so a future reader doesn't "fix" it by dropping the suffix.
- `models.md` image section: status Preview → **GA on Vertex / `-preview` on Developer API**, with the surface caveat spelled out.
- Documented newly-confirmed capabilities: 512/1K/2K GA + 4K preview (512 is 3.1-Flash-only), up to 14 reference images, Search + Image-Search grounding (3.1 Flash only), `thinking_level` control.
- Flagged that the announcement's **video-as-input** feature is **Vertex preview only** — the Developer API rejects video/audio input for image gen, so don't route video here.

No functional code change; menu + docs accuracy only.

Source: cloud.google.com GA post + ai.google.dev/gemini-api/docs/image-generation, both 2026-05-28.