### PR TITLE
flowing v1.4.0: content-addressed durable journal (cross-session resume)

### DIFF
--- a/flowing/CHANGELOG.md
+++ b/flowing/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `flowing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.4.0] - 2026-06-02
+
+### Added
+
+- **Content-addressed durable journal (`Flow(journal_path=...)`)** — opt-in cross-process replay, adapted from the StepKey/divergence design in `antstanley/pi-flow` specs 07. Each succeeded task appends a `Completed` entry to an append-only JSONL, keyed by a chained `step_key` = SHA-256 over the task body's bytecode + its `when`/`validate`/`retry_until` fingerprints + sorted dependency keys. A subsequent `run()` — including in a fresh container after the in-memory `self.results` is gone — replays the unchanged prefix from the journal and executes only tasks whose key is absent. This delivers the cross-session checkpoint `SKILL.md` already advertised but `resume()` only provided in-memory.
+- **Divergence + cascade** — editing a task body changes its `step_key`; key chaining means its dependents' keys change too, so the edited task and everything downstream re-run while the unchanged upstream prefix stays cached. Cosmetic knobs (`retry`, `retry_backoff_*`, `timeout_s`, `detached`, `name`) are excluded from the key, so tuning them does not bust the cache.
+- **Crash tolerance** — journal load discards a truncated trailing line (partial write on crash) rather than failing; non-picklable return values are skipped with a log line and simply re-run on the next pass.
+- `StepResult` gains `step_key` and `cached` fields (both `None`/`False` on the no-journal path, which is byte-for-byte unchanged).
+- New `compute_step_key()` / `STEP_KEY_VERSION` module surface; 5 new journal tests (33 total).
+
+### Notes
+
+- The fingerprint hashes the task's own code, not values it closes over — a task parameterized by a captured variable will not see that variable change reflected in its key. Pass inputs through `depends_on` (the flowing analog of pi-flow's explicit `args`) for them to participate in divergence.
+
 ## [1.3.2] - 2026-05-15
 
 ### Other

--- a/flowing/SKILL.md
+++ b/flowing/SKILL.md
@@ -2,7 +2,7 @@
 name: flowing
 description: DAG workflow runner that encodes control flow in code, not prose. Use when a procedure has 3+ steps with branching, retries, or validation that must be enforced — gates as `when=`, edge contracts as `validate=`, predicate loops as `retry_until=`. The runner owns the graph; the LLM provides leaves. Also covers parallel execution, checkpoint resume, detached side-effects.
 metadata:
-  version: 1.3.2
+  version: 1.4.0
 ---
 
 ## NOT SUPERSEDED BY DYNAMIC WORKFLOWS — read first
@@ -92,7 +92,8 @@ Distinct from `retry=` alone, which only retries on a raised exception.
 
 - **Parallel execution** — independent tasks in a layer run on a thread pool (`max_workers=`).
 - **`detached=True`** — side-effect tasks (memory writes, notifications) that run after the main DAG and never block it on failure.
-- **Resume** — `flow.run()` → fix → `flow.resume()` re-runs from the failure point, keeping succeeded tasks cached. `flow.override(task, value)` injects a corrected result.
+- **In-process resume** — `flow.run()` → fix → `flow.resume()` re-runs from the failure point, keeping succeeded tasks cached **in memory** (same process only). `flow.override(task, value)` injects a corrected result.
+- **Durable journal (`journal_path=`)** — opt-in content-addressed replay that survives container death. `Flow(term, journal_path="/path/run.jsonl").run()` appends each succeeded task's result to an append-only JSONL keyed by a `step_key` = SHA-256 over the task's bytecode + its `when`/`validate`/`retry_until` bodies + its dependencies' keys (chained, so an upstream change propagates downstream). A later `run()` — even in a fresh container — replays the unchanged prefix from the journal and only executes tasks whose key is absent; editing a task body busts its key and re-runs it and its dependents, while cosmetic knobs (`retry=`, `timeout_s=`, `name`) do not. This is the cross-session checkpoint hub-spoke work relies on. Caveat: results are pickled, so non-picklable return values simply re-run; closure-captured values are not part of the key (only the task body's own code is).
 - **`timeout_s=`**, **`retry=`** with exponential backoff, **`fail_fast=`**.
 
 Read [references/reference.md](references/reference.md) before using anything beyond the quick start and the three primitives above — it covers every `@task` parameter, the `Flow` methods, resume/override, detached auto-discovery, and the `validate=`/`when=` signature-matching gotcha.

--- a/flowing/scripts/flowing.py
+++ b/flowing/scripts/flowing.py
@@ -35,7 +35,11 @@ Detached side-effects:
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import inspect
+import json
+import pickle
 import sys
 import time
 from concurrent.futures import (
@@ -65,6 +69,8 @@ class StepResult:
     error: Optional[Exception] = None
     duration_ms: float = 0
     attempts: int = 0
+    step_key: Optional[str] = None  # content-addressed key (set only when journaling)
+    cached: bool = False            # True if this result was replayed from the journal
 
 
 @dataclass
@@ -154,6 +160,60 @@ def _log(msg: str, **kw):
     for k, v in kw.items():
         parts.append(f"{k}={v}")
     print(" ".join(parts), file=sys.stderr, flush=True)
+
+
+def _fn_fingerprint(fn: Optional[Callable]) -> str:
+    """Stable-ish fingerprint of a callable's behaviour.
+
+    Prefers bytecode (co_code + stringified co_consts), which changes when the
+    body changes but is stable across re-imports of unchanged source. Falls
+    back to source text, then to a qualified-name repr. Never raises.
+    """
+    if fn is None:
+        return ""
+    try:
+        code = fn.__code__
+        return "bc:" + hashlib.sha256(
+            code.co_code + repr(code.co_consts).encode("utf-8", "replace")
+        ).hexdigest()
+    except Exception:
+        pass
+    try:
+        return "src:" + hashlib.sha256(
+            inspect.getsource(fn).encode("utf-8", "replace")
+        ).hexdigest()
+    except Exception:
+        return "id:" + getattr(fn, "__qualname__", repr(fn))
+
+
+STEP_KEY_VERSION = 1
+
+
+def compute_step_key(td: TaskDef, dep_keys: list[str]) -> str:
+    """Content-addressed, chained key for one task.
+
+    Hashes, in order: the version, the sorted dependency keys (so an upstream
+    change propagates through the chain — pi-flow's prefix sensitivity), and
+    the fingerprints of the task body plus its when/validate/retry_until
+    control callables. The result is `v<version>:<sha256>`.
+
+    What is deliberately NOT in the key: name, retry/backoff/timeout knobs,
+    detached flag. Tuning a reliability knob or renaming must not bust the
+    cache; changing behaviour must.
+    """
+    h = hashlib.sha256()
+    h.update(f"v{STEP_KEY_VERSION}\n".encode())
+    for k in sorted(dep_keys):
+        h.update(b"dep:")
+        h.update(k.encode())
+        h.update(b"\n")
+    for label, f in (("fn", td.fn), ("when", td.when),
+                     ("validate", td.validate), ("retry_until", td.retry_until)):
+        h.update(label.encode())
+        h.update(b"=")
+        h.update(_fn_fingerprint(f).encode())
+        h.update(b"\n")
+    return f"v{STEP_KEY_VERSION}:{h.hexdigest()}"
 
 
 def _run_step(td: TaskDef, results: dict[str, StepResult]) -> StepResult:
@@ -269,7 +329,8 @@ def _run_step(td: TaskDef, results: dict[str, StepResult]) -> StepResult:
 
 # @lat: [[orchestration#DAG Workflow Runner]]
 class Flow:
-    def __init__(self, *terminals: TaskDef, max_workers: int = 5, fail_fast: bool = True):
+    def __init__(self, *terminals: TaskDef, max_workers: int = 5, fail_fast: bool = True,
+                 journal_path: Optional[str] = None):
         if not terminals:
             raise ValueError("Flow requires at least one terminal task")
         self.terminals = list(terminals)
@@ -277,6 +338,99 @@ class Flow:
         self.fail_fast = fail_fast
         self.results: dict[str, StepResult] = {}
         self.detached_failures: list[StepResult] = []
+        # Content-addressed durable journal (opt-in). When set, run() replays
+        # the unchanged prefix from disk and only executes tasks whose
+        # step_key is absent — surviving container death and re-running any
+        # task whose body changed (and, via key chaining, its dependents).
+        self.journal_path = journal_path
+        self._journal_completed: dict[str, Any] = {}  # step_key -> value
+        self._step_keys: dict[TaskDef, str] = {}
+
+    def _load_journal(self) -> None:
+        """Load completed step_keys -> values from the JSONL journal.
+
+        Append-only, tolerant of a truncated trailing line (crash mid-write).
+        A value that fails to unpickle is dropped, so its task simply re-runs.
+        """
+        self._journal_completed = {}
+        if not self.journal_path:
+            return
+        try:
+            with open(self.journal_path, "r", encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except FileNotFoundError:
+            return
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # truncated final line — discard
+            if entry.get("kind") != "Completed":
+                continue
+            try:
+                val = pickle.loads(base64.b64decode(entry["value"]))
+            except Exception:
+                continue  # unpicklable/corrupt -> treat as not-cached
+            self._journal_completed[entry["key"]] = val
+
+    def _compute_keys(self, tasks: set[TaskDef]) -> None:
+        """Compute chained step_keys for all tasks in dependency order."""
+        self._step_keys = {}
+        remaining = set(tasks)
+        # Iterate to fixed point: a task is keyable once all its in-graph deps
+        # have keys. Detached-or-not, deps may sit in another partition.
+        while remaining:
+            progressed = False
+            for t in list(remaining):
+                dep_keys = []
+                ready = True
+                for dep in t.depends_on:
+                    if dep in tasks:
+                        if dep not in self._step_keys:
+                            ready = False
+                            break
+                        dep_keys.append(self._step_keys[dep])
+                if not ready:
+                    continue
+                self._step_keys[t] = compute_step_key(t, dep_keys)
+                remaining.discard(t)
+                progressed = True
+            if not progressed:
+                # Dependency outside `tasks` (shouldn't happen) — key on body only.
+                for t in list(remaining):
+                    self._step_keys[t] = compute_step_key(t, [])
+                    remaining.discard(t)
+
+    def _cached_result(self, td: TaskDef) -> Optional[StepResult]:
+        """Return a replayed SUCCEEDED result if td's step_key is journaled."""
+        if not self.journal_path:
+            return None
+        key = self._step_keys.get(td)
+        if key is not None and key in self._journal_completed:
+            return StepResult(
+                name=td.name, state=StepState.SUCCEEDED,
+                value=self._journal_completed[key], step_key=key, cached=True,
+            )
+        return None
+
+    def _journal_append(self, result: StepResult) -> None:
+        """Append a Completed entry for a freshly-succeeded, non-cached task."""
+        if not self.journal_path or result.cached:
+            return
+        if result.state != StepState.SUCCEEDED or result.step_key is None:
+            return
+        try:
+            blob = base64.b64encode(pickle.dumps(result.value)).decode("ascii")
+        except Exception as e:
+            _log(f"JOURNAL_SKIP {result.name}", reason=f"unpicklable value: {str(e)[:80]}")
+            return
+        line = json.dumps({"kind": "Completed", "key": result.step_key,
+                           "name": result.name, "value": blob})
+        with open(self.journal_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
 
     def _collect_tasks(self) -> tuple[set[TaskDef], set[TaskDef]]:
         """Collect all tasks, separating main DAG from detached tasks.
@@ -384,6 +538,25 @@ class Flow:
                 if not layer:
                     continue
 
+            # Journal replay: tasks whose step_key is already Completed return
+            # their cached value without re-running. A miss falls through to a
+            # live run; key chaining means an edited task's dependents miss too.
+            if self.journal_path:
+                cached_hits = []
+                live = []
+                for t in layer:
+                    cr = self._cached_result(t)
+                    if cr is not None:
+                        self.results[t.name] = cr
+                        cached_hits.append(t.name)
+                    else:
+                        live.append(t)
+                if cached_hits:
+                    _log("CACHED", tasks=",".join(cached_hits))
+                layer = live
+                if not layer:
+                    continue
+
             parallel = len(layer) > 1
             _log(f"LAYER {layer_idx}",
                  tasks=",".join(t.name for t in layer), parallel=parallel)
@@ -395,8 +568,12 @@ class Flow:
                         for td in layer
                     }
                     for future in as_completed(futures):
+                        td = futures[future]
                         result = future.result()
+                        if self.journal_path:
+                            result.step_key = self._step_keys.get(td)
                         self.results[result.name] = result
+                        self._journal_append(result)
                         if self.fail_fast and result.state == StepState.FAILED:
                             _log(f"FAIL_FAST triggered by {result.name}")
                             # Cancels queued-but-unstarted siblings. Siblings
@@ -408,7 +585,10 @@ class Flow:
             else:
                 for td in layer:
                     result = _run_step(td, self.results)
+                    if self.journal_path:
+                        result.step_key = self._step_keys.get(td)
                     self.results[result.name] = result
+                    self._journal_append(result)
                     if self.fail_fast and result.state == StepState.FAILED:
                         _log(f"FAIL_FAST triggered by {result.name}")
                         break
@@ -448,6 +628,22 @@ class Flow:
                         name=t.name, state=StepState.SKIPPED, attempts=0)
                     self.results[t.name] = skip_result
 
+            # Journal replay for detached side-effects: a cached hit means the
+            # side-effect already fired on a prior run — don't re-fire it.
+            if self.journal_path and runnable:
+                still = []
+                cached_hits = []
+                for t in runnable:
+                    cr = self._cached_result(t)
+                    if cr is not None:
+                        self.results[t.name] = cr
+                        cached_hits.append(t.name)
+                    else:
+                        still.append(t)
+                if cached_hits:
+                    _log("CACHED_DETACHED", tasks=",".join(cached_hits))
+                runnable = still
+
             if not runnable:
                 continue
 
@@ -460,14 +656,21 @@ class Flow:
                         for td in runnable
                     }
                     for future in as_completed(futures):
+                        td = futures[future]
                         result = future.result()
+                        if self.journal_path:
+                            result.step_key = self._step_keys.get(td)
                         self.results[result.name] = result
+                        self._journal_append(result)
                         if result.state == StepState.FAILED:
                             self.detached_failures.append(result)
             else:
                 for td in runnable:
                     result = _run_step(td, self.results)
+                    if self.journal_path:
+                        result.step_key = self._step_keys.get(td)
                     self.results[result.name] = result
+                    self._journal_append(result)
                     if result.state == StepState.FAILED:
                         self.detached_failures.append(result)
 
@@ -478,6 +681,9 @@ class Flow:
 
         main_tasks, detached_tasks = self._collect_tasks()
         self._validate_signatures(main_tasks | detached_tasks)
+        if self.journal_path:
+            self._compute_keys(main_tasks | detached_tasks)
+            self._load_journal()
         main_layers = self._build_layers(main_tasks)
 
         total_tasks = sum(len(l) for l in main_layers) + len(detached_tasks)
@@ -514,6 +720,9 @@ class Flow:
             del self.results[name]
 
         main_tasks, detached_tasks = self._collect_tasks()
+        if self.journal_path:
+            self._compute_keys(main_tasks | detached_tasks)
+            self._load_journal()
         main_layers = self._build_layers(main_tasks)
 
         cached = sum(1 for r in self.results.values() if r.state == StepState.SUCCEEDED)

--- a/flowing/tests/test_flowing.py
+++ b/flowing/tests/test_flowing.py
@@ -535,5 +535,104 @@ class TestClearRegistry(unittest.TestCase):
         self.assertEqual(_TASK_REGISTRY, [])
 
 
+class TestContentAddressedJournal(unittest.TestCase):
+    """Opt-in durable journal: cross-process replay + edit divergence."""
+
+    def setUp(self):
+        clear_registry()
+        import tempfile
+        self.jp = tempfile.mktemp(suffix=".jsonl")
+
+    def tearDown(self):
+        if os.path.exists(self.jp):
+            os.unlink(self.jp)
+
+    def _build(self, mult):
+        clear_registry()
+        calls = {"a": 0, "b": 0, "c": 0}
+
+        @task
+        def a():
+            calls["a"] += 1
+            return 10
+
+        if mult == 2:
+            @task(depends_on=[a], name="b")
+            def b(a):
+                calls["b"] += 1
+                return a * 2
+        else:
+            @task(depends_on=[a], name="b")
+            def b(a):
+                calls["b"] += 1
+                return a * 3
+
+        @task(depends_on=[b], name="c")
+        def c(b):
+            calls["c"] += 1
+            return b + 1
+
+        return c, calls
+
+    def test_no_journal_path_is_unchanged(self):
+        c, calls = self._build(2)
+        r = Flow(c).run()
+        self.assertEqual(r["c"].value, 21)
+        self.assertIsNone(r["c"].step_key)
+        self.assertFalse(r["c"].cached)
+
+    def test_replay_across_fresh_flow(self):
+        c, calls = self._build(2)
+        Flow(c, journal_path=self.jp).run()
+        self.assertEqual((calls["a"], calls["b"], calls["c"]), (1, 1, 1))
+        c2, calls2 = self._build(2)
+        r2 = Flow(c2, journal_path=self.jp).run()
+        self.assertEqual((calls2["a"], calls2["b"], calls2["c"]), (0, 0, 0))
+        self.assertEqual(r2["c"].value, 21)
+        self.assertTrue(r2["c"].cached and r2["a"].cached)
+
+    def test_edit_diverges_and_cascades(self):
+        c, _ = self._build(2)
+        Flow(c, journal_path=self.jp).run()
+        c3, calls3 = self._build(3)  # b's body edited
+        r3 = Flow(c3, journal_path=self.jp).run()
+        self.assertEqual(calls3["a"], 0)   # unchanged upstream cached
+        self.assertEqual(calls3["b"], 1)   # edited task re-runs
+        self.assertEqual(calls3["c"], 1)   # dependent cascades (chained key)
+        self.assertEqual(r3["c"].value, 31)
+        self.assertTrue(r3["a"].cached)
+        self.assertFalse(r3["b"].cached or r3["c"].cached)
+
+    def test_cosmetic_knob_does_not_bust_key(self):
+        clear_registry()
+        calls = {"x": 0}
+
+        @task(retry=5, name="x")
+        def x():
+            calls["x"] += 1
+            return 99
+
+        Flow(x, journal_path=self.jp).run()
+        clear_registry()
+
+        @task(retry=0, name="x")  # knob changed, body identical
+        def x2():
+            calls["x"] += 1
+            return 99
+
+        Flow(x2, journal_path=self.jp).run()
+        self.assertEqual(calls["x"], 1)
+
+    def test_truncated_trailing_line_tolerated(self):
+        c, _ = self._build(2)
+        Flow(c, journal_path=self.jp).run()
+        with open(self.jp, "a") as fh:
+            fh.write('{"kind":"Completed","key":"v1:dead","nam')  # torn write
+        c2, calls2 = self._build(2)
+        r = Flow(c2, journal_path=self.jp).run()
+        self.assertEqual((calls2["a"], calls2["b"], calls2["c"]), (0, 0, 0))
+        self.assertEqual(r["c"].value, 21)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Add an opt-in **content-addressed durable journal** to `flowing` so `run()` becomes replay-aware across container death — `Flow(terminal, journal_path="/path/run.jsonl")`. Adapted from the StepKey + divergence design in [`antstanley/pi-flow`](https://github.com/antstanley/pi-flow) specs 07.

## Why

Reviewed pi-flow against our orchestration layer. Most of it doesn't transfer (Rust/TS/JSON-RPC/Rhai harness machinery solves a standalone-harness problem we don't have; the "program over graph" / zero-turn property flowing already has — the DAG *is* the authored program). Two genuine residuals: (1) dynamic fan-out granularity, (2) resume.

Our `resume()` was **in-memory and keyed by name**: it evaporates with the container, and if a task body changes it silently reuses the stale cached value. `SKILL.md` already advertised "the cross-session checkpoint hub-spoke depends on" — but the code only delivered same-process resume. This PR makes that claim true and fixes the stale-edit reuse.

(Dropped the budget-guard idea from the same review: flowing's graph is bounded at construction, so a Flow-level call cap would be ceremonial — the runaway surface is inside task bodies it can't see.)

## How

- `step_key` = SHA-256 over the task body's **bytecode** + `when`/`validate`/`retry_until` fingerprints + **sorted dependency keys** (chained → an upstream change propagates downstream, pi-flow's prefix sensitivity).
- `run()` with `journal_path` set loads the append-only JSONL, replays the unchanged prefix (`CACHED`), and runs only tasks whose key is absent. Editing a body busts its key → that task + dependents re-run; cosmetic knobs (`retry`, `timeout_s`, `name`, `detached`) are excluded from the key.
- Crash-tolerant: truncated trailing line discarded; non-picklable values skipped (re-run next pass) rather than fatal.
- `StepResult` gains `step_key`/`cached`. **No-journal path is byte-for-byte unchanged** (both fields default null/false; zero overhead).

## Limits (called out, not hidden)

- Fingerprint hashes the task's own code, not values it **closes over**. Pass inputs via `depends_on` (the flowing analog of pi-flow's explicit `args`) for them to participate in divergence.
- Values are pickled — fine across restarts of the same image; an unpicklable value just re-runs.
- This is the in-context-pipeline checkpoint; it does not add dynamic runner-managed fan-out (residual #1 — noted, not built; low usage-pressure since in-session I am the model loop).

## Tests

33 passing (28 existing + 5 new in `TestContentAddressedJournal`): no-journal parity, cross-fresh-Flow replay, edit-divergence-cascade, cosmetic-knob-ignore, truncated-line tolerance.

*Reviewed and implemented by Muninn.*