### PR TITLE
querying-markdown v0.2.0: use-gate + empirical findings

### DIFF
--- a/querying-markdown/CHANGELOG.md
+++ b/querying-markdown/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `querying-markdown` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-06-04
+
+### Added
+
+- Use-gate decision table ("Before you use mq: is this actually a structural task?") routing line-prefix/substring work to grep/awk and code-structure to tree-sitting, reserving mq for language-filtered code blocks, structured links, and valid-Markdown transforms.
+- "Empirical findings" section: parse-bound performance (latency tracks document size, not selector/match count; ~1.3 MB/s), selectors-return-nodes-not-concepts, and the ambiguous-empty-result trap.
+
+### Notes
+
+- Findings measured against a full KJV smoke test. The cheatsheet's `.code("lang") | to_text()` idiom is correct (an earlier "bug" report was a `dash` `time: not found` error misread as empty output).
+
 ## [0.1.0] - 2026-06-04
 
 ### Other

--- a/querying-markdown/SKILL.md
+++ b/querying-markdown/SKILL.md
@@ -2,7 +2,7 @@
 name: querying-markdown
 description: Query, filter, and transform Markdown structurally with mq — a jq-like CLI for Markdown. Use to extract headings/sections/code-blocks/links from .md files, build a table of contents, pull code blocks of a given language, slice or reshape LLM prompt/output Markdown, or batch-transform docs. Triggers on "extract sections from this markdown", "get all the code blocks", "jq for markdown", "mq", or any structural query over Markdown that grep/Read can't do cleanly.
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # querying-markdown
@@ -13,6 +13,33 @@ you select, filter, and transform by structure (`.h2`, `.code("rust")`,
 "every H2 title", "all bash code blocks", "a table of contents", "strip the
 frontmatter". For plain substring search, `grep` is still the right tool; for
 code (not prose) structure, use `tree-sitting`.
+
+## Before you use mq: is this actually a structural task?
+
+mq parses the whole document into a node tree before it answers, and that parse
+cost is real (see [Empirical findings](#empirical-findings)). Most "query a
+markdown file" tasks don't need it. Decide first, using the target — not the
+file type:
+
+| Your target | Use | Why |
+| --- | --- | --- |
+| Lines with a fixed prefix — `#`/`##` headings, `>` quotes, `-` bullets, a leading line/verse number | **grep / awk** | Line-matching, not structure. grep is faster and already installed. |
+| A substring anywhere | **grep** | mq adds nothing. |
+| Code *structure* inside fences (ASTs, symbols, call sites) | **tree-sitting** | mq sees the fence, not the code inside it. |
+| Language-filtered code blocks (`.code("bash")`); links as structured `(text, url)` (`-F json '.link'`) | **mq** | grep can't filter a fenced block by language without a brittle hand-rolled fence state machine. |
+| Markdown→Markdown transforms that must emit valid Markdown — demote/promote headings, rebuild a TOC with anchors, in-place edit | **mq** | `sed` doesn't know structure and will corrupt nesting/fences. |
+
+If your task lands in a grep/awk row, **do not install mq** — close this skill
+and use the line tool. Diagnosed 2026-06-04: a full-KJV smoke test queried
+books/chapters/verses (all line-prefix structure) with mq — ~3.3 s per query
+where grep is milliseconds, the same answers, and a grep post-filter still
+needed on top. Wrong-shape corpus; mq's selectors earn their parse cost only on
+the structural rows.
+
+The judgment call is whether the case is *actually* line-prefix or only looks
+it. A heading is a prefix; a heading you want demoted **with its subtree**, or a
+match you must re-emit as valid Markdown, is structure — mq's row even when the
+match looks like a prefix.
 
 ## Setup
 
@@ -45,6 +72,32 @@ mq '.h.level' file.md                     # heading depth per heading
 mq -F json '.h2 | to_text()' file.md      # results as JSON
 mq '.h2 | to_text()' file.md | wc -l      # count matches (reliable idiom)
 ```
+
+## Empirical findings
+
+Measured 2026-06-04 against a full public-domain KJV Bible (66 files, 4.28 MB).
+
+**Parse-bound, not query-bound.** mq reparses the whole document on every
+invocation; latency tracks document *size*, not selector or match count. On the
+4.28 MB file every query — whether it returned 66 matches or 32,418 — ran
+~3.2–3.3 s (~1.3 MB/s); on a normal-sized doc it is single-digit ms. Never loop
+mq per query over a large corpus: extract once with `-F json` and work on the
+result, or accept a constant per-call parse tax.
+
+**Selectors return nodes, not your domain concepts.** `.h2` over the KJV
+returned 1,250 nodes — 1,184 chapter headings plus 66 `eof` markers the source
+appended per file, while single-chapter books emitted no chapter heading at all.
+`.text` also pulled heading text into the paragraph stream. A raw selector count
+is a *node* count; map it to your concept with an explicit predicate
+(e.g. `grep -E '^[0-9]+ '` for verses) and check it against a known total before
+trusting the number.
+
+**An empty result is ambiguous.** Zero output means *either* the selector
+matched nothing *or* mq never ran — a wrapper like `time`/`env` failed in `dash`,
+or a malformed heredoc swallowed the command. Re-run the bare
+`mq 'QUERY' file.md` before concluding a selector or function is broken.
+(Self-inflicted 2026-06-04: a `time: not found` shell error read as a
+`to_text()` defect; `to_text()` on code blocks works.)
 
 ## Reference
 


### PR DESCRIPTION
## What

`querying-markdown` v0.1.0 → **0.2.0**. Two additions, both grounded in a full-KJV smoke test on 2026-06-04.

### 1. Use-gate (new section, placed before Setup)
A decision table on the **target**, not the file type:
- line-prefix (`#`/`##`, `>`, `-`, leading numbers) or substring → **grep/awk** (faster, already installed)
- code *structure* inside fences → **tree-sitting**
- language-filtered code blocks, links as `(text,url)`, valid-Markdown transforms → **mq**

If the task is a grep/awk row, the skill tells the agent **not to install mq**. Enforcement is placement + Authority + the diagnosed failure (per skill-language-compliance: a SKILL.md can't host a real tool-call gate, so the gate is the first thing read + an imperative rule + social proof).

### 2. Empirical findings (new section)
- **Parse-bound:** latency tracks document *size*, not selector/match count (~3.3 s on 4.28 MB regardless of 66 vs 32,418 matches; ~1.3 MB/s; single-digit ms on normal docs). Don't loop mq per query on a large corpus.
- **Selectors return nodes, not concepts:** `.h2` returned chapter headings + `eof` markers; `.text` leaked heading text. Map to concepts with a predicate, verify against a known total.
- **Empty output is ambiguous:** matched-nothing vs never-ran look identical; re-run the bare command before blaming the tool.

## Why
A skill smoke test queried books/chapters/verses — all line-prefix structure — and mq was slower than grep with no benefit. The skill now steers agents away from that misuse and documents what to expect when mq *is* the right tool.

## Verification
- Every differentiator claim tested live before writing it. Dropped two unverified claims (`frontmatter()` errors "not defined" in mq 0.5.31; table-cells untested).
- Confirmed the cheatsheet's `.code("lang") | to_text()` idiom is **correct** — an earlier "bug" was a `dash` `time: not found` error misread as empty output. No code/example changes.
- Edited SKILL.md dogfooded: parses cleanly with mq, example blocks still extract.

No behavior change to `mq` or `install-mq.sh`; docs + version only.