### PR TITLE
python-lsp 0.3.0: auto-detect project root to stop silent reference undercount

### DIFF
--- a/python-lsp/SKILL.md
+++ b/python-lsp/SKILL.md
@@ -2,7 +2,7 @@
 name: python-lsp
 description: Semantic Python code queries via a stdio LSP client driving pyright-langserver. Provides binding-resolved go-to-definition, find-references, hover types, type diagnostics, file symbol outlines, and project-wide symbol search — name resolution and type inference that tree-sitter and ripgrep cannot do. Use when you need to follow an import to a definition, find all real uses of a symbol (excluding same-named-but-unrelated ones), get an inferred type, surface type errors, outline a file, or search symbols across a project. Triggers on "go to definition", "find references", "what type is", "resolve this symbol", "symbol outline", "find symbol in project", "pyright", "type-check this file".
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # python-lsp
@@ -77,6 +77,16 @@ with LSPClient("/path/to/repo") as c:        # context manager reaps the subproc
 (all zero-based) and `.as_dict()`. Convert 1-based UI input with
 `Position.from_one_based(line, col)`.
 
+The `root` you pass is split into two roles. Relative `<file>` arguments resolve
+against it (call that the *scope*), but pyright is rooted at the enclosing
+**project root** — by default `LSPClient` climbs out of any package the scope
+sits inside (every ancestor with an `__init__.py`) via `find_project_root`. This
+is what makes a query scoped to a sub-package (`scipy/optimize`) still resolve
+the project's own absolute imports (`from scipy.optimize._x import Y`); without
+it, references **silently undercount** — same blindness as a text grep, opposite
+direction. The promotion is announced on stderr. Pass `auto_root=False` to pin
+pyright at the scope verbatim.
+
 ## Methods
 
 | Method | Returns | Notes |
@@ -110,6 +120,14 @@ with LSPClient("/path/to/repo") as c:        # context manager reaps the subproc
 4. **Open the files you query.** Queries auto-`did_open` their target file, but
    for cross-file `references` open all relevant files first so pyright has
    built their models.
+5. **Root at the project, not the sub-package.** pyright resolves absolute
+   intra-project imports only when rooted where the top-level package is
+   importable. Rooted at a sub-package, those imports fail and references
+   undercount with no error. `LSPClient` auto-detects this (climbs out of the
+   enclosing package; see `find_project_root`) and prints the promotion to
+   stderr; `auto_root=False` opts out. This was a live silent-undercount bug:
+   `--refs ScalarFunction` over `scipy/optimize` returned 3 references rooted at
+   the sub-package vs 30 rooted at the project root.
 
 ## Tests
 

--- a/python-lsp/scripts/lsp_client.py
+++ b/python-lsp/scripts/lsp_client.py
@@ -213,6 +213,37 @@ def uri_to_path(uri: str) -> str:
     return uri
 
 
+def find_project_root(start: str) -> str:
+    """Resolve the directory pyright should use as its workspace root.
+
+    The subtle, silent failure this guards against: point pyright at a
+    *sub-package* (e.g. ``scipy/optimize``) and its own absolute intra-project
+    imports (``from scipy.optimize._x import Y``) no longer resolve, because
+    ``scipy`` isn't importable when ``optimize`` is the root. References then
+    undercount with no error — as quietly as a text grep over-counts.
+
+    Detection is principled, not marker-based: the Python import root is the
+    first ancestor that is **not itself a package**, i.e. the directory you
+    would put on ``sys.path`` for ``import top_level_pkg`` to work. We climb out
+    of any package the start path sits inside (every ancestor with an
+    ``__init__.py``). If the start isn't inside a package, it is already an
+    import-root candidate and is returned unchanged — we deliberately do NOT
+    walk up to a project marker or ``.git`` from there, since that would promote
+    a self-contained directory to an unrelated parent and widen every query.
+
+    ``start`` may be a file or a directory. The return value is always an
+    absolute directory path.
+    """
+    base = Path(start).resolve()
+    if not base.is_dir():
+        base = base.parent
+
+    d = base
+    while (d / "__init__.py").exists() and d.parent != d:
+        d = d.parent
+    return str(d)
+
+
 # ── The client ──────────────────────────────────────────────────────────────
 
 class LSPError(RuntimeError):
@@ -232,8 +263,23 @@ class LSPClient:
         root: str,
         server_cmd: Optional[list[str]] = None,
         auto_install: bool = True,
+        auto_root: bool = True,
     ):
-        self.root = str(Path(root).resolve())
+        # ``scope`` is the path the caller reasons about — relative file
+        # arguments resolve against it, and it scopes what callers scan/open.
+        # ``root`` is what pyright is rooted at: when ``auto_root`` is set we
+        # promote ``scope`` to the enclosing project/import root so the
+        # project's own absolute imports resolve and references don't silently
+        # undercount (see ``find_project_root``). They differ only when
+        # ``scope`` sits inside a package.
+        self.scope = str(Path(root).resolve())
+        self.root = find_project_root(self.scope) if auto_root else self.scope
+        if self.root != self.scope:
+            print(
+                f"python-lsp: rooted at project root {self.root} "
+                f"(promoted from {self.scope} so intra-project imports resolve)",
+                file=sys.stderr,
+            )
         self._server_cmd = server_cmd
         self._auto_install = auto_install
         self._proc: Optional[subprocess.Popen] = None
@@ -544,7 +590,7 @@ class LSPClient:
     def _abs(self, file: str) -> str:
         p = Path(file)
         if not p.is_absolute():
-            p = Path(self.root) / p
+            p = Path(self.scope) / p
         return str(p.resolve())
 
     def _text_document_position(self, file: str, line: int, col: int) -> dict:

--- a/python-lsp/tests/test_lsp_client.py
+++ b/python-lsp/tests/test_lsp_client.py
@@ -26,6 +26,7 @@ from lsp_client import (  # noqa: E402
     Position,
     SymbolInfo,
     ensure_pyright,
+    find_project_root,
     uri_to_path,
 )
 
@@ -96,6 +97,54 @@ def test_bootstrap_fails_loudly_without_node(monkeypatch):
     with pytest.raises(BootstrapError) as exc:
         ensure_pyright(install=True)
     assert "node" in str(exc.value).lower()
+
+
+# ── project-root detection (the silent-undercount guard) ────────────────────
+
+def test_find_project_root_climbs_out_of_package():
+    # FIXTURE has no __init__.py; FIXTURE/pkg does. Pointed at the package,
+    # the import root is FIXTURE — the dir you'd put on sys.path for
+    # `import pkg` to resolve.
+    assert find_project_root(str(FIXTURE / "pkg")) == str(FIXTURE.resolve())
+    # A file inside the package resolves the same way.
+    assert find_project_root(str(FIXTURE / "pkg" / "models.py")) == str(FIXTURE.resolve())
+    # A non-package dir is already an import root — returned unchanged, NOT
+    # promoted to an unrelated parent (e.g. the repo's .git).
+    assert find_project_root(str(FIXTURE)) == str(FIXTURE.resolve())
+
+
+def test_auto_root_resolves_absolute_imports_misrooted_undercounts():
+    # The 3-vs-30 bug in miniature. service.py uses an ABSOLUTE intra-project
+    # import (`from pkg.models import User`). Rooted at the package `pkg`,
+    # `pkg` isn't importable, so pyright silently misses the cross-file use.
+    # auto_root promotes the root to FIXTURE, where it resolves.
+    ensure_pyright()
+
+    # auto_root=True (default): rooted at FIXTURE, the use in service.py resolves.
+    with LSPClient(str(FIXTURE / "pkg")) as c:
+        assert c.root == str(FIXTURE.resolve())   # promoted out of the package
+        assert c.scope == str((FIXTURE / "pkg").resolve())
+        c.open_all("models.py", "service.py", "other.py")
+        assert c.wait_for_index(timeout=30)
+        # `User` class def is models.py line 0, col 6.
+        files = {_rel(loc) for loc in c.references("models.py", 0, 6)}
+    assert any(f.endswith("service.py") for f in files), (
+        "auto-rooted client must resolve the absolute import and find the use "
+        "in service.py"
+    )
+
+    # auto_root=False: rooted at the package, the absolute import is unresolved
+    # and the cross-file reference silently disappears — exactly the failure
+    # auto_root exists to prevent.
+    with LSPClient(str(FIXTURE / "pkg"), auto_root=False) as c:
+        assert c.root == str((FIXTURE / "pkg").resolve())
+        c.open_all("models.py", "service.py", "other.py")
+        assert c.wait_for_index(timeout=30)
+        mis = {_rel(loc) for loc in c.references("models.py", 0, 6)}
+    assert not any(f.endswith("service.py") for f in mis), (
+        "mis-rooted client is expected to undercount (regression witness): the "
+        "cross-file use is unresolved when the package isn't on the import root"
+    )
 
 
 # ── semantic queries (the win over ripgrep) ─────────────────────────────────


### PR DESCRIPTION
## The bug

`LSPClient` took its `root` verbatim and handed it straight to pyright as `rootUri`. Point it at a **sub-package** and the project's own *absolute* intra-project imports stop resolving — `from scipy.optimize._x import Y` can't resolve when `optimize` is the root, because `scipy` isn't importable from there. `references` then **undercounts with no error** — as quietly as a text grep over-counts, opposite direction.

Measured on a real SciPy clone:

| pyright root | `--refs ScalarFunction` |
|---|---|
| `scipy/optimize` (sub-package) | **3** |
| project root | **30** |

## The fix

Split the constructor's `root` into two roles:
- **`scope`** — relative `<file>` args resolve against it (unchanged behaviour; `_abs` now uses `scope`).
- **`root`** — pyright's workspace. `find_project_root` climbs out of the enclosing package(s) to the import root: the first ancestor without `__init__.py`, i.e. the directory you'd put on `sys.path`.

Default `auto_root=True`; `auto_root=False` pins the scope verbatim. The promotion is announced on stderr — it degrades **loudly**, which is the whole point.

Detection is the `__init__.py` climb *only*. An earlier draft added a marker/`.git` fallback; it over-promoted a self-contained dir to the enclosing git repo and widened `workspace/symbol` to everything — caught by the existing suite, then removed.

## Tests

- `find_project_root`: climbs out of a package; leaves a non-package dir unchanged (no over-promotion).
- The 3-vs-30 bug in miniature on the fixture: `service.py`'s absolute `from pkg.models import User` — auto-rooted resolves the cross-file use; `auto_root=False` witnesses the undercount.
- **20 passed.** Verified end-to-end: `searching-codebases --refs` over `scipy/optimize` now returns 30 (was 3). `searching-codebases` picks this up transitively — it imports `python-lsp` at runtime, no change needed there.

SKILL.md bumped 0.2.0 → 0.3.0 with the usage note and a new lifecycle gotcha.

https://claude.ai/code/session_012XWFuGm3Wz82uJMVkZFk7R