### PR TITLE
Add optimizing-skills: validation-gated skill-revision discipline (from SkillOpt)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -155,7 +155,7 @@
       "name": "skill-development",
       "description": "Tools for creating, versioning, installing, inspecting, and orchestrating Claude skills.",
       "source": "./plugins/skill-development",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "repository": "https://github.com/oaustegard/claude-skills",
       "homepage": "https://github.com/oaustegard/claude-skills",
       "license": "MIT",
@@ -165,6 +165,7 @@
         "creating-skill",
         "inspecting-skills",
         "installing-skills",
+        "optimizing-skills",
         "orchestrating-skills",
         "versioning-skills"
       ]

--- a/optimizing-skills/README.md
+++ b/optimizing-skills/README.md
@@ -1,0 +1,5 @@
+# optimizing-skills
+
+Disciplined, validation-gated revision of an existing skill so each edit is a measured improvement rather than a guess. Use when editing, revising, or tuning a skill that already exists and there is evidence it underperforms (observed failures, drift, complaints) — invoke by name, or have versioning-skills / creating-skill defer to it before applying edits. Not for authoring a brand-new skill from scratch (use creating-skill) or one-off prose.
+
+Distilled from [SkillOpt](https://arxiv.org/abs/2605.23904) (microsoft/SkillOpt): a held-out check set, a two-tier `best`/`candidate` validation gate (ship only on a strict improvement), bounded edits, failure-first reflection, impact ranking, a protected core, and `remember()`-backed cross-revision memory — the discipline kept, the training harness dropped.

--- a/optimizing-skills/SKILL.md
+++ b/optimizing-skills/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: optimizing-skills
+description: Disciplined, validation-gated revision of an EXISTING skill so each edit is a measured improvement rather than a guess. Use when editing, revising, or tuning a skill that already exists and there is evidence it underperforms (observed failures, drift, complaints) — invoke by name, or have versioning-skills / creating-skill defer to it before applying edits. Not for authoring a brand-new skill from scratch (use creating-skill) or one-off prose.
+metadata:
+  version: 0.1.0
+---
+
+# Optimizing Skills
+
+Treat the skill document as the parameter under optimization: change it only
+when the change **demonstrably beats the version you already ship**. This is
+the discipline distilled from SkillOpt (microsoft/SkillOpt, arXiv:2605.23904) —
+its training apparatus dropped, its reproducibility discipline kept. The point
+is to stop editing skills on intuition and start editing them on evidence.
+
+## Core principle
+
+A skill edit is only worth shipping if it strictly improves measured behavior
+on a held-out check. Most edits that *feel* like improvements don't move the
+needle, and some quietly regress. The gate below is what separates a real
+improvement from a confident guess.
+
+## The gate — run it every revision
+
+1. **Assemble a held-out check set.** 3–8 representative tasks/prompts the skill
+   should handle well, and it **must include the failure(s) that prompted this
+   revision**. Keep the set fixed across the revision so before/after scores are
+   comparable.
+2. **Hold two versions.** `best` = what you currently ship (never let it
+   silently degrade). `candidate` = `best` + your proposed edits.
+3. **Score both on the check set.** "Run" here = dispatch each check task to the
+   **Agent tool** (`subagent_type=general-purpose`) with the skill version in
+   context, or evaluate by hand for small sets. Score hard pass/fail per task.
+4. **Accept only if `candidate` strictly beats `best`** (more tasks pass). Ties
+   → reject, keep `best`. An edit that doesn't move the needle does not ship.
+
+This two-tier `best`/`candidate` split is the heart of it: a working revision
+can explore, but the shipped skill only ever ratchets upward.
+
+## Bounded edits (the "textual learning rate")
+
+Cap edits per revision — **default ~4** distinct add/replace/delete operations,
+fewer as the skill matures. Large speculative rewrites drift and destroy your
+ability to attribute a regression to a cause. If a revision wants more edits
+than the budget, rank and keep the top ones (below) and let the rest wait.
+
+## Reflect: failures first, then successes
+
+Separate the evidence before proposing edits:
+
+- **Failure reflection.** Across the failing cases, find the *common,
+  systematic* pattern — not a one-off edge case. Propose edits that fix the
+  pattern. **Failures take priority** in any merge.
+- **Success reflection.** Across cases that already work, find generalizable
+  patterns worth encoding so they survive future edits. Reinforce; don't
+  duplicate.
+
+For both: edits must **generalize** (never hardcode task-specific values), and
+must **not duplicate** content already in the skill — patch genuine gaps only.
+
+## Rank when over budget
+
+When candidate edits exceed the budget, keep them in this priority order:
+
+1. **Systematic impact** — fixes a recurring failure across many cases, not one.
+2. **Complementarity** — fills a real gap rather than restating existing content.
+3. **Generality** — phrased as a durable principle, not tied to one task/entity.
+4. **Actionability** — concrete, followable guidance over vague advice.
+
+Drop the rest. They can return next revision if still warranted.
+
+## Protect the hard-won core
+
+If a skill has a battle-tested core that routine edits keep eroding, fence it
+off and treat it as off-limits to fast edits. Revisit it only on a **deliberate
+longitudinal review**: compare the *same* check tasks across several versions to
+catch slow drift and regressions that single-edit review misses. (SkillOpt
+fences this region with HTML-comment markers and only rewrites it at epoch
+boundaries — the same idea, manual cadence.)
+
+## Carry memory across revisions
+
+After a revision, record what you learned about editing **this** skill — which
+kinds of edits helped, which were brittle, redundant, or harmful — via
+`remember()` tagged with the skill name. Before the next revision, `recall()`
+it. This is the compounding part: each revision starts smarter than the last,
+the way SkillOpt's optimizer-side meta-skill conditions its future edits.
+
+## Edit mechanics
+
+Edits are literal string operations (the `Edit` tool): the target text must
+match **exactly** or the edit is a silent no-op. Keep targets unique and
+verbatim. Prefer append / insert-after-heading / replace-exact / delete-exact,
+and verify each edit landed before scoring.
+
+## When NOT to use this
+
+- Authoring a brand-new skill from scratch → **creating-skill**.
+- Tracking/rolling back versions during development → **versioning-skills**.
+- One-off prose with no reuse → just write it.
+
+## Checklist
+
+- [ ] Held-out check set assembled (includes the triggering failure), fixed for the revision
+- [ ] Edits bounded (~4 max), each generalizable and non-duplicative
+- [ ] Failure patterns addressed before success reinforcement
+- [ ] Candidate scored against `best` on the check set; shipped only if strictly better
+- [ ] Hard-won core left untouched unless doing a deliberate longitudinal review
+- [ ] Lesson about editing this skill recorded via `remember()`
+
+For the deeper "dispatch reflection/scoring to the Agent tool" recipe and the
+adapted reflection/ranking prompt templates, see
+[`references/skillopt-provenance.md`](references/skillopt-provenance.md).

--- a/optimizing-skills/references/skillopt-provenance.md
+++ b/optimizing-skills/references/skillopt-provenance.md
@@ -1,0 +1,59 @@
+# Provenance & the Agent-tool recipe
+
+This skill is distilled from **SkillOpt** (microsoft/SkillOpt,
+arXiv:2605.23904, MIT). SkillOpt trains a skill document as the external state
+of a frozen agent: a separate optimizer LLM turns scored rollouts into bounded
+add/delete/replace edits, accepted only when they strictly improve a held-out
+score. We keep the discipline and drop the training harness — no Azure, no
+rollout infra, no weight-training analogy required.
+
+## Mapping: SkillOpt mechanism → this skill
+
+| SkillOpt | Here |
+|---|---|
+| Validation gate (`gate.py`, strict `>`, ties rejected) | "The gate" — accept only if candidate strictly beats `best` |
+| Two-tier `current`/`best` skill state | `candidate` / `best` |
+| Textual learning rate = integer cap on edits/step, cosine-annealed | "Bounded edits", ~4 default, fewer as it matures |
+| Failure-minibatch + success-minibatch reflection, failures win merge | "Reflect: failures first, then successes" |
+| Rank-and-select top-L by impact (`clip.py`, `ranking.md`) | "Rank when over budget" |
+| Protected slow-update region (`<!-- SLOW_UPDATE_START/END -->`) | "Protect the hard-won core" + longitudinal review |
+| Optimizer-side meta-skill (`meta_skill.md`) | "Carry memory across revisions" via `remember()`/`recall()` |
+| Literal `str.replace(target, content, 1)` edits | "Edit mechanics" — exact-match `Edit` tool ops |
+
+## Recipe: dispatch scoring/reflection to the Agent tool
+
+The one piece that needs compute is scoring the check set. There is no
+ANTHROPIC_API_KEY in this environment — route through the **Agent tool**, not a
+standalone SDK call.
+
+1. **Score a version.** For each check task, spawn `subagent_type=general-purpose`
+   (model `sonnet` for cheap, `opus` for hard checks) with the skill version
+   pasted into the prompt and the task. Collect hard pass/fail. Run `best` and
+   `candidate` the same way for a fair comparison. Parallelize independent tasks
+   in one message.
+2. **Reflect (optional, for large failure sets).** Hand the failing transcripts
+   to an optimizer subagent using the prompt below; it returns bounded edits.
+   You still apply them with the `Edit` tool and re-score through the gate.
+
+### Adapted failure-reflection prompt (optimizer subagent)
+
+```
+You are a failure-analysis agent for an existing skill document.
+Given the current skill and MULTIPLE failed task transcripts, identify the
+most important COMMON failure pattern across them (not one-off edge cases) and
+propose AT MOST <budget> generalizable edits. Do not hardcode task-specific
+values. Do not duplicate content already in the skill — patch gaps only.
+Return JSON: {"failure_summary": [...], "edits": [{"op": "append|insert_after|
+replace|delete", "target": "<exact text, if needed>", "content": "<markdown>"}]}
+```
+
+### Adapted ranking prompt (when edits exceed budget)
+
+```
+Rank the proposed edits and select the top <budget>, by: (1) systematic impact
+on recurring failures, (2) complementarity / fills a gap, (3) generality as a
+principle, (4) actionability. Return {"selected_indices": [...]} in priority order.
+```
+
+Keep the optimizer subagent separate from the target subagent — the model that
+*proposes* edits should not be the one being measured by them.

--- a/plugins/skill-development/.claude-plugin/plugin.json
+++ b/plugins/skill-development/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "skill-development",
   "description": "Tools for creating, versioning, installing, inspecting, and orchestrating Claude skills.",
-  "version": "2.1.2"
+  "version": "2.2.0"
 }

--- a/plugins/skill-development/skills/optimizing-skills
+++ b/plugins/skill-development/skills/optimizing-skills
@@ -1,0 +1,1 @@
+../../../optimizing-skills

--- a/registry/categories.json
+++ b/registry/categories.json
@@ -102,6 +102,7 @@
         "creating-skill",
         "inspecting-skills",
         "installing-skills",
+        "optimizing-skills",
         "orchestrating-skills",
         "versioning-skills"
       ]


### PR DESCRIPTION
## What

A new skill, **`optimizing-skills`**, registered under the `skill-development` plugin.

It distills the discipline from **SkillOpt** (microsoft/SkillOpt, [arXiv:2605.23904](https://arxiv.org/abs/2605.23904)) — read in full, including the source — into a reusable, reference-invoked methodology for revising **existing** skills on evidence rather than intuition.

## The discipline

- **Two-tier gate** — keep a `best` (shipped) and a `candidate`; ship only if the candidate *strictly* beats `best` on a fixed held-out check set. Ties rejected.
- **Bounded edits** (~4/revision) to prevent drift and keep regressions attributable.
- **Failure-first reflection**, then success reinforcement; edits must generalize and not duplicate existing content.
- **Impact ranking** when over budget.
- **Protected core** + longitudinal review for hard-won sections.
- **Cross-revision memory** via `remember()`/`recall()` — the adapted analogue of SkillOpt's optimizer-side meta-skill.

The training apparatus (rollout infra, Azure, weight-training analogy) is deliberately dropped; scoring routes through the Agent tool. See `optimizing-skills/references/skillopt-provenance.md` for the SkillOpt→skill mapping and the Agent-tool scoring recipe.

## Changes

- `optimizing-skills/` — SKILL.md, README.md, references/
- Symlinked into `plugins/skill-development/skills/`
- Registered in `.claude-plugin/marketplace.json` (keywords) and `registry/categories.json`
- `skill-development` plugin bumped 2.1.2 → 2.2.0

https://claude.ai/code/session_01BxsW8Z3dkBYTz7j1XCa8Tu