### PR TITLE
composing-html v0.5.0: deterministic check command + rule anchors

### DIFF
--- a/composing-html/CHANGELOG.md
+++ b/composing-html/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `composing-html` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0] - 2026-06-03
+
+### Added
+
+- `build.py check <file.html>` — a deterministic structural linter (no model
+  call, stdlib only) for built artifacts and body fragments. Calibrated to
+  composing-html's actual failure modes: content that breaks *out* of the
+  fixed design system (`hardcoded-color`, `inline-typography`,
+  `undefined-token`) or miswires `base.js` hooks (`broken-tabs`,
+  `broken-bind`, `broken-sortable`), plus `chrome-leak`, `nested-card`,
+  `heading-skip`, `img-no-alt`. Error-severity rules set a non-zero exit code;
+  `--json` for machine output; full-artifact vs fragment auto-detected
+  (`--full` / `--fragment` to force). Contrast checking intentionally
+  out of scope (token pairs are pre-vetted; regex can't judge custom pairs).
+- `scripts/checker.py` module exposing `check_html()` / `format_findings()`.
+- `tests/test_checker.py` — one fire/silent assertion pair per rule.
+- SKILL.md: a "Checking output" section, and `<!-- rule:ID -->` anchors on the
+  output rules tying each guidance line to its checker rule, so teaching and
+  enforcement stay in sync. (Approach adapted from pbakaus/impeccable's
+  rule-anchored guidance, retargeted from freehand-design taste to
+  system-adherence + hook integrity.)
+
 ## [0.4.1] - 2026-05-21
 
 ### Other

--- a/composing-html/SKILL.md
+++ b/composing-html/SKILL.md
@@ -2,7 +2,7 @@
 name: composing-html
 description: Composes single-file HTML artifacts (PR review writeups, status reports, incident postmortems, slide decks, design systems, prototypes, flowcharts, module maps, feature explainers, kanban boards, prompt tuners) from a small JSON spec instead of hand-written HTML/CSS/JS. Use when the user asks to "compare options side-by-side", requests an HTML version of a report or review or deck, asks for a flowchart, status update, postmortem, design system reference, interactive prototype, custom editor — or explicitly says "HTML artifact", "single HTML file", "self-contained HTML". Skip for ad-hoc HTML snippets (forms, emails, embedded widgets) where there's no template fit.
 metadata:
-  version: 0.4.1
+  version: 0.5.0
 ---
 
 # composing-html
@@ -172,15 +172,53 @@ Spend output tokens on **content**, not chrome:
 
 1. **Never write `<html>`, `<head>`, `<style>`, `<script>`, or `<link>`.** The
    composer adds all of them. If you find yourself writing a complete page,
-   you missed the skill.
+   you missed the skill. <!-- rule:chrome-leak -->
 2. **Don't restate design tokens.** Reuse the inventory above — `var(--clay)`,
-   `.card`, `.badge--warn`, `.bullets`, etc. are already loaded.
+   `.card`, `.badge--warn`, `.bullets`, etc. are already loaded. Don't
+   hardcode hex/`rgb()` colours, inline `font-family`/`font-size`, or
+   reference tokens that aren't in the palette.
+   <!-- rule:hardcoded-color rule:inline-typography rule:undefined-token -->
 3. **`body_html` is HTML, not a JSON dialect.** Write `<section>`, `<h2>`,
    `<ul class="bullets">` directly. No translation layer.
 4. **Anything in an `_html` field is inserted verbatim** — escape any
    user-supplied content yourself. All other string values are
    HTML-escaped automatically.
 5. **One artifact per build.** Browser tabs are free.
+
+## Checking output
+
+After building, lint the artifact before presenting it:
+
+```
+python scripts/build.py check artifact.html
+```
+
+The checker is deterministic — no model call, stdlib only. It doesn't grade
+taste (the fixed chrome already prevents the usual AI tells); it flags content
+that breaks *out* of the design system or wires `base.js` hooks to nothing —
+the failure modes the chrome can't prevent on its own:
+
+| rule | catches | severity |
+|---|---|---|
+| `chrome-leak` | `<html>/<head>/<link>` (and top-level `<style>/<script>`) in body_html | error |
+| `undefined-token` | `var(--typo)` — a token not in the palette or declared here | error |
+| `broken-tabs` | `data-target` with no matching `.tab-panel[data-id]` | error |
+| `hardcoded-color` | `#hex` / `rgb()` literals instead of palette tokens | warn |
+| `inline-typography` | `font-family` / `font-size` overriding the type stacks | warn |
+| `undefined-token` for `--bind-*` | (allowed — created by `data-bind`) | — |
+| `nested-card` | `.card` inside `.card` | warn |
+| `broken-bind` | `data-bind` with no consumer, or orphan `data-out` | warn |
+| `broken-sortable` | `data-sortable` with no `draggable` children | warn |
+| `heading-skip` | heading levels that jump (h1 → h3) | warn |
+| `img-no-alt` | `<img>` without an `alt` attribute | warn |
+
+Exit code is non-zero when any error-severity rule fires. The output rules
+above carry `<!-- rule:ID -->` anchors tying each guidance line to its check,
+so the teaching and the enforcement stay in sync. Full-artifact vs body
+fragment is auto-detected; force with `--full` / `--fragment`. `--json` emits
+machine-readable findings. Contrast ratios are intentionally not checked — the
+token pairs are pre-vetted and regex can't judge author-introduced pairs
+without false positives.
 
 ## Iteration
 
@@ -240,12 +278,17 @@ Some templates with prose-heavy slots take raw HTML in keys ending with
 `tests/test_smoke.py` covers every template with a representative spec plus
 explicit security regressions (table escaping, script-tag breakout in
 `prompt_tuner`, attribute injection in `flag_editor`, CSS-color injection,
-spec mutation in `module_map`). Run with:
+spec mutation in `module_map`). `tests/test_checker.py` covers the `check`
+linter — one assertion per rule (fires on the violation, silent on the clean
+case). Run with:
 
 ```
 python composing-html/tests/test_smoke.py        # no pytest required
+python composing-html/tests/test_checker.py      # no pytest required
 python -m pytest composing-html/tests -q          # if pytest is available
 ```
 
 When adding or changing a template, add a spec entry and any regression
-asserts before merging.
+asserts before merging. When adding a checker rule, add it to both
+`scripts/checker.py` and a `<!-- rule:ID -->` anchor in the relevant guidance
+line, plus a test assertion.

--- a/composing-html/scripts/build.py
+++ b/composing-html/scripts/build.py
@@ -8,6 +8,8 @@ Usage
   build.py build <template> [--spec FILE|-] [--set K=V ...] [--out FILE]
                                                     # render HTML; spec from FILE, stdin,
                                                     # and/or --set overrides
+  build.py check <file.html> [--json]               # lint body/artifact for system drift
+                                                    # and miswired interactive hooks
 
 The "build" command reads a JSON spec, runs it through the named template's
 builder, and emits a single self-contained HTML document. With no --out, the
@@ -188,6 +190,34 @@ def cmd_build(args) -> int:
     return 0
 
 
+def cmd_check(args) -> int:
+    from checker import check_html, format_findings, has_errors
+
+    path = Path(args.file)
+    if not path.exists():
+        print(f"no such file: {args.file}", file=sys.stderr)
+        return 2
+    html = path.read_text(encoding="utf-8")
+
+    fragment = None
+    if args.fragment:
+        fragment = True
+    elif args.full:
+        fragment = False
+
+    findings = check_html(html, fragment=fragment)
+
+    if args.json:
+        print(json.dumps(
+            [{"rule": f.rule, "severity": f.severity, "message": f.message,
+              "detail": f.detail} for f in findings],
+            indent=2))
+    else:
+        print(format_findings(findings))
+
+    return 1 if has_errors(findings) else 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(prog="build.py", description="Compose HTML artifacts from a small JSON spec.")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -211,6 +241,16 @@ def main(argv: list[str] | None = None) -> int:
                          "HTML/CSS/JS (e.g. --set body_html=@body.html).")
     pb.add_argument("--out", "-o", default=None, help="Write HTML to this file (default: stdout).")
     pb.set_defaults(fn=cmd_build)
+
+    pc = sub.add_parser("check", help="Lint a built artifact or body fragment for "
+                                      "design-system drift and miswired hooks.")
+    pc.add_argument("file", help="Path to the .html file to check.")
+    pc.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    pc.add_argument("--fragment", action="store_true",
+                    help="Force fragment mode (body_html, no page chrome).")
+    pc.add_argument("--full", action="store_true",
+                    help="Force full-artifact mode (skip chrome-leak rule).")
+    pc.set_defaults(fn=cmd_check)
 
     args = p.parse_args(argv)
     return args.fn(args)

--- a/composing-html/scripts/checker.py
+++ b/composing-html/scripts/checker.py
@@ -1,0 +1,333 @@
+"""Deterministic structural linter for composing-html output.
+
+No LLM, no network, stdlib only. Catches the ways body content breaks *out*
+of the composer's fixed design system or miswires its interactive hooks —
+the inverse of a freehand design linter. The composer supplies a vetted token
+palette and type stacks; this checker flags content that bypasses them or
+wires `base.js` behaviours (tabs / binds / sortables) to nothing.
+
+Each rule carries a stable `id` that is anchored in SKILL.md (`<!-- rule:ID -->`)
+so the teaching and the enforcement stay linked.
+
+Public API:
+    check_html(html, *, fragment=None) -> list[Finding]
+    format_findings(findings) -> str
+
+Exit-code contract (CLI): 1 if any error-severity finding, else 0.
+
+Deliberately NOT checked in v1: colour-contrast ratios. The token pairs are
+pre-vetted, and contrast on author-introduced custom pairs needs colour math +
+rendering that a regex pass can't do without false positives. Deferred.
+"""
+
+from __future__ import annotations
+
+import html.parser as _hp
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+# --------------------------------------------------------------------------- #
+# canonical design tokens (mirror of assets/base.css :root)                   #
+# --------------------------------------------------------------------------- #
+
+BASE_TOKENS = {
+    "ivory", "paper", "slate", "clay", "clay-d", "oat", "olive", "rust", "moss",
+    "g100", "g150", "g200", "g300", "g500", "g700",
+    "border", "border-soft",
+    "radius", "radius-sm", "radius-lg",
+    "shadow-card", "shadow-pop",
+    "serif", "sans", "mono",
+    "ok", "warn", "err", "info",
+}
+
+# colours that are fine as literals (not palette drift)
+_COLOR_KEYWORD_OK = {"transparent", "currentcolor", "inherit", "none", "initial", "unset"}
+
+_HEX_RE = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+_FUNC_COLOR_RE = re.compile(r"\b(?:rgb|rgba|hsl|hsla)\s*\(", re.I)
+_VAR_RE = re.compile(r"var\(\s*--([a-z0-9-]+)", re.I)
+_FONT_FAMILY_RE = re.compile(r"font-family\s*:", re.I)
+_FONT_SIZE_RE = re.compile(r"font-size\s*:", re.I)
+
+
+# --------------------------------------------------------------------------- #
+# findings                                                                    #
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class Finding:
+    rule: str
+    severity: str          # "error" | "warn"
+    message: str
+    detail: str = ""
+
+    def __str__(self) -> str:
+        tail = f" — {self.detail}" if self.detail else ""
+        return f"[{self.severity}] {self.rule}: {self.message}{tail}"
+
+
+# --------------------------------------------------------------------------- #
+# minimal DOM (parent pointers; enough for structural rules)                  #
+# --------------------------------------------------------------------------- #
+
+_VOID = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link",
+         "meta", "param", "source", "track", "wbr"}
+
+
+@dataclass
+class Node:
+    tag: str
+    attrs: dict
+    parent: Optional["Node"] = None
+    children: list = field(default_factory=list)
+
+    @property
+    def classes(self) -> set:
+        return set((self.attrs.get("class") or "").split())
+
+
+class _DOM(_hp.HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.root = Node("#root", {})
+        self._stack = [self.root]
+        self.nodes: list[Node] = []
+
+    def handle_starttag(self, tag, attrs):
+        node = Node(tag, {k: (v or "") for k, v in attrs}, parent=self._stack[-1])
+        self._stack[-1].children.append(node)
+        self.nodes.append(node)
+        if tag not in _VOID:
+            self._stack.append(node)
+
+    def handle_startendtag(self, tag, attrs):
+        node = Node(tag, {k: (v or "") for k, v in attrs}, parent=self._stack[-1])
+        self._stack[-1].children.append(node)
+        self.nodes.append(node)
+
+    def handle_endtag(self, tag):
+        for i in range(len(self._stack) - 1, 0, -1):
+            if self._stack[i].tag == tag:
+                del self._stack[i:]
+                break
+
+
+def _parse(html: str) -> _DOM:
+    dom = _DOM()
+    dom.feed(html)
+    return dom
+
+
+def _ancestors(node: Node):
+    p = node.parent
+    while p is not None:
+        yield p
+        p = p.parent
+
+
+# --------------------------------------------------------------------------- #
+# rules                                                                       #
+# --------------------------------------------------------------------------- #
+
+def _is_fragment(html: str) -> bool:
+    head = html.lstrip()[:200].lower()
+    return not (head.startswith("<!doctype") or head.startswith("<html") or "<html" in head[:200])
+
+
+def _rule_chrome_leak(html: str, dom: _DOM, fragment: bool, out: list):
+    # SKILL.md output rule 1: body_html must never contain page chrome.
+    # Only meaningful for fragments — a full artifact is *expected* to have it.
+    if not fragment:
+        return
+    for node in dom.nodes:
+        if node.tag in ("html", "head", "link"):
+            out.append(Finding("chrome-leak", "error",
+                               f"<{node.tag}> in body content",
+                               "the composer supplies page chrome; body_html must not"))
+        elif node.tag in ("style", "script"):
+            out.append(Finding("chrome-leak", "warn",
+                               f"top-level <{node.tag}> in body content",
+                               "prefer extra_css / extra_js spec fields"))
+
+
+def _defined_tokens(html: str, dom: _DOM) -> set:
+    """Tokens legitimately available: base palette + --bind-* (created by
+    data-bind hooks) + any custom --x declared in an author <style>."""
+    defined = set(BASE_TOKENS)
+    for m in re.finditer(r"data-bind\s*=\s*[\"']([a-z0-9_-]+)", html, re.I):
+        defined.add("bind-" + m.group(1))
+    # author-declared custom properties:  --foo:
+    for m in re.finditer(r"(?<![a-z0-9-])--([a-z0-9-]+)\s*:", html, re.I):
+        defined.add(m.group(1))
+    return defined
+
+
+def _rule_undefined_token(html: str, dom: _DOM, fragment: bool, out: list):
+    defined = _defined_tokens(html, dom)
+    seen = set()
+    for m in _VAR_RE.finditer(html):
+        name = m.group(1).lower()
+        if name not in defined and name not in seen:
+            seen.add(name)
+            out.append(Finding("undefined-token", "error",
+                               f"var(--{name}) references an undefined token",
+                               "typo, or a token that isn't in the palette / not declared here"))
+
+
+def _style_strings(dom: _DOM):
+    for node in dom.nodes:
+        st = node.attrs.get("style")
+        if st:
+            yield node, st
+
+
+def _rule_hardcoded_color(html: str, dom: _DOM, fragment: bool, out: list):
+    reported = 0
+    for node, st in _style_strings(dom):
+        if _HEX_RE.search(st) or _FUNC_COLOR_RE.search(st):
+            reported += 1
+            if reported <= 8:
+                out.append(Finding("hardcoded-color", "warn",
+                                   f"literal colour in style= on <{node.tag}>",
+                                   "use a palette token, e.g. var(--clay), var(--g500)"))
+    if reported > 8:
+        out.append(Finding("hardcoded-color", "warn",
+                           f"...and {reported - 8} more literal-colour style attributes"))
+
+
+def _rule_inline_typography(html: str, dom: _DOM, fragment: bool, out: list):
+    for node, st in _style_strings(dom):
+        if _FONT_FAMILY_RE.search(st):
+            out.append(Finding("inline-typography", "warn",
+                               f"font-family in style= on <{node.tag}>",
+                               "use the type stacks: var(--serif), var(--sans), var(--mono)"))
+        if _FONT_SIZE_RE.search(st):
+            out.append(Finding("inline-typography", "warn",
+                               f"font-size in style= on <{node.tag}>",
+                               "prefer the heading scale / existing type sizes"))
+
+
+def _rule_nested_card(html: str, dom: _DOM, fragment: bool, out: list):
+    for node in dom.nodes:
+        if "card" in node.classes:
+            if any("card" in a.classes for a in _ancestors(node)):
+                out.append(Finding("nested-card", "warn",
+                                   f"<{node.tag} class=card> nested inside another .card",
+                                   "card-in-card; flatten or use a plain container"))
+
+
+def _rule_broken_tabs(html: str, dom: _DOM, fragment: bool, out: list):
+    targets = [(n, n.attrs.get("data-target")) for n in dom.nodes if n.attrs.get("data-target")]
+    panel_ids = {n.attrs.get("data-id") for n in dom.nodes if "tab-panel" in n.classes}
+    panel_ids.discard(None)
+    target_vals = {t for _, t in targets}
+    for node, t in targets:
+        if t not in panel_ids:
+            out.append(Finding("broken-tabs", "error",
+                               f'data-target="{t}" has no matching .tab-panel[data-id="{t}"]',
+                               "tab button wired to a missing panel"))
+    for n in dom.nodes:
+        if "tab-panel" in n.classes:
+            pid = n.attrs.get("data-id")
+            if pid and pid not in target_vals:
+                out.append(Finding("broken-tabs", "warn",
+                                   f'.tab-panel[data-id="{pid}"] has no button targeting it',
+                                   "orphan panel — unreachable"))
+
+
+def _rule_broken_bind(html: str, dom: _DOM, fragment: bool, out: list):
+    binds = {n.attrs.get("data-bind") for n in dom.nodes if n.attrs.get("data-bind")}
+    outs = {n.attrs.get("data-out") for n in dom.nodes if n.attrs.get("data-out")}
+    var_binds = {m.group(1)[5:] for m in _VAR_RE.finditer(html)
+                 if m.group(1).lower().startswith("bind-")}
+    for b in binds:
+        if b not in outs and b not in var_binds:
+            out.append(Finding("broken-bind", "warn",
+                               f'data-bind="{b}" has no consumer',
+                               f'no [data-out="{b}"] and no var(--bind-{b})'))
+    for o in outs:
+        if o not in binds:
+            out.append(Finding("broken-bind", "warn",
+                               f'[data-out="{o}"] has no matching data-bind="{o}"',
+                               "output element will never update"))
+
+
+def _rule_broken_sortable(html: str, dom: _DOM, fragment: bool, out: list):
+    for node in dom.nodes:
+        if "data-sortable" in node.attrs:
+            # descendants
+            stack = list(node.children)
+            has_draggable = False
+            while stack:
+                cur = stack.pop()
+                if (cur.attrs.get("draggable") or "").lower() == "true":
+                    has_draggable = True
+                    break
+                stack.extend(cur.children)
+            if not has_draggable:
+                out.append(Finding("broken-sortable", "warn",
+                                   f"<{node.tag} data-sortable> has no draggable children",
+                                   'add draggable="true" to the reorderable items'))
+
+
+def _rule_heading_skip(html: str, dom: _DOM, fragment: bool, out: list):
+    prev = None
+    for node in dom.nodes:
+        if len(node.tag) == 2 and node.tag[0] == "h" and node.tag[1].isdigit():
+            lvl = int(node.tag[1])
+            if prev is not None and lvl > prev + 1:
+                out.append(Finding("heading-skip", "warn",
+                                   f"heading jumps h{prev} -> h{lvl}",
+                                   "don't skip heading levels"))
+            prev = lvl
+
+
+def _rule_img_no_alt(html: str, dom: _DOM, fragment: bool, out: list):
+    for node in dom.nodes:
+        if node.tag == "img" and "alt" not in node.attrs:
+            out.append(Finding("img-no-alt", "warn",
+                               "<img> without alt attribute",
+                               'add alt="" (empty for decorative)'))
+
+
+_RULES = [
+    _rule_chrome_leak,
+    _rule_undefined_token,
+    _rule_hardcoded_color,
+    _rule_inline_typography,
+    _rule_nested_card,
+    _rule_broken_tabs,
+    _rule_broken_bind,
+    _rule_broken_sortable,
+    _rule_heading_skip,
+    _rule_img_no_alt,
+]
+
+
+# --------------------------------------------------------------------------- #
+# public                                                                      #
+# --------------------------------------------------------------------------- #
+
+def check_html(html: str, *, fragment: Optional[bool] = None) -> list[Finding]:
+    if fragment is None:
+        fragment = _is_fragment(html)
+    dom = _parse(html)
+    out: list[Finding] = []
+    for rule in _RULES:
+        rule(html, dom, fragment, out)
+    return out
+
+
+def format_findings(findings: list[Finding]) -> str:
+    if not findings:
+        return "OK — no findings."
+    errs = sum(1 for f in findings if f.severity == "error")
+    warns = sum(1 for f in findings if f.severity == "warn")
+    lines = [str(f) for f in findings]
+    lines.append(f"\n{errs} error(s), {warns} warning(s).")
+    return "\n".join(lines)
+
+
+def has_errors(findings: list[Finding]) -> bool:
+    return any(f.severity == "error" for f in findings)

--- a/composing-html/tests/test_checker.py
+++ b/composing-html/tests/test_checker.py
@@ -1,0 +1,130 @@
+"""Tests for composing-html's deterministic checker.
+
+Run with:  python composing-html/tests/test_checker.py    (no pytest needed)
+       or  python -m pytest composing-html/tests -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from checker import check_html, has_errors  # noqa: E402
+
+
+def _rules(html, **kw):
+    return {f.rule for f in check_html(html, **kw)}
+
+
+_PASS = 0
+_FAIL = 0
+
+
+def ok(cond, label):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+    else:
+        _FAIL += 1
+        print(f"  FAIL: {label}")
+
+
+# --- clean fragment: no findings ------------------------------------------- #
+clean = """
+<section>
+  <div class="eyebrow">OVERVIEW</div>
+  <h2>Status</h2>
+  <div class="grid grid--2">
+    <div class="card"><p style="color: var(--clay)">All good</p></div>
+    <div class="card"><span class="badge badge--ok">v1</span></div>
+  </div>
+  <img src="x.png" alt="diagram">
+</section>
+"""
+ok(_rules(clean, fragment=True) == set(), "clean fragment yields no findings")
+ok(not has_errors(check_html(clean, fragment=True)), "clean fragment has no errors")
+
+# --- chrome leak (fragment only) ------------------------------------------- #
+ok("chrome-leak" in _rules('<head><link rel="x"></head><p>hi</p>', fragment=True),
+   "chrome-leak fires on <head>/<link> in fragment")
+ok("chrome-leak" not in _rules('<!doctype html><html><head></head><body>x</body></html>'),
+   "chrome-leak silent on a full artifact")
+
+# --- undefined token ------------------------------------------------------- #
+ok("undefined-token" in _rules('<p style="color: var(--cley)">typo</p>', fragment=True),
+   "undefined-token catches var(--cley) typo")
+ok("undefined-token" not in _rules('<p style="color: var(--clay)">ok</p>', fragment=True),
+   "undefined-token silent on valid token")
+ok("undefined-token" not in _rules(
+       '<input data-bind="size"><span style="width: var(--bind-size)"></span>', fragment=True),
+   "undefined-token silent on --bind-* created by data-bind")
+ok("undefined-token" not in _rules(
+       '<div style="--mytok: 4px; padding: var(--mytok)"></div>', fragment=True),
+   "undefined-token silent on author-declared custom property")
+
+# --- hardcoded colour ------------------------------------------------------ #
+ok("hardcoded-color" in _rules('<p style="color:#ff0000">red</p>', fragment=True),
+   "hardcoded-color catches hex literal")
+ok("hardcoded-color" in _rules('<p style="background: rgb(1,2,3)">x</p>', fragment=True),
+   "hardcoded-color catches rgb()")
+
+# --- inline typography ----------------------------------------------------- #
+ok("inline-typography" in _rules('<p style="font-family: Inter">x</p>', fragment=True),
+   "inline-typography catches font-family")
+ok("inline-typography" in _rules('<p style="font-size: 22px">x</p>', fragment=True),
+   "inline-typography catches font-size")
+
+# --- nested card ----------------------------------------------------------- #
+ok("nested-card" in _rules('<div class="card"><div class="card">x</div></div>', fragment=True),
+   "nested-card catches card-in-card")
+ok("nested-card" not in _rules('<div class="card">x</div><div class="card">y</div>', fragment=True),
+   "nested-card silent on sibling cards")
+ok("nested-card" not in _rules('<div class="scorecard"><div class="card">x</div></div>', fragment=True),
+   "nested-card does not match substring 'scorecard'")
+
+# --- broken tabs ----------------------------------------------------------- #
+broken_tabs = '<div class="tabs"><button data-target="a">A</button></div>'
+ok("broken-tabs" in _rules(broken_tabs, fragment=True),
+   "broken-tabs catches target with no panel")
+good_tabs = ('<div class="tabs"><button data-target="a">A</button></div>'
+             '<div class="tab-panel" data-id="a">x</div>')
+ok("broken-tabs" not in _rules(good_tabs, fragment=True),
+   "broken-tabs silent on wired tabs")
+
+# --- broken bind ----------------------------------------------------------- #
+ok("broken-bind" in _rules('<input data-bind="size">', fragment=True),
+   "broken-bind catches bind with no consumer")
+ok("broken-bind" in _rules('<span data-out="ghost"></span>', fragment=True),
+   "broken-bind catches orphan data-out")
+
+# --- broken sortable ------------------------------------------------------- #
+ok("broken-sortable" in _rules('<div data-sortable="true"><div>x</div></div>', fragment=True),
+   "broken-sortable catches no draggable children")
+ok("broken-sortable" not in _rules(
+       '<div data-sortable="true"><div draggable="true">x</div></div>', fragment=True),
+   "broken-sortable silent when draggable present")
+
+# --- heading skip ---------------------------------------------------------- #
+ok("heading-skip" in _rules('<h1>a</h1><h3>b</h3>', fragment=True),
+   "heading-skip catches h1->h3")
+ok("heading-skip" not in _rules('<h1>a</h1><h2>b</h2><h3>c</h3>', fragment=True),
+   "heading-skip silent on proper nesting")
+
+# --- img no alt ------------------------------------------------------------ #
+ok("img-no-alt" in _rules('<img src="x.png">', fragment=True),
+   "img-no-alt catches missing alt")
+ok("img-no-alt" not in _rules('<img src="x.png" alt="">', fragment=True),
+   "img-no-alt silent on empty alt")
+
+# --- severity contract ----------------------------------------------------- #
+ok(has_errors(check_html('<p style="color: var(--nope)">x</p>', fragment=True)),
+   "undefined-token is error severity")
+ok(not has_errors(check_html('<img src=x>', fragment=True)),
+   "img-no-alt alone is not error severity")
+
+
+print(f"\n{_PASS} passed, {_FAIL} failed")
+sys.exit(1 if _FAIL else 0)


### PR DESCRIPTION
## composing-html v0.5.0 — deterministic `check` command + rule anchors

Adds a deterministic linter (`build.py check <file.html>`) calibrated to composing-html's real failure modes, plus `<!-- rule:ID -->` anchors tying SKILL.md output rules to checker rules.

**Why:** the composer's fixed token system prevents the usual freehand AI tells by construction, so the useful check is the inverse — catch body content that breaks *out* of the system (`hardcoded-color`, `inline-typography`, `undefined-token`) or wires `base.js` hooks to nothing (`broken-tabs`, `broken-bind`, `broken-sortable`), plus `chrome-leak`, `nested-card`, `heading-skip`, `img-no-alt`. Approach (rule-anchored guidance) adapted from pbakaus/impeccable, retargeted from design-taste to system-adherence.

**Scope:** new `scripts/checker.py`, `tests/test_checker.py`; `check` subcommand wired into `build.py`; SKILL.md gains a "Checking output" section + anchors; version 0.4.1 → 0.5.0; CHANGELOG entry.

**Verification:** `tests/test_smoke.py` 22/22 (no regression), `tests/test_checker.py` 27/27, clean built artifact lints clean (exit 0), dirty fragment flagged (exit 1). Contrast checking intentionally deferred (token pairs pre-vetted; regex false-positive risk).

*Filed by Muninn.*