### PR TITLE
searching-codebases: binding-resolved Python tier via python-lsp (#695)

### DIFF
--- a/searching-codebases/CHANGELOG.md
+++ b/searching-codebases/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `searching-codebases` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.1.0] - 2026-06-15
+
+### Added
+
+- Binding-resolved reference/definition tier for Python via the `python-lsp` skill (pyright): `--refs`, `--def`, `--hover` (#695)
+  - `--refs SYMBOL` excludes same-named-but-unrelated symbols and follows imports — the precision the regex cross-reference tier lacks
+  - Engaged lazily (pyright index cost paid only on these flags); Python-only with a mandatory soft fallback to the regex text path (non-`.py`, or pyright/node absent) that emits a one-line degradation note
+  - `scripts/lsp_refs.py`: tree-sitting symbol→position resolution, 1-based↔0-based conversion at the LSP boundary, lifecycle-safe queries (index-wait + subprocess reaping)
+  - `tests/test_lsp_refs.py`: binding-resolution, import-following, indexing-wait determinism, no orphaned subprocess, and soft-fallback coverage
+
 ## [2.0.0] - 2026-03-31
 
 ### Other

--- a/searching-codebases/SKILL.md
+++ b/searching-codebases/SKILL.md
@@ -9,9 +9,11 @@ description: >-
   or answer "where is X" / "how does Y work" about code. Triggers on "search
   this repo", "find where X is", "grep for", "what handles Y", regex patterns,
   or natural-language questions about code. This is the convergent "find X" skill
-  — for first-encounter orientation, use exploring-codebases instead.
+  — for first-encounter orientation, use exploring-codebases instead. For Python
+  sources, a binding-resolved reference/definition tier (pyright, via python-lsp)
+  is available with --refs/--def/--hover.
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Searching Codebases
@@ -62,9 +64,29 @@ python3 $SKILL_DIR/scripts/search.py ./repo "error handling strategy"
 Auto-detection: short queries and code-like tokens → regex. Multi-word
 natural language → semantic. Override with `--regex` or `--semantic`.
 
+**Binding-resolved mode** (Python only — pyright via the `python-lsp` skill):
+```bash
+python3 $SKILL_DIR/scripts/search.py ./repo --refs SYMBOL    # find all real uses
+python3 $SKILL_DIR/scripts/search.py ./repo --def SYMBOL     # go-to-definition
+python3 $SKILL_DIR/scripts/search.py ./repo --hover SYMBOL   # inferred type/signature
+```
+
+Regex mode matches *text*, so a cross-reference for a function false-positives
+on shadowed and same-named-but-unrelated symbols. `--refs` is **binding-resolved**:
+pyright excludes the unrelated same-named symbol and follows imports. Use it when
+you need a true "find all callers/users" for a `.py` symbol, not a text grep.
+
+The tier is engaged **lazily** — pyright's index cost is paid only when you ask
+for `--refs`/`--def`/`--hover`, never on ordinary searches. It is **Python-only**;
+for non-`.py` sources, or when pyright/node is unavailable, it prints a one-line
+degradation note and falls back to the regex text path. Each takes a single bare
+symbol name and is mutually exclusive with the other two and with text queries.
+
 ## Options
 
 - `--regex` / `--semantic`: Force search mode
+- `--refs SYMBOL` / `--def SYMBOL` / `--hover SYMBOL`: Binding-resolved Python
+  queries via pyright (see Binding-resolved mode above)
 - `--expand`: Return full function bodies via tree-sitting AST context
 - `--benchmark`: Compare indexed regex vs brute-force ripgrep
 - `--branch NAME`: Git branch for GitHub URLs (default: main)
@@ -110,13 +132,17 @@ python3 $SKILL_DIR/scripts/search.py ./repo \
   in results.
 - **ripgrep**: Required for regex verification. Install via `uv tool install ripgrep`.
 - **scikit-learn**: Required for semantic mode. Installs automatically.
+- **python-lsp**: Provides the binding-resolved tier (`--refs`/`--def`/`--hover`).
+  Self-bootstraps pyright on first use and requires system `node` (v18+). Not
+  required — without it those flags degrade to the regex text path.
 
 ## When to Use
 
 - **Known target**: "where is the retry logic?", "find all error handlers"
 - **Pattern matching**: regex across large codebases with indexed speedup
 - **Concept search**: "authentication flow", "database connection pooling"
-- **Cross-reference**: find all callers/users of a specific function
+- **Cross-reference**: find all callers/users of a specific function — for
+  `.py` symbols use `--refs` (binding-resolved, no same-name false positives)
 
 ## When NOT to Use
 
@@ -133,3 +159,5 @@ python3 $SKILL_DIR/scripts/search.py ./repo \
 - `scripts/ngram_index.py` — Sparse n-gram inverted index, regex decomposition
 - `scripts/sparse_ngrams.py` — Core n-gram algorithms, frequency weights
 - `scripts/code_rag.py` — TF-IDF semantic search over code chunks
+- `scripts/lsp_refs.py` — Binding-resolved Python tier: symbol→position
+  resolution (tree-sitting), pyright queries (python-lsp), soft fallback

--- a/searching-codebases/scripts/lsp_refs.py
+++ b/searching-codebases/scripts/lsp_refs.py
@@ -1,0 +1,368 @@
+"""Binding-resolved reference/definition tier for Python sources.
+
+Bridges searching-codebases to the ``python-lsp`` skill so that
+cross-reference queries on ``.py`` files are resolved by pyright's binder
+instead of by text matching. The win over the regex tier: a same-named but
+unrelated symbol (a shadowed name, an unrelated ``helper`` in another module)
+is *excluded*, and ``definition`` follows imports across files — neither of
+which ripgrep or tree-sitter can do.
+
+This tier is engaged lazily: only when a true cross-reference / definition /
+hover is requested, so pyright's index cost is never paid on ordinary text
+searches.
+
+Soft-fallback contract: every path that cannot produce a binding-resolved
+answer raises :class:`LspUnavailable` with a one-line reason. The caller
+(``search.py``) catches it, emits a one-line degradation note, and falls back
+to the existing regex/tree-sitting text path. Causes that trigger fallback:
+non-Python target (the symbol has no Python definition), pyright/node absent,
+or the python-lsp client being unimportable.
+
+Coordinate seam: tree-sitting / ripgrep positions are 1-based; LSP is 0-based.
+Conversion happens at the boundary via ``Position.from_one_based(line, col)``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Set
+
+# Default directories to skip when collecting Python files / occurrences.
+_SKIP_DIRS = {
+    ".git", ".hg", ".svn", "node_modules", "__pycache__", ".venv", "venv",
+    "env", ".tox", "build", "dist", ".mypy_cache", ".pytest_cache", ".idea",
+    ".eggs", "site-packages",
+}
+
+# Bound the number of files opened in the language server and the number of
+# occurrence positions queried, so a huge repo doesn't make the lazy path hang.
+_MAX_OPEN_FILES = 600
+_MAX_OCCURRENCES = 40
+
+
+class LspUnavailable(Exception):
+    """Signals the binding-resolved path can't run — caller should fall back.
+
+    The message is a single line suitable for a user-facing degradation note.
+    """
+
+
+@dataclass
+class Site:
+    """A 1-based position on a symbol token, plus context for display."""
+    file: str          # path relative to root
+    line: int          # 1-based line
+    col: int           # 1-based column of the symbol token
+    kind: str = ""     # tree-sitting symbol kind (function/class/method/...)
+    line_text: str = ""
+
+
+# ── locating sibling skills ──────────────────────────────────────────────────
+
+def _skill_scripts(name: str, env_var: Optional[str] = None) -> Optional[str]:
+    """Locate a sibling skill's ``scripts/`` dir across deploy and dev layouts.
+
+    Order: explicit env override, the installed ``/mnt/skills/user`` location,
+    then a sibling of this repo checkout (``<repo>/<name>/scripts``).
+    """
+    candidates: List[str] = []
+    if env_var and os.environ.get(env_var):
+        candidates.append(os.environ[env_var])
+    candidates.append(f"/mnt/skills/user/{name}/scripts")
+    # parents[0]=scripts, [1]=searching-codebases, [2]=repo root
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates.append(str(repo_root / name / "scripts"))
+    for c in candidates:
+        if c and os.path.isdir(c):
+            return c
+    return None
+
+
+def _import_lsp_client():
+    """Import the python-lsp client, or raise LspUnavailable on a soft miss."""
+    scripts = _skill_scripts("python-lsp", env_var="PYTHON_LSP_SCRIPTS")
+    if not scripts:
+        raise LspUnavailable("python-lsp skill not found (binding-resolved tier unavailable)")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    try:
+        import lsp_client  # noqa: F401
+        return lsp_client
+    except ImportError as e:  # pragma: no cover - import-path dependent
+        raise LspUnavailable(f"cannot import python-lsp client: {e}")
+
+
+def _code_cache(root: str):
+    """Build a tree-sitting CodeCache over ``root``, or raise LspUnavailable."""
+    scripts = _skill_scripts("tree-sitting", env_var="TREE_SITTING_SCRIPTS")
+    if not scripts:
+        raise LspUnavailable("tree-sitting skill not found (cannot resolve symbol position)")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    try:
+        from engine import CodeCache
+    except ImportError as e:  # pragma: no cover - import-path dependent
+        raise LspUnavailable(f"cannot import tree-sitting engine: {e}")
+    cache = CodeCache()
+    cache.scan(root)
+    return cache
+
+
+# ── symbol → position resolution ─────────────────────────────────────────────
+
+def _col_of(line_text: str, name: str) -> int:
+    """1-based column of the first whole-word occurrence of ``name`` in a line.
+
+    Falls back to a substring search, then to column 1, so a position is always
+    produced even if the token is adjacent to non-word characters.
+    """
+    m = re.search(rf"\b{re.escape(name)}\b", line_text)
+    if m:
+        return m.start() + 1
+    idx = line_text.find(name)
+    return (idx + 1) if idx >= 0 else 1
+
+
+def _read_line(root: str, rel: str, line1: int) -> str:
+    try:
+        with open(os.path.join(root, rel), "r", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return ""
+    return lines[line1 - 1].rstrip("\n") if 0 < line1 <= len(lines) else ""
+
+
+def definition_sites(root: str, symbol: str) -> List[Site]:
+    """Definition sites of ``symbol`` in Python files, via tree-sitting.
+
+    Returns one :class:`Site` per ``def`` / ``class`` / method named exactly
+    ``symbol`` (children included). Empty when the symbol has no Python
+    definition — which is the non-Python / wrong-target fallback signal.
+    """
+    cache = _code_cache(root)
+    sites: List[Site] = []
+    for sym in cache.find_symbol(symbol, limit=200):
+        if sym.name != symbol:
+            continue  # find_symbol does substring matching; we want exact
+        if not sym.file.endswith(".py"):
+            continue
+        text = _read_line(root, sym.file, sym.line)
+        sites.append(Site(file=sym.file, line=sym.line, col=_col_of(text, symbol),
+                          kind=sym.kind, line_text=text))
+    return sites
+
+
+def _find_ripgrep() -> Optional[str]:
+    from shutil import which
+    return which("rg")
+
+
+def occurrence_sites(root: str, symbol: str, limit: int = _MAX_OCCURRENCES) -> List[Site]:
+    """Every textual ``\\bsymbol\\b`` occurrence in ``.py`` files under root.
+
+    Used as anchors for ``definition`` (so it can follow an import from any use
+    site) and to bound the set of files opened in the language server. Text
+    matching here is intentional and safe — it is a *superset* of the real
+    references; pyright narrows it to the binding-resolved set.
+    """
+    rg = _find_ripgrep()
+    sites: List[Site] = []
+    pattern = rf"\b{re.escape(symbol)}\b"
+    if rg:
+        cmd = [rg, "--no-heading", "--line-number", "--column", "--color=never",
+               "-t", "py"]
+        for d in _SKIP_DIRS:
+            cmd.extend(["--glob", f"!{d}"])
+        cmd.extend(["-e", pattern, root])
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True, timeout=60).stdout
+        except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+            out = ""
+        for line in out.splitlines():
+            parts = line.split(":", 3)
+            if len(parts) >= 4 and parts[1].isdigit() and parts[2].isdigit():
+                rel = os.path.relpath(parts[0], root)
+                sites.append(Site(file=rel, line=int(parts[1]), col=int(parts[2]),
+                                  line_text=parts[3]))
+                if len(sites) >= limit:
+                    break
+        return sites
+    # No ripgrep: fall back to a Python walk.
+    rx = re.compile(pattern)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")]
+        for fn in filenames:
+            if not fn.endswith(".py"):
+                continue
+            fp = os.path.join(dirpath, fn)
+            try:
+                with open(fp, "r", errors="replace") as f:
+                    for i, text in enumerate(f, start=1):
+                        m = rx.search(text)
+                        if m:
+                            sites.append(Site(file=os.path.relpath(fp, root), line=i,
+                                              col=m.start() + 1, line_text=text.rstrip("\n")))
+                            if len(sites) >= limit:
+                                return sites
+            except OSError:
+                continue
+    return sites
+
+
+# ── the query ────────────────────────────────────────────────────────────────
+
+def lsp_query(root: str, symbol: str, op: str = "references",
+              max_open: int = _MAX_OPEN_FILES, verbose: bool = False) -> dict:
+    """Run a binding-resolved ``op`` for ``symbol`` over the Python sources.
+
+    ``op`` is one of ``references`` | ``definition`` | ``hover``.
+
+    - ``references``: anchored at each definition site; pyright returns the
+      binding-resolved uses, excluding same-named symbols of other bindings.
+      Results are grouped per definition (per binding).
+    - ``definition``: anchored at each occurrence; follows imports to the real
+      definition(s); results are unioned and de-duplicated.
+    - ``hover``: anchored at each definition site; returns the inferred
+      type/signature string.
+
+    Raises :class:`LspUnavailable` (soft fallback) when the binding-resolved
+    answer cannot be produced.
+    """
+    if op not in ("references", "definition", "hover"):
+        raise ValueError(f"unknown op: {op!r}")
+
+    lsp = _import_lsp_client()
+    Position = lsp.Position
+
+    defs = definition_sites(root, symbol)
+    occurrences = occurrence_sites(root, symbol)
+    if not defs and not occurrences:
+        raise LspUnavailable(f"no Python occurrence of {symbol!r} found")
+    if op in ("references", "hover") and not defs:
+        raise LspUnavailable(f"no Python definition of {symbol!r} found")
+
+    # Ensure pyright is available; fail soft (one-line reason) if not.
+    try:
+        lsp.ensure_pyright(install=True)
+    except lsp.BootstrapError as e:
+        raise LspUnavailable(str(e).splitlines()[0])
+
+    # Relevant files to open = every file that mentions the symbol, plus the
+    # definition files. This builds pyright's model for exactly the files that
+    # could contain a reference, without indexing the whole repo.
+    open_files: Set[str] = {s.file for s in occurrences} | {s.file for s in defs}
+    files = sorted(f for f in open_files if f.endswith(".py"))
+    truncated = len(files) > max_open
+    if truncated:
+        files = files[:max_open]
+
+    note_parts: List[str] = []
+    results: List[dict] = []
+    try:
+        with lsp.LSPClient(root) as client:
+            if files:
+                client.open_all(*files)
+            if not client.wait_for_index(timeout=30):
+                note_parts.append("pyright index wait timed out; results may be incomplete")
+
+            if op == "references":
+                for d in defs:
+                    pos = Position.from_one_based(d.line, d.col)
+                    locs = client.references(d.file, pos.line, pos.character)
+                    results.append({"anchor": d, "locations": locs})
+            elif op == "hover":
+                for d in defs:
+                    pos = Position.from_one_based(d.line, d.col)
+                    results.append({"anchor": d, "hover": client.hover(d.file, pos.line, pos.character)})
+            else:  # definition
+                anchors = occurrences or defs
+                seen = set()
+                union = []
+                for a in anchors:
+                    pos = Position.from_one_based(a.line, a.col)
+                    for loc in client.definition(a.file, pos.line, pos.character):
+                        key = (loc.path, loc.start_line, loc.start_char)
+                        if key not in seen:
+                            seen.add(key)
+                            union.append(loc)
+                results.append({"anchor": None, "locations": union})
+    except LspUnavailable:
+        raise
+    except Exception as e:  # any client/runtime failure → soft fallback
+        raise LspUnavailable(f"binding-resolved query failed: {e}")
+
+    if truncated:
+        note_parts.append(f"opened first {max_open} of {len(open_files)} candidate files")
+
+    return {
+        "op": op,
+        "symbol": symbol,
+        "results": results,
+        "opened": len(files),
+        "note": "; ".join(note_parts) or None,
+    }
+
+
+# ── formatting ───────────────────────────────────────────────────────────────
+
+def _rel(path: str, root: str) -> str:
+    try:
+        return os.path.relpath(path, root)
+    except ValueError:
+        return path
+
+
+def format_lsp(result: dict, root: str, json_out: bool = False) -> str:
+    """Render an :func:`lsp_query` result. LSP 0-based positions become 1-based."""
+    if json_out:
+        import json
+        payload = {"op": result["op"], "symbol": result["symbol"],
+                   "opened": result["opened"], "note": result["note"], "results": []}
+        for grp in result["results"]:
+            entry: dict = {}
+            anchor = grp.get("anchor")
+            if anchor is not None:
+                entry["anchor"] = {"file": anchor.file, "line": anchor.line,
+                                   "col": anchor.col, "kind": anchor.kind}
+            if "hover" in grp:
+                entry["hover"] = grp["hover"]
+            if "locations" in grp:
+                entry["locations"] = [
+                    {"file": _rel(loc.path, root), "line": loc.start_line + 1,
+                     "col": loc.start_char + 1} for loc in grp["locations"]
+                ]
+            payload["results"].append(entry)
+        return json.dumps(payload, indent=2)
+
+    op = result["op"]
+    sym = result["symbol"]
+    lines = [f"{sym} — binding-resolved {op} (python-lsp)"]
+    total = 0
+    for grp in result["results"]:
+        anchor = grp.get("anchor")
+        if "hover" in grp:
+            where = f"{anchor.file}:{anchor.line}" if anchor else ""
+            hover = grp["hover"] or "(no type information)"
+            lines.append(f"  {where}  {hover}")
+            total += 1
+            continue
+        locs = grp.get("locations", [])
+        if anchor is not None:
+            lines.append(f"  definition {anchor.file}:{anchor.line}"
+                         f"{f' ({anchor.kind})' if anchor.kind else ''}")
+        for loc in locs:
+            lines.append(f"    {_rel(loc.path, root)}:{loc.start_line + 1}:{loc.start_char + 1}")
+            total += 1
+        if anchor is not None and not locs:
+            lines.append("    (no references)")
+    if op == "references":
+        lines.append(f"  {total} reference{'s' if total != 1 else ''} "
+                     f"(binding-resolved; same-named symbols of other bindings excluded)")
+    if result.get("note"):
+        lines.append(f"  note: {result['note']}")
+    return "\n".join(lines)

--- a/searching-codebases/scripts/search.py
+++ b/searching-codebases/scripts/search.py
@@ -259,14 +259,44 @@ def format_results(results: dict, root: str, output_json: bool = False) -> str:
     return "\n".join(lines)
 
 
+def run_lsp_query(root: str, symbol: str, op: str, json_out: bool,
+                  verbose: bool) -> None:
+    """Binding-resolved (pyright) tier for Python symbols, with soft fallback.
+
+    On any condition where the binding-resolved answer can't be produced
+    (non-Python target, pyright/node absent, client unimportable), emit a
+    one-line degradation note and fall back to the regex text path so the user
+    still gets results.
+    """
+    from lsp_refs import lsp_query, format_lsp, LspUnavailable
+
+    try:
+        result = lsp_query(root, symbol, op=op, verbose=verbose)
+    except LspUnavailable as e:
+        print(f"[python-lsp unavailable: {e}] falling back to regex text search",
+              file=sys.stderr)
+        results = search_regex(root, [symbol], verbose=verbose)
+        print(format_results(results, root, json_out))
+        return
+    print(format_lsp(result, root, json_out))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Unified code search")
     parser.add_argument("source", help="Path, GitHub URL, 'uploads', or 'project'")
-    parser.add_argument("queries", nargs="+", help="Search queries")
+    parser.add_argument("queries", nargs="*", help="Search queries")
     parser.add_argument("--regex", action="store_true", help="Force regex mode")
     parser.add_argument("--semantic", action="store_true", help="Force semantic mode")
     parser.add_argument("--expand", action="store_true", help="Expand to full function bodies")
     parser.add_argument("--benchmark", action="store_true", help="Benchmark indexed vs brute-force")
+    parser.add_argument("--refs", metavar="SYMBOL", default=None,
+                        help="Binding-resolved references for a Python SYMBOL (pyright; "
+                             "excludes same-named unrelated symbols)")
+    parser.add_argument("--def", dest="defn", metavar="SYMBOL", default=None,
+                        help="Binding-resolved go-to-definition for a Python SYMBOL "
+                             "(follows imports across files)")
+    parser.add_argument("--hover", metavar="SYMBOL", default=None,
+                        help="Inferred type/signature for a Python SYMBOL (pyright)")
     parser.add_argument("--branch", default="main", help="Git branch for GitHub URLs")
     parser.add_argument("--skip", default=None, help="Comma-separated directories to skip")
     parser.add_argument("--json", action="store_true", help="JSON output")
@@ -278,6 +308,20 @@ def main():
     root = resolve(args.source, args.branch)
     if args.verbose:
         print(f"Resolved: {root} ({count_files(root)} files)", file=sys.stderr)
+
+    # Binding-resolved tier (Python only, engaged lazily). Mutually exclusive
+    # with the text-search queries — these answer a single symbol query.
+    lsp_ops = [("references", args.refs), ("definition", args.defn), ("hover", args.hover)]
+    active = [(op, sym) for op, sym in lsp_ops if sym]
+    if active:
+        if len(active) > 1:
+            parser.error("--refs / --def / --hover are mutually exclusive")
+        op, symbol = active[0]
+        run_lsp_query(root, symbol, op, args.json, args.verbose)
+        return
+
+    if not args.queries:
+        parser.error("no queries given (provide search terms, or use --refs/--def/--hover)")
 
     skip_dirs = None
     if args.skip:

--- a/searching-codebases/tests/fixture/pkg/models.py
+++ b/searching-codebases/tests/fixture/pkg/models.py
@@ -1,0 +1,10 @@
+class User:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def greet(self) -> str:
+        return f"hi {self.name}"
+
+
+def helper(x: int) -> int:
+    return x + 1

--- a/searching-codebases/tests/fixture/pkg/other.py
+++ b/searching-codebases/tests/fixture/pkg/other.py
@@ -1,0 +1,5 @@
+def helper() -> str:
+    return "unrelated"
+
+
+print(helper())

--- a/searching-codebases/tests/fixture/pkg/service.py
+++ b/searching-codebases/tests/fixture/pkg/service.py
@@ -1,0 +1,7 @@
+from pkg.models import User, helper
+
+
+def make_user(name: str) -> User:
+    u = User(name)
+    print(helper(3))
+    return u

--- a/searching-codebases/tests/test_lsp_refs.py
+++ b/searching-codebases/tests/test_lsp_refs.py
@@ -1,0 +1,148 @@
+"""Tests for the binding-resolved (python-lsp) tier of searching-codebases.
+
+Round-trips against a small multi-file fixture driving a real
+``pyright-langserver``, and exercises the mandatory soft-fallback contract.
+
+Run: python -m pytest searching-codebases/tests/test_lsp_refs.py -v
+Or:  python searching-codebases/tests/test_lsp_refs.py   (standalone)
+
+The semantic tests require pyright (and system node); they are skipped if the
+bootstrap can't make pyright available. The fallback tests have no such
+dependency — they assert the degradation path.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import lsp_refs  # noqa: E402
+from lsp_refs import (  # noqa: E402
+    LspUnavailable,
+    definition_sites,
+    lsp_query,
+    occurrence_sites,
+)
+
+FIXTURE = str(Path(__file__).parent / "fixture")
+
+
+def _pyright_available() -> bool:
+    try:
+        lsp = lsp_refs._import_lsp_client()
+        lsp.ensure_pyright(install=True)
+        return True
+    except Exception:
+        return False
+
+
+pyright = pytest.mark.skipif(not _pyright_available(),
+                             reason="pyright/node unavailable")
+
+
+def _pyright_proc_count() -> int:
+    out = subprocess.run(["pgrep", "-f", "pyright-langserver"],
+                         capture_output=True, text=True).stdout
+    return len([ln for ln in out.splitlines() if ln.strip()])
+
+
+# ── symbol → position resolution (no server) ─────────────────────────────────
+
+def test_definition_sites_finds_both_helpers():
+    sites = definition_sites(FIXTURE, "helper")
+    by_file = {s.file: s for s in sites}
+    assert "pkg/models.py" in by_file and "pkg/other.py" in by_file
+    # Column lands on the symbol token, not the `def` keyword (1-based).
+    assert by_file["pkg/models.py"].col == 5  # "def helper" -> h at col 5
+    assert by_file["pkg/models.py"].line == 9
+
+
+def test_occurrence_sites_are_a_superset():
+    occ = occurrence_sites(FIXTURE, "helper")
+    files = {s.file for s in occ}
+    # Text matching catches all three files (including the unrelated other.py).
+    assert {"pkg/models.py", "pkg/other.py", "pkg/service.py"} <= files
+
+
+# ── binding-resolved queries (the win over regex) ────────────────────────────
+
+@pyright
+def test_references_exclude_unrelated_same_named_symbol():
+    result = lsp_query(FIXTURE, "helper", op="references")
+    groups = {g["anchor"].file: g for g in result["results"]}
+    # The models.py binding's references include its def and the use in
+    # service.py, but EXCLUDE the unrelated helper in other.py.
+    models = {Path(loc.path).name for loc in groups["pkg/models.py"]["locations"]}
+    models_files = {str(Path(loc.path).relative_to(Path(FIXTURE)))
+                    for loc in groups["pkg/models.py"]["locations"]}
+    assert "pkg/models.py" in models_files
+    assert "pkg/service.py" in models_files
+    assert "pkg/other.py" not in models_files, (
+        "binding-resolved references must exclude the same-named unrelated symbol"
+    )
+    assert "models.py" in models  # sanity on the name extraction
+
+
+@pyright
+def test_definition_follows_import_across_files():
+    result = lsp_query(FIXTURE, "User", op="definition")
+    locs = result["results"][0]["locations"]
+    files = {str(Path(loc.path).relative_to(Path(FIXTURE))) for loc in locs}
+    # Anchored at every occurrence (incl. the import + use in service.py),
+    # definition resolves across the import to the class in models.py.
+    assert "pkg/models.py" in files
+
+
+@pyright
+def test_hover_returns_inferred_signature():
+    result = lsp_query(FIXTURE, "helper", op="hover")
+    hovers = " ".join(g["hover"] or "" for g in result["results"])
+    assert "helper" in hovers and "int" in hovers
+
+
+@pyright
+def test_indexing_wait_makes_queries_deterministic():
+    # Without wait_for_index this would flake to empty. Repeat must be stable.
+    for _ in range(2):
+        result = lsp_query(FIXTURE, "User", op="references")
+        total = sum(len(g["locations"]) for g in result["results"])
+        assert total >= 3
+
+
+@pyright
+def test_no_orphaned_subprocess():
+    before = _pyright_proc_count()
+    lsp_query(FIXTURE, "User", op="references")
+    # Context manager in lsp_query must reap the server.
+    assert _pyright_proc_count() == before, "pyright-langserver leaked"
+
+
+# ── soft-fallback contract (no pyright dependency) ───────────────────────────
+
+def test_missing_symbol_raises_lsp_unavailable():
+    with pytest.raises(LspUnavailable):
+        lsp_query(FIXTURE, "NoSuchSymbolAnywhere", op="references")
+
+
+def test_bootstrap_failure_raises_lsp_unavailable(monkeypatch):
+    # Simulate node/pyright absence: ensure_pyright fails loud, the tier must
+    # degrade (raise LspUnavailable) rather than hang.
+    lsp = lsp_refs._import_lsp_client()
+
+    def boom(*a, **k):
+        raise lsp.BootstrapError("pyright requires system 'node' but none found")
+
+    monkeypatch.setattr(lsp, "ensure_pyright", boom)
+    with pytest.raises(LspUnavailable) as exc:
+        lsp_query(FIXTURE, "helper", op="references")
+    assert "node" in str(exc.value).lower()
+
+
+# ── standalone runner ────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #695.

Wires the `python-lsp` client into **searching-codebases** as a binding-resolved reference/definition tier for Python — the skill-wiring follow-up #693 deferred. Scope is searching-codebases only (the convergent "where is X / find all users" lane), per the issue's divergent/convergent rationale.

## What this closes

searching-codebases' "find all callers/users" runs through the regex/n-gram tier today — *text* matching that false-positives on shadowed and same-named-but-unrelated symbols. `python-lsp.references()` is binding-resolved: it excludes the unrelated same-named symbol and follows imports.

## Change

New flags on `search.py` (Python sources only, engaged **lazily** so pyright's index cost is never paid on ordinary searches):

- `--refs SYMBOL` — binding-resolved references, grouped per binding
- `--def SYMBOL` — go-to-definition, unioned across occurrences (follows imports)
- `--hover SYMBOL` — inferred type / signature

`scripts/lsp_refs.py` is the bridge:
- **Symbol → position**: tree-sitting resolves the symbol name to its definition site(s); ripgrep enumerates occurrences (a safe superset) both to anchor `--def` and to bound the set of files opened in the server.
- **Coordinate seam**: tree-sitting/ripgrep are 1-based, LSP is 0-based — converted at the boundary via `Position.from_one_based(line, col)`.
- **Lifecycle** (python-lsp gotchas): opens the relevant files, `wait_for_index()` before querying, context-managed so no `pyright-langserver` leaks.
- **Mandatory soft fallback**: non-`.py` target, no Python definition, or absent pyright/node → one-line degradation note + regex text path. No hang, no orphaned subprocess.

## Acceptance criteria

All met and tested against a multi-file fixture driving a real pyright:

- ✅ reference query excludes the unrelated same-named symbol (`helper` in `other.py` stays out of `models.py`'s binding)
- ✅ `definition` follows an import across files
- ✅ non-Python / node-absent falls back with a one-line note (no hang, no orphan)
- ✅ indexing-wait respected (determinism test); subprocess cleanup verified
- ✅ test suite green: `python3 -m pytest searching-codebases/tests/test_lsp_refs.py` → 9 passed

Out of scope (per issue): exploring-codebases pointer, mapping-codebases wiring, additional language servers.

SKILL.md bumped 2.0.0 → 2.1.0; CHANGELOG updated.

https://claude.ai/code/session_01Udn81q5THz9iz79UNa7AFo