### PR TITLE
fix(verifying-claims): valid YAML frontmatter

### DIFF
--- a/verifying-claims/SKILL.md
+++ b/verifying-claims/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verifying-claims
-description: Check that a document's claims about code are actually true by reading the prose, the code, and the tests and reporting (or fixing) where they disagree. Use whenever the user wants to verify a README, guide, spec, or docstring still matches the code; whenever they mention documentation drift, doc-code sync, "is this still accurate", stale docs, or keeping docs/tests/code consistent; before publishing or merging a docs change; or as a periodic doc-accuracy sweep. The agent reads the prose's meaning directly — there is no claim-comment DSL to maintain. Pairs with TDD: the test suite is the deterministic behavioral gate, this skill is the semantic prose-vs-reality review.
+description: Check that a document's claims about code are actually true by reading the prose, the code, and the tests and reporting (or fixing) where they disagree. Use whenever the user wants to verify a README, guide, spec, or docstring still matches the code; whenever they mention documentation drift, doc-code sync, "is this still accurate", stale docs, or keeping docs/tests/code consistent; before publishing or merging a docs change; or as a periodic doc-accuracy sweep. The agent reads the prose's meaning directly — there is no claim-comment DSL to maintain. Pairs with TDD — the test suite is the deterministic behavioral gate, this skill is the semantic prose-vs-reality review.
 metadata:
   version: 0.2.0
 ---


### PR DESCRIPTION
The `description` in the SKILL.md frontmatter contained `Pairs with TDD: ` — a colon-space inside an unquoted YAML scalar, which YAML parses as a nested mapping. GitHub flagged it ("mapping values are not allowed in this context at line 2 column 585") and, more importantly, the frontmatter failed to parse — so `name`/`description` (which drive skill triggering) weren't being read.

Fix: changed the colon to an em-dash. The block now parses (verified with `yaml.safe_load`). Introduced in #691.

🤖 Built in a claude.ai session.