### PR TITLE
skill(verso): claim verifier + literate-TDD protocol (with CI/pytest forcing functions)

### DIFF
--- a/verso/CHANGELOG.md
+++ b/verso/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.1.0 — 2026-06-06
+
+Initial skill. Packaged from the muninn-utilities prototype (`prototypes/verso/`,
+PRs #58/#59/#60).
+
+- `signature` and `command-output` claim types (invariants only).
+- Removed `pr-state`/`issue-state`: mutable state that is expected to change is
+  not an invariant to verify; the only way to clear such a FAIL is to edit the
+  claim, which is backwards. Belongs in transclusion, not verification.
+- Removed `eval` (arbitrary code execution on document input); `command-output`
+  replaces it via subprocess.
+- `--watch` inner-loop mode.
+- Module-import allowlist (`VERSO_IMPORT_ALLOW`) for `signature` safety.
+- Integration templates: GitHub Action (`assets/verso-claims.yml`) and pytest
+  (`assets/test_verso_claims.py`) — the forcing functions that gate merges.
+- `references/example-spec.md`: an all-green, gateable spec.

--- a/verso/README.md
+++ b/verso/README.md
@@ -1,0 +1,34 @@
+# verso
+
+A claim verifier for documentation. Prose embeds typed claims as HTML
+comments; `verso.py` resolves each against live state and reports
+PASS / FAIL / STALE / ERROR. Documentation that breaks loudly when it drifts,
+instead of going silently stale.
+
+See `SKILL.md` for the full protocol: claim types, the invariant-vs-mutable
+rule, the literate-TDD loop, and the forcing functions that make the check
+unskippable.
+
+## Quick start
+
+```
+python3 scripts/verso.py references/example-spec.md     # verify (exit 0/1)
+python3 scripts/verso.py --watch path/to/spec.md        # re-verify on save
+```
+
+## Claim types
+
+- `signature` — a Python callable has the expected named parameters.
+- `command-output` — a subprocess exits as expected / prints expected output
+  (the bridge to a real test suite: point it at a named pytest).
+
+Both encode invariants. Mutable state that is *expected* to change (PR/issue
+state, current versions) is deliberately out of scope — see SKILL.md.
+
+## Integration (forcing functions)
+
+- `assets/verso-claims.yml` — GitHub Action; make it a required check so drift
+  cannot merge.
+- `assets/test_verso_claims.py` — pytest that runs verso on gated specs; rides
+  the existing green-bar gate.
+- `references/example-spec.md` — a working all-green spec to gate on.

--- a/verso/SKILL.md
+++ b/verso/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: verso
+description: Verify typed claims embedded in markdown/docs against live state, and run the literate-TDD loop (write spec with claims → red/green → gate in CI). Use this whenever the user wants to check that a README, spec, ops note, or design doc still matches the code it describes; whenever they mention claim verification, documentation drift, spec drift, executable documentation, literate testing, doc-code sync, or "docs that fail when they're wrong"; whenever turning a spec into a test that fails on drift; or when wiring doc-verification into TDD, CI, pre-commit, or a publish gate. Covers the `signature` and `command-output` claim types, the invariant-vs-mutable-state rule (never verify state that is expected to change), and the GitHub Action + pytest forcing functions that make the check unskippable.
+metadata:
+  version: 0.1.0
+---
+
+# verso
+
+A claim verifier for documentation. Prose makes typed claims as HTML comments;
+`verso.py` resolves each against live state and reports PASS / FAIL / STALE /
+ERROR. The point: documentation that **breaks loudly when it drifts**, instead
+of going silently stale.
+
+Named after [Verso](https://github.com/leanprover/verso), Lean's literate
+framework, where the documentation and the formal proof share one elaboration
+context so they cannot drift. This is the lightweight, language-agnostic
+cousin: claims live next to prose and are checked against the live system.
+
+## Claim syntax
+
+A claim is an HTML comment sitting next to the prose it backs:
+
+```
+parse_claims takes a `text` argument.
+<!-- claim: signature target=mymod.parse_claims has-params=text -->
+```
+
+The prose stays human-readable; the claim is invisible in rendered markdown.
+
+## Claim types
+
+Both encode **invariants** — things that should stay true. A FAIL means a real
+defect to fix, not the passage of time.
+
+### `signature`
+Does a Python callable accept the listed named parameters? An interface
+contract — like a checked header file.
+```
+<!-- claim: signature target=pkg.module.func has-params=a,b,c -->
+```
+Imports are restricted to an allowlist of module prefixes for safety
+(`VERSO_IMPORT_ALLOW`, default `muninn_utils,scripts,verso`).
+
+### `command-output`
+Run a command (subprocess, no shell, no eval) and assert its exit code and/or
+output substrings. This is the behavioral / acceptance claim, and the bridge
+to a real test suite — point it at a named test:
+```
+<!-- claim: command-output cmd='pytest tests/test_parse.py::test_quoted' exit=0 -->
+<!-- claim: command-output cmd='mytool --help' exit=0 stdout-contains=usage -->
+```
+Args: `cmd` (required), `exit`, `stdout-contains`, `stderr-contains`, `timeout`.
+
+## The one rule that matters: verify invariants, not mutable state
+
+Only encode claims about things that **should stay true**. Do NOT verify state
+that is *expected* to change — a PR's open/merged status, an issue's state, a
+"current version" number. A PR going open→merged is the PR doing its job, not
+drift.
+
+The diagnostic: **which artifact do you edit to make a failing check pass?**
+- Signature mismatch → you fix the code. Correct: there's a defect.
+- "PR #687 is open" gone red → you can only edit the *claim* to say "merged,"
+  chasing reality instead of constraining it.
+
+When the document is the thing that must change, the check is just confirming a
+stale cache. Mutable state wants **transclusion** (render the current value at
+read time), not a frozen assertion + diff — a different mechanism, out of scope
+here. (Earlier versions had `pr-state`/`issue-state`; they were removed for
+exactly this reason.)
+
+## Verdicts, and how they map to TDD states
+
+- **PASS** — claim matches reality → green
+- **FAIL** — the referenced thing exists but the assertion fails → classic red
+- **STALE** — the referenced thing doesn't exist yet (function/test missing) →
+  you're ahead of the code; pre-red
+- **ERROR** — the resolver couldn't run (bad syntax, blocked import, timeout)
+
+Exit 0 if all PASS, 1 otherwise. `--json` for machine output.
+
+## Literate TDD: the spec doc IS the test suite
+
+verso is the **outer** loop around a normal TDD inner loop. The inner loop
+stays pure pytest (red→green→refactor, fast, behavioral). verso binds the prose
+spec to those tests and to the code's interface, so the doc cannot claim a
+behavior whose test was deleted.
+
+The loop, test-first:
+1. Write the spec doc describing what you want, with claims pointing at
+   not-yet-written tests and signatures.
+2. Run `verso spec.md` → all STALE/FAIL → **red**.
+3. Write the test, then the implementation.
+4. `verso spec.md` all PASS → **green**.
+5. Refactor with verso as the regression net.
+
+`signature` claims give the contract-first variant: write the API in the doc,
+run verso (STALE), stub the function (PASS) — you've locked the interface in
+prose before writing behavior.
+
+Honest limit: verso does not assert `f(x) == y` itself (the unsafe `eval`
+claim type was removed). Behavioral truth lives in pytest; `command-output`
+claims check that the named test *passed*. verso is a binding/acceptance layer,
+not a replacement for your assertions.
+
+## What forces a run (the part that actually matters)
+
+A verifier only helps if it runs — otherwise the drift moves from "doc vs code"
+to "the verify-run vs reality." Unlike real Verso, where the check *is*
+compilation, markdown renders fine whether or not its claims pass. So nothing
+intrinsic forces a run. Bind verso to an event with its own enforcement, ranked
+by how hard it is to skip:
+
+1. **Required CI check on PRs** — strongest. Branch protection makes the verso
+   job a required status; you cannot merge red. Structural, not disciplinary.
+   Template: `assets/verso-claims.yml`.
+2. **Claims as part of the pytest suite** — `test_verso_claims` runs verso and
+   asserts exit 0, so verso runs whenever tests run and inherits the green-bar
+   gate. Best fit when verso wraps a TDD loop. Template:
+   `assets/test_verso_claims.py`.
+3. **Publish-time gate** — the publish flow runs verso and refuses to ship a
+   doc with failing claims. Binds verify to the irreversible action.
+4. **Pre-commit hook / `--watch` / boot-surfacing** — raise the probability,
+   don't force. Bypassable, local, or merely informational.
+
+General rule: only gating the **irreversible action** (merge, publish, deploy)
+on a **required** check actually forces a run, because it removes the choice.
+
+## Running it
+
+```
+python3 scripts/verso.py spec.md            # verify once; exit 0/1
+python3 scripts/verso.py --json spec.md     # machine-readable output
+python3 scripts/verso.py --watch spec.md    # re-verify on save (inner-loop aid)
+```
+
+`--watch` re-runs in a fresh subprocess on every save, so `signature` claims
+pick up edited code. It forces nothing — it's category 4 above.
+
+## Setting up the gate in a repo (the integration)
+
+1. Copy `assets/test_verso_claims.py` into the repo's `tests/`, and point the
+   `SPECS` list at the docs you want gated. Keep gated specs **all-green** —
+   don't put teaching/demo claims that intentionally FAIL into a gated file.
+2. Copy `assets/verso-claims.yml` into `.github/workflows/`. It runs verso on
+   the gated specs and the pytest suite on every PR.
+3. In repo settings → branches, add the workflow's job as a **required status
+   check**. Now drift cannot merge.
+
+See `references/example-spec.md` for a working all-green spec.
+
+## Files
+
+- `scripts/verso.py` — the verifier (signature + command-output, --watch).
+- `assets/verso-claims.yml` — GitHub Action template (forcing function #1).
+- `assets/test_verso_claims.py` — pytest template (forcing function #2).
+- `references/example-spec.md` — an all-green spec suitable for gating.

--- a/verso/assets/test_verso_claims.py
+++ b/verso/assets/test_verso_claims.py
@@ -1,0 +1,45 @@
+"""verso claim verification as a pytest — forcing function #2.
+
+Drop this into the repo's tests/. It runs verso on each gated spec and asserts
+exit 0, so the spec's claims are checked whenever the test suite runs — which
+CI already gates. This is the elegant integration when verso wraps a TDD loop:
+the literate spec's claims become just more tests behind the same green bar.
+
+Edit SPECS to point at the docs you want gated. Keep gated specs all-green —
+do not include teaching/demo claims that intentionally FAIL.
+
+Assumes scripts/verso.py is reachable from the repo root. Adjust VERSO if your
+layout differs.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSO = REPO_ROOT / "scripts" / "verso.py"
+
+# Docs to gate. Each must be all-green.
+SPECS = [
+    "README.md",
+    # "docs/spec.md",
+]
+
+
+@pytest.mark.parametrize("spec", SPECS)
+def test_verso_claims(spec):
+    """Every claim in `spec` must resolve to PASS."""
+    spec_path = REPO_ROOT / spec
+    if not spec_path.exists():
+        pytest.skip(f"{spec} not found")
+    proc = subprocess.run(
+        [sys.executable, str(VERSO), str(spec_path)],
+        capture_output=True,
+        text=True,
+    )
+    # verso exits 0 only when every claim passes; surface its report on failure.
+    assert proc.returncode == 0, (
+        f"verso reported drift in {spec}:\n{proc.stdout}\n{proc.stderr}"
+    )

--- a/verso/assets/verso-claims.yml
+++ b/verso/assets/verso-claims.yml
@@ -1,0 +1,54 @@
+# verso claim verification — forcing function #1.
+#
+# Drop this into .github/workflows/ and add the `verify` job as a REQUIRED
+# status check (repo Settings → Branches → branch protection). Then drift
+# cannot merge: a doc whose claims no longer match the code fails the build.
+#
+# Edit SPECS below to point at the docs you want gated. Gated specs must be
+# all-green — keep teaching/demo claims that intentionally FAIL out of them.
+
+name: verso-claims
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install (edit if the repo has its own deps/tests)
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e . || true; fi
+
+      - name: Verify documentation claims
+        env:
+          # Allow signature imports from the repo's own packages.
+          VERSO_IMPORT_ALLOW: "verso,src,app,scripts"
+        run: |
+          # SPECS: the docs to gate. Add paths as needed.
+          SPECS="README.md docs/spec.md"
+          rc=0
+          for f in $SPECS; do
+            if [ -f "$f" ]; then
+              echo "::group::verso $f"
+              python scripts/verso.py "$f" || rc=1
+              echo "::endgroup::"
+            fi
+          done
+          exit $rc
+
+      # Optional but recommended: run the test suite too, so command-output
+      # claims that point at named tests have those tests actually exercised.
+      - name: Run tests
+        run: |
+          if [ -d tests ]; then python -m pytest -q || exit 1; fi

--- a/verso/references/example-spec.md
+++ b/verso/references/example-spec.md
@@ -1,0 +1,37 @@
+# Example spec — all green, gateable
+
+This document is a working example of a verso spec that is safe to put behind a
+CI gate: every claim resolves to PASS. Unlike a teaching demo, it contains no
+intentional drift. Run it from the skill directory:
+
+```
+VERSO_IMPORT_ALLOW=verso python3 scripts/verso.py references/example-spec.md
+```
+
+It makes claims about `verso.py` itself, so it doubles as a smoke test of the
+verifier.
+
+## Interface contracts (`signature`)
+
+The parser takes the document text. <!-- claim: signature target=verso.parse_claims has-params=text -->
+
+The driver takes a path and a json flag. <!-- claim: signature target=verso.verify_file has-params=path,json_out -->
+
+The watch loop takes a path and an interval. <!-- claim: signature target=verso.watch has-params=path,interval -->
+
+Each resolver takes the parsed claim args. <!-- claim: signature target=verso.resolve_signature has-params=args --> <!-- claim: signature target=verso.resolve_command_output has-params=args -->
+
+## Behavior (`command-output`)
+
+The CLI prints usage to stderr and exits 2 when given no file:
+<!-- claim: command-output cmd='python3 ../scripts/verso.py' exit=2 stderr-contains=usage -->
+
+The CLI accepts the documented flags in its usage line:
+<!-- claim: command-output cmd='python3 ../scripts/verso.py' stderr-contains=--watch -->
+
+## Why this one is gateable
+
+A gated spec must be all-green: a CI required check fails the build on any
+non-PASS verdict, so an intentional FAIL or STALE (the kind a teaching demo
+uses to show what drift looks like) would wedge the gate. Keep demonstrations
+in a separate, ungated document.

--- a/verso/scripts/verso.py
+++ b/verso/scripts/verso.py
@@ -1,0 +1,369 @@
+"""
+verso.py — Verso-inspired claim verifier for markdown documents.
+
+Embeds typed claims as HTML comments next to prose:
+
+    parse_claims takes a `text` argument.
+    <!-- claim: signature target=verso.parse_claims has-params=text -->
+
+Each claim is resolved against live system state. Verdicts:
+    PASS    claim matches reality
+    FAIL    claim mismatches reality
+    STALE   referenced artifact no longer exists
+    ERROR   resolver failed (network, import, bad syntax)
+
+Run:
+    python3 verso.py path/to/file.md
+    python3 verso.py --json path/to/file.md
+
+Exit 0 if all PASS, 1 otherwise.
+
+Claim types in this prototype:
+    signature        Python callable has expected named parameters
+    command-output   subprocess exit code and/or stdout substring
+
+Both encode INVARIANTS — things that should stay true. A FAIL means a real
+defect to fix, not the passage of time.
+
+NOTE: earlier versions had `pr-state` / `issue-state` (GitHub state) and an
+`eval` resolver. All removed:
+    pr-state / issue-state checked MUTABLE state — a PR going open→merged is
+        the PR working, not drift. The only way to clear such a FAIL is to edit
+        the claim to match reality, which is backwards from verification.
+        Mutable state wants live transclusion, not a frozen assertion.
+    eval was arbitrary-code-execution on attacker-controlled markdown.
+`command-output` replaces eval safely (no shell, no eval, just subprocess).
+"""
+
+import re
+import sys
+import os
+import json
+import inspect
+import importlib
+from dataclasses import dataclass
+from typing import Callable
+
+
+# ─── claim parsing ────────────────────────────────────────────────────────────
+
+CLAIM_RE = re.compile(
+    r'<!--\s*claim:\s*(?P<type>\S+)\s+(?P<args>[^>]*?)\s*-->',
+    re.DOTALL,
+)
+
+# key=value, key="quoted value", key='quoted value'
+KV_RE = re.compile(r"""(\S+?)=(?:"([^"]*)"|'([^']*)'|(\S+))""")
+
+
+@dataclass
+class Claim:
+    type: str
+    args: dict
+    line: int
+    context: str  # surrounding prose (claim comment stripped)
+
+
+def parse_claims(text: str) -> list[Claim]:
+    claims = []
+    for m in CLAIM_RE.finditer(text):
+        kvs = {}
+        for km in KV_RE.finditer(m.group('args')):
+            key = km.group(1)
+            val = km.group(2) if km.group(2) is not None else \
+                  km.group(3) if km.group(3) is not None else \
+                  km.group(4)
+            kvs[key] = val
+        line = text[:m.start()].count('\n') + 1
+        line_start = text.rfind('\n', 0, m.start()) + 1
+        line_end = text.find('\n', m.end())
+        if line_end == -1:
+            line_end = len(text)
+        line_text = text[line_start:line_end]
+        prose = re.sub(r'<!--\s*claim:.*?-->', '', line_text).strip()
+        # If the claim sits on a line of its own, the stripped context is
+        # empty. Walk back to the nearest non-empty preceding line so the
+        # report shows the prose the claim actually describes.
+        if not prose:
+            cursor = line_start - 1
+            while cursor > 0:
+                prev_end = cursor
+                prev_start = text.rfind('\n', 0, prev_end) + 1
+                prev = text[prev_start:prev_end].strip()
+                if prev and not prev.startswith('#'):
+                    prose = prev
+                    break
+                cursor = prev_start - 1
+        claims.append(Claim(type=m.group('type'), args=kvs, line=line, context=prose))
+    return claims
+
+
+# ─── result type ──────────────────────────────────────────────────────────────
+
+@dataclass
+class Result:
+    status: str  # 'pass' | 'fail' | 'stale' | 'error'
+    expected: str = ''
+    actual: str = ''
+    detail: str = ''
+
+
+# ─── resolvers ────────────────────────────────────────────────────────────────
+#
+# Every claim type here encodes an INVARIANT — something that should stay true,
+# so that a FAIL means a real defect to fix. Mutable-state checks (a PR's state,
+# an issue's state) were removed: a snapshot that is *expected* to change is not
+# an invariant, and "fixing" its FAIL means editing the claim to chase reality,
+# which is backwards. See README "Why no pr-state / issue-state".
+
+def resolve_signature(args: dict) -> Result:
+    target = args.get('target', '')
+    raw = args.get('has-params', '')
+    expected_params = [p.strip() for p in raw.split(',') if p.strip()]
+    if '.' not in target:
+        return Result('error', detail=f'bad target {target!r}; want module.function')
+    mod_path, _, func_name = target.rpartition('.')
+    # importlib.import_module executes the target module's top-level code.
+    # Only import modules under an allowlisted prefix so a crafted claim
+    # can't trigger arbitrary imports. Override via VERSO_IMPORT_ALLOW
+    # (comma-separated prefixes).
+    allow = os.environ.get('VERSO_IMPORT_ALLOW', 'muninn_utils,scripts,verso')
+    prefixes = tuple(p.strip() for p in allow.split(',') if p.strip())
+    top = mod_path.split('.', 1)[0]
+    if top not in prefixes:
+        return Result('error',
+                      detail=f'import of {mod_path!r} blocked; '
+                             f'allowed prefixes: {list(prefixes)} '
+                             f'(set VERSO_IMPORT_ALLOW to extend)')
+    try:
+        mod = importlib.import_module(mod_path)
+        fn = getattr(mod, func_name)
+    except (ImportError, AttributeError) as e:
+        return Result('stale', detail=f'{target}: {type(e).__name__}: {e}')
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError) as e:
+        return Result('error', detail=f'inspect failed on {target}: {e}')
+    actual_params = list(sig.parameters.keys())
+    missing = [p for p in expected_params if p not in actual_params]
+    if missing:
+        return Result('fail',
+                      expected=f'params include {expected_params}',
+                      actual=f'params are {actual_params}',
+                      detail=f'missing: {missing}')
+    return Result('pass',
+                  expected=f'params include {expected_params}',
+                  actual=f'params are {actual_params}')
+
+
+def resolve_command_output(args: dict) -> Result:
+    """Run a command via subprocess (NOT shell=True). Assert exit code and/or
+    stdout substring. Replaces v1's `eval` resolver, which executed arbitrary
+    Python from the markdown — a critical RCE surface.
+
+    Args:
+        cmd               required; shlex-split, run with shell=False
+        exit              expected exit code
+        stdout-contains   expected substring of stdout
+        timeout           seconds, default 10
+    """
+    import shlex
+    import subprocess
+
+    cmd_str = args.get('cmd')
+    if not cmd_str:
+        return Result('error', detail='no cmd given')
+    try:
+        argv = shlex.split(cmd_str)
+    except ValueError as e:
+        return Result('error', detail=f'cmd parse: {e}')
+    try:
+        timeout = int(args.get('timeout', '10'))
+    except ValueError:
+        return Result('error', detail=f'bad timeout {args.get("timeout")!r}')
+
+    cwd = args.get('_cwd')  # injected by driver from the markdown file's dir
+    try:
+        proc = subprocess.run(
+            argv, cwd=cwd, capture_output=True, text=True,
+            timeout=timeout, check=False,
+        )
+    except FileNotFoundError as e:
+        return Result('stale', detail=f'command not found: {e}')
+    except subprocess.TimeoutExpired:
+        return Result('error', detail=f'timed out after {timeout}s')
+    except Exception as e:
+        return Result('error', detail=f'{type(e).__name__}: {e}')
+
+    failures = []
+    if 'exit' in args:
+        try:
+            want = int(args['exit'])
+        except ValueError:
+            return Result('error', detail=f'bad exit {args["exit"]!r}')
+        if proc.returncode != want:
+            failures.append(f'exit={proc.returncode} want={want}')
+    if 'stdout-contains' in args:
+        needle = args['stdout-contains']
+        if needle not in proc.stdout:
+            failures.append(f'stdout missing {needle!r}')
+    if 'stderr-contains' in args:
+        needle = args['stderr-contains']
+        if needle not in proc.stderr:
+            failures.append(f'stderr missing {needle!r}')
+
+    assertion_keys = ('exit', 'stdout-contains', 'stderr-contains')
+    if not any(k in args for k in assertion_keys):
+        return Result('error',
+                      detail='no assertions (need exit / stdout-contains / stderr-contains)')
+
+    actual = f'exit={proc.returncode} stdout={len(proc.stdout)}B stderr={len(proc.stderr)}B'
+    if failures:
+        expected = '; '.join(f'{k}={v}' for k, v in args.items()
+                             if k in assertion_keys)
+        return Result('fail', expected=expected, actual=actual,
+                      detail='; '.join(failures))
+    return Result('pass', expected='assertions met', actual=actual)
+
+
+RESOLVERS: dict[str, Callable[[dict], Result]] = {
+    'signature':       resolve_signature,
+    'command-output':  resolve_command_output,
+}
+
+
+# ─── driver ───────────────────────────────────────────────────────────────────
+
+SYMBOL = {'pass': '✓', 'fail': '✗', 'stale': '⚠', 'error': '!'}
+COLOR  = {'pass': '\033[32m', 'fail': '\033[31m',
+          'stale': '\033[33m', 'error': '\033[35m'}
+RESET  = '\033[0m'
+
+
+def verify_file(path: str, json_out: bool = False) -> int:
+    with open(path, encoding='utf-8') as f:
+        text = f.read()
+    file_dir = os.path.dirname(os.path.abspath(path))
+    claims = parse_claims(text)
+    results = []
+    for c in claims:
+        # Inject cwd for command-output so relative paths in cmd resolve from
+        # the directory containing the markdown file.
+        if c.type == 'command-output':
+            c.args.setdefault('_cwd', file_dir)
+        resolver = RESOLVERS.get(c.type)
+        r = resolver(c.args) if resolver else \
+            Result('error', detail=f'unknown claim type {c.type!r}')
+        results.append((c, r))
+
+    if json_out:
+        print(json.dumps([{
+            'line': c.line, 'type': c.type, 'args': c.args,
+            'context': c.context, 'status': r.status,
+            'expected': r.expected, 'actual': r.actual, 'detail': r.detail,
+        } for c, r in results], indent=2))
+    else:
+        use_color = sys.stdout.isatty()
+        for c, r in results:
+            sym = SYMBOL[r.status]
+            if use_color:
+                head = f'{COLOR[r.status]}{sym} {r.status.upper():<5}{RESET}'
+            else:
+                head = f'{sym} {r.status.upper():<5}'
+            ctx = c.context[:75] + ('…' if len(c.context) > 75 else '')
+            print(f'{head} L{c.line:<3} [{c.type}] {ctx}')
+            if r.status != 'pass':
+                if r.expected: print(f'         expected: {r.expected}')
+                if r.actual:   print(f'         actual:   {r.actual}')
+                if r.detail:   print(f'         {r.detail}')
+        counts: dict[str, int] = {}
+        for _, r in results:
+            counts[r.status] = counts.get(r.status, 0) + 1
+        print()
+        print(f'Summary: {len(results)} claim(s) — ' +
+              ', '.join(f'{n} {s}' for s, n in sorted(counts.items())))
+
+    return 0 if all(r.status == 'pass' for _, r in results) else 1
+
+
+def _watch_snapshot(spec_path: str) -> dict:
+    """mtimes of the spec file plus every .py under its directory tree.
+    Editing the spec OR any source it might reference re-triggers a run."""
+    snap = {}
+    try:
+        snap[spec_path] = os.path.getmtime(spec_path)
+    except OSError:
+        pass
+    root = os.path.dirname(os.path.abspath(spec_path)) or '.'
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in ('__pycache__', '.git')
+                       and not d.startswith('.')]
+        for fn in filenames:
+            if fn.endswith('.py'):
+                p = os.path.join(dirpath, fn)
+                try:
+                    snap[p] = os.path.getmtime(p)
+                except OSError:
+                    pass
+    return snap
+
+
+def watch(path: str, interval: float = 0.5) -> int:
+    """Re-verify on change. Each run is a fresh subprocess so signature claims
+    pick up edited code (no stale sys.modules cache). Forces nothing — this is
+    an inner-loop convenience; the forcing function is a CI/publish gate."""
+    import subprocess
+    import time
+
+    def run_once():
+        ts = time.strftime('%H:%M:%S')
+        proc = subprocess.run([sys.executable, os.path.abspath(__file__), path],
+                              capture_output=True, text=True)
+        sys.stdout.write('\033[2J\033[H' if sys.stdout.isatty() else '\n' + '─' * 60 + '\n')
+        print(proc.stdout, end='')
+        if proc.stderr:
+            print(proc.stderr, end='', file=sys.stderr)
+        green = proc.returncode == 0
+        if sys.stdout.isatty():
+            banner = ('\033[42;30m GREEN \033[0m all claims pass' if green
+                      else '\033[41;37m RED \033[0m claims failing')
+        else:
+            banner = 'GREEN — all claims pass' if green else 'RED — claims failing'
+        print(f'\n[{ts}] {banner}   (watching; ctrl-c to stop)')
+        return proc.returncode
+
+    print(f'verso --watch {path}  (re-runs on save)')
+    last_rc = run_once()
+    snap = _watch_snapshot(path)
+    try:
+        while True:
+            time.sleep(interval)
+            cur = _watch_snapshot(path)
+            if cur != snap:
+                snap = cur
+                last_rc = run_once()
+    except KeyboardInterrupt:
+        print('\nstopped.')
+    return last_rc
+
+
+def main():
+    args = sys.argv[1:]
+    json_out = False
+    watch_mode = False
+    if '--json' in args:
+        json_out = True
+        args.remove('--json')
+    if '--watch' in args:
+        watch_mode = True
+        args.remove('--watch')
+    if len(args) != 1:
+        print('usage: verso.py [--json] [--watch] path/to/file.md', file=sys.stderr)
+        return 2
+    if watch_mode:
+        return watch(args[0])
+    return verify_file(args[0], json_out=json_out)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## What

New skill: **verso** — a claim verifier for documentation plus the literate-TDD protocol around it. Promotes the muninn-utilities prototype (`prototypes/verso/`, PRs #58/#59/#60) into a self-contained, portable skill.

## Why a skill

verso is a tool *and* a practice. The tool (`scripts/verso.py`) verifies typed claims embedded in markdown against live state. The practice — write a spec with claims, run red→green, gate the result — is exactly what a SKILL.md encodes (when-to-use + methodology), and the integration pieces are reusable templates you drop into any repo.

## Contents

- `SKILL.md` — claim syntax; the two claim types; the invariant-vs-mutable-state rule; verdicts mapped to TDD states; the literate-TDD loop; **what forces a run** (ranked forcing functions); setup steps.
- `scripts/verso.py` — the verifier. Claim types: `signature` (callable has expected params) and `command-output` (subprocess exit/stdout/stderr; the bridge to a real test suite). `--watch` inner-loop mode. Import allowlist (`VERSO_IMPORT_ALLOW`) for `signature` safety.
- `assets/verso-claims.yml` — GitHub Action template. Make it a required check → drift can't merge (forcing function #1).
- `assets/test_verso_claims.py` — pytest template. Runs verso on gated specs; rides the existing green-bar gate (forcing function #2).
- `references/example-spec.md` — an all-green, gateable spec; doubles as a smoke test.

## Design decisions carried in

- **Invariants only.** `pr-state`/`issue-state` were removed: a PR's state is *expected* to change, so it isn't an invariant. The tell is which artifact you'd edit to clear a FAIL — for mutable state the only move is editing the claim to match reality, which is backwards. Mutable state wants transclusion, noted as out of scope.
- **No `eval`.** The original `eval` claim type was arbitrary code execution on document input; `command-output` replaces it via subprocess (no shell, no eval).
- **The forcing function is the point.** `--watch` and pre-commit hooks raise the odds; only gating the irreversible action (merge/publish) on a required check actually forces a run. The Action + pytest templates are that gate.

## Validation

- Example spec runs all-green, exit 0 (7 claims).
- pytest template: passes on the clean spec; **fails** on injected drift (claiming a nonexistent parameter), with verso's report surfaced in the assertion. Confirmed both directions.
- Action YAML lints; pytest template parses and runs.

🤖 Built in a claude.ai session.
