### PR TITLE
reading-business-cards: model-driven floor-based tile sizing

### DIFF
--- a/reading-business-cards/SKILL.md
+++ b/reading-business-cards/SKILL.md
@@ -2,7 +2,7 @@
 name: reading-business-cards
 description: "Preprocesses photographed sheets of many business cards — slicing each into overlapping high-resolution tiles and de-glaring them with container tooling (OpenCV/ImageMagick) — then reads every card via cheap parallel temperature-0 API calls (Haiku or Sonnet) using a distilled extraction prompt, and writes deduped contact fields to a CSV. Use when a user has photos or scans holding multiple business cards per image, mentions glare or unreadable cards, batch card transcription, contact extraction, or wants to read many cards without an expensive in-conversation pass. Triggers on 'business cards', 'card scan', 'extract contacts', 'read these cards', 'card glare', 'too many cards per photo'."
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Reading Business Cards
@@ -19,9 +19,14 @@ it. A phone photo of 50-60 cards is often 4000-6000px; downscaled to one image,
 each card lands ~150px wide — unreadable, which forces you onto a more expensive
 model. The script cuts the sheet into overlapping **tiles**, each near the
 downscale cap (~1300px), so every card in a tile keeps 500px+ of real
-resolution. That resolution recovery is what lets the cheaper model (Sonnet)
-read cards that only the expensive one (Opus) could read before. Run this skill
-with **Sonnet selected** — that's the whole point.
+resolution. That resolution recovery is what lets a cheaper model (Sonnet) read
+cards that only the expensive one (Opus) could read before — and it lets Opus
+read cards from far fewer tiles. **The grid is sized to the reader model** (see
+Stage 1): pass `--model` and the script tiles aggressively for Haiku, moderately
+for Sonnet, and least for Opus, because a stronger reader has a lower resolution
+floor. The floor is set by the *pixels*, not the model's intelligence: at
+~220px/card (a whole dense sheet) even Opus reads only company and some names,
+not phone/email — so even Opus needs a few tiles for fine print on dense sheets.
 
 De-glaring (illumination flattening + local contrast) is applied to each tile.
 It corrects uneven lighting and the haze off glossy cards and plastic binder
@@ -39,15 +44,27 @@ overlapping, piled. Detecting individual card boundaries fails on all of these.
 overlapping rectangles. Each tile holds a few cards at high resolution; the
 overlap means a card split by one tile's edge is whole in its neighbour.
 
-Run it with no tuning — the script derives the tile grid from each image's own
-dimensions so every tile stays just under the model's downscale cap:
+Run it sized to whichever model will read the tiles — pass `--model` and the
+script measures each sheet's native card size, then derives the coarsest grid
+whose cards still clear that model's OCR floor:
 
 ```bash
-python3 scripts/prep_cards.py /mnt/user-data/uploads --out /home/claude/cards_work
+python3 scripts/prep_cards.py /mnt/user-data/uploads --out /home/claude/cards_work --model opus
 ```
 
-It prints the grid it chose per image (e.g. `auto 5x4 from 4284x5712`) and writes
-tiles to `cards_work/tiles/` (`<sheet>__r{R}_c{C}.png`) plus a `manifest.json`.
+`--model opus|sonnet|haiku` (or a full id like `claude-opus-4-8`) sets the floor:
+Opus tiles least, Haiku most. Default is `sonnet` (the safe middle). On a dense
+~660px-card sheet this yields roughly 6 tiles/sheet for Opus, 9-12 for Sonnet,
+12-20 for Haiku. If the reader is the in-conversation model (the no-key path,
+below), set `--model` to match whatever you're running. Overrides: `--target-px`
+forces an explicit tile size, `--card-px` overrides the auto card-size estimate,
+`--floor-px` overrides the per-model floor.
+
+It prints the grid it chose per image (e.g.
+`auto 3x2 from 4284x5712 [model=opus floor=350 card~668px -> target 2993]`) and
+writes tiles to `cards_work/tiles/` (`<sheet>__r{R}_c{C}.png`) plus a
+`manifest.json`. If a sheet's cards are smaller than the model's floor even at
+native resolution, it warns — that sheet needs a re-shoot, not a finer grid.
 
 Then **verify and self-adjust by inspection** — this is your judgment, not the
 person's:
@@ -64,19 +81,33 @@ De-glaring (illumination flatten + local contrast) is on by default and is
 non-destructive. Decide on the extra flags by looking at a tile, then commit to
 the full read.
 
-## Stage 2 — Read and extract (cheap path: the API runner)
+## Stage 2 — Read and extract
 
-Do NOT read 1,000 tiles yourself in this conversation — that is the token blowup
-to avoid. Instead, run `extract_cards.py`, which sends each tile to a model in a
-separate, parallel, temperature-0 API call using the distilled prompt in
-`prompts/haiku_extract.md`, parses the JSON, dedupes across overlapping tiles,
-and writes the CSV. Reading happens outside the chat context, so it costs a
-fraction of in-conversation reading and runs many tiles at once.
+There are two ways to read the tiles. **In-session reading is the universal path
+and works for everyone, key or no key:** view the tiles with the `view` tool and
+transcribe them in this conversation, applying the rules in
+`prompts/haiku_extract.md` (one row per fully-visible card, skip edge-clipped
+cards that are whole in a neighbour, never invent, `confidence` low when unsure).
+The coarse model-sized grid is what makes this tractable — a dozen tiles per
+sheet, not eighty — and the conversation model reading them is exactly the model
+that reads cards well. Cost here is the subscription's usage allowance, not
+per-token dollars; the coarser the grid (Opus), the fewer reads.
 
-**Validate the model on a sample before the full run — do not assume Haiku is
-accurate enough.** Haiku is ~6x cheaper but its OCR is weaker; on phone photos of
-loose or angled cards it confidently misreads names and companies and marks the
-errors `high` confidence. Tested guidance:
+**The API runner is an optional optimization, only when an API key is present**
+(`API_KEY` in env / `/mnt/project/claude.env`). It sends each tile to a model in
+a separate parallel temperature-0 call using the distilled prompt, dedupes, and
+writes the CSV — reading outside the chat context, so it is cheaper per token and
+runs many tiles at once. Without a key it cannot run; use the in-session path.
+The runner bills the API account per token; it buys parallelism and a cheaper
+meter, never accuracy.
+
+### Running the API runner (keyed path)
+
+**Validate the model on a sample before the full run.** Haiku is ~6x cheaper but
+its OCR is weaker; on phone photos of loose or angled cards it confidently
+misreads names and marks the errors `high` confidence. (Gemini's free tier was
+tested 2026-06-15 and read these poorly — do not reach for it here.) Tested
+guidance:
 
 1. Sample run with Haiku:
    ```bash

--- a/reading-business-cards/scripts/prep_cards.py
+++ b/reading-business-cards/scripts/prep_cards.py
@@ -205,13 +205,80 @@ def build_montage(crop_paths, indices, cell_w, out_path):
 
 def auto_grid(h, w, overlap, target=1500):
     """Derive rows x cols from the image's own dimensions so each tile's long
-    edge (including overlap) stays at or below `target` px — just under the
-    model's ~1568 downscale cap, so tiles keep full resolution and cards stay
-    legible. No human tuning needed; adapts per image and orientation."""
+    edge (including overlap) stays at or below `target` px. With a target <=1568
+    tiles keep full resolution; with a larger target (Opus path) tiles are
+    deliberately downscaled, trading surplus resolution for fewer tiles.
+    No human tuning needed; adapts per image and orientation."""
     factor = 1.0 + 2.0 * overlap
     rows = max(1, math.ceil(h * factor / target))
     cols = max(1, math.ceil(w * factor / target))
     return rows, cols
+
+
+# Per-model OCR floor: the native-card long-edge (px) a reader model needs to
+# pull fine print (phone/email/address) reliably — NOT just the company/name.
+# Stronger models tolerate smaller cards and more glare, so they need fewer,
+# bigger tiles (or, when native card px already clears the floor, none).
+# Empirically seeded 2026-06-15: at ~220px/card (a whole dense sheet downscaled
+# to the 1568 cap) even Opus 4.8 reads only company + some names, not contact
+# details — so the Opus floor for fine print is ~350, not magically low. The
+# limiter is pixels resolving 6pt glyphs, not model intelligence. Tune via
+# --floor-px and validate on a sample (see SKILL Stage 2).
+MODEL_FLOORS = {
+    "opus":   350,   # claude-opus-4-x  : lowest floor -> fewest/biggest tiles
+    "sonnet": 450,   # claude-sonnet-4-x: moderate (the safe default)
+    "haiku":  600,   # claude-haiku-4-x : needs big cards; validate regardless
+}
+DOWNSCALE_CAP = 1568  # model downscales any image to ~this on the long edge
+
+
+def model_key(model):
+    m = (model or "sonnet").lower()
+    for k in MODEL_FLOORS:
+        if k in m:
+            return k
+    return "sonnet"
+
+
+def estimate_card_px(bgr):
+    """Rough median card long-edge (px) from card-like bright rectangles.
+    Returns None if too few are found (caller falls back to a safe default).
+    Conservative by design: business-card aspect ~1.45-2.15, area 0.15-4% of
+    the sheet. Detection need not be complete — a handful of clean cards gives
+    a good-enough median to size the grid."""
+    H, W = bgr.shape[:2]
+    gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+    th = cv2.adaptiveThreshold(gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C,
+                               cv2.THRESH_BINARY, 101, -10)
+    th = cv2.morphologyEx(th, cv2.MORPH_CLOSE, np.ones((15, 15), np.uint8))
+    cnts, _ = cv2.findContours(th, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    sheet_area = float(W * H)
+    longs = []
+    for c in cnts:
+        (_, _), (w, h), _ = cv2.minAreaRect(c)
+        if w < 10 or h < 10:
+            continue
+        lo, sh = max(w, h), min(w, h)
+        if 1.45 < lo / sh < 2.15 and 0.0015 * sheet_area < w * h < 0.04 * sheet_area:
+            longs.append(lo)
+    if len(longs) < 4:
+        return None
+    longs.sort()
+    return float(longs[len(longs) // 2])
+
+
+def target_for_model(h, w, card_px, floor):
+    """Largest tile long-edge whose post-downscale card still clears `floor`:
+        target = CAP * card_px / floor
+    Clamped so a tile never exceeds the sheet's own long edge (i.e. 1x1, no
+    tiling, when the sheet already clears the floor) and never drops below 800
+    (avoid pathological over-tiling). If card_px is unknown, fall back to the
+    full-resolution cap (Sonnet-safe). If card_px < floor, even native res is
+    short — return the cap and let the caller flag a likely re-shoot."""
+    if card_px is None:
+        return DOWNSCALE_CAP
+    raw = DOWNSCALE_CAP * card_px / max(1.0, float(floor))
+    return int(max(800, min(raw, float(max(h, w)))))
 
 
 def gather_inputs(path):
@@ -230,9 +297,19 @@ def main():
     ap.add_argument("--tiles", default="",
                     help="ROWSxCOLS override, e.g. 5x4. Omit to auto-derive the "
                          "grid from each image's size (the default).")
-    ap.add_argument("--target-px", type=int, default=1500,
-                    help="max tile long edge for auto-grid (default 1500, just "
-                         "under the model's downscale cap)")
+    ap.add_argument("--model", default="sonnet",
+                    help="reader model the tiles are sized for: opus | sonnet | "
+                         "haiku (or a full id like claude-opus-4-8). Sets the OCR "
+                         "floor -> Opus tiles least, Haiku most. Default sonnet.")
+    ap.add_argument("--target-px", type=int, default=0,
+                    help="explicit max tile long edge; overrides --model sizing. "
+                         "0 (default) = derive from model floor x measured card px.")
+    ap.add_argument("--card-px", type=int, default=0,
+                    help="native card long-edge in px; 0 (default) = auto-estimate "
+                         "per sheet. Override if the estimator misfires.")
+    ap.add_argument("--floor-px", type=int, default=0,
+                    help="override the per-model OCR floor (native card px needed). "
+                         "0 (default) = use the model's table value.")
     ap.add_argument("--overlap", type=float, default=0.12,
                     help="tile overlap fraction (default 0.12)")
     ap.add_argument("--detect", action="store_true",
@@ -279,8 +356,23 @@ def main():
                     sys.exit("--tiles must look like ROWSxCOLS, e.g. 5x4")
                 how = f"{tr}x{tc} override"
             else:
-                tr, tc = auto_grid(h, w, args.overlap, args.target_px)
-                how = f"auto {tr}x{tc} from {w}x{h}"
+                if args.target_px > 0:
+                    target = args.target_px
+                    how_extra = f"target-px {target} (explicit)"
+                else:
+                    card_px = (float(args.card_px) if args.card_px > 0
+                               else estimate_card_px(bgr))
+                    mk = model_key(args.model)
+                    floor = args.floor_px if args.floor_px > 0 else MODEL_FLOORS[mk]
+                    target = target_for_model(h, w, card_px, floor)
+                    cps = f"{card_px:.0f}px" if card_px else "unknown"
+                    how_extra = f"model={mk} floor={floor} card~{cps} -> target {target}"
+                    if card_px and card_px < floor:
+                        print(f"  ! {sheet_name}: card ~{card_px:.0f}px < {mk} floor "
+                              f"{floor}px — even native res is short; expect low "
+                              f"reads, consider a re-shoot.", file=sys.stderr)
+                tr, tc = auto_grid(h, w, args.overlap, target)
+                how = f"auto {tr}x{tc} from {w}x{h} [{how_extra}]"
             tiles = slice_tiles(bgr, tr, tc, args.overlap)
             for k, (tile, (x0, y0)) in enumerate(tiles):
                 if not args.no_deglare:


### PR DESCRIPTION
## Model-driven, floor-based tile sizing

Sizes the tile grid to the **reader model** instead of a fixed ~1500px target.
A stronger reader has a lower OCR floor, so it needs fewer/bigger tiles.

### What changed
- `prep_cards.py`: new `--model {opus|sonnet|haiku|<full-id>}` sets a per-model
  OCR floor (native card px needed for fine print: opus 350 / sonnet 450 /
  haiku 600). `estimate_card_px()` measures each sheet's native card size (cv2
  contour median); `target_for_model()` derives the coarsest tile size whose
  downscaled card still clears the floor. `--target-px` now defaults to 0
  (=derive); pass a value to force. Added `--card-px` / `--floor-px` overrides.
  Warns when a sheet's cards are below the floor even at native res (re-shoot).
- `SKILL.md` (v2.1.0): documents model-driven tiling; reframes Stage 2 so
  **in-session reading is the universal path (key or no key)** and the API
  runner is the optional keyed optimization (cheaper meter + parallelism, never
  accuracy). Notes Gemini free tier tested poorly (2026-06-15).

### Grid gradient (measured on two 24.5MP phone sheets, ~670px native cards)
| model | tiles/sheet | card @ read |
|---|---|---|
| Opus 4.8 | 6 | ~400px |
| Sonnet | 9-12 | ~460-590px |
| Haiku | 12-20 | ~620-670px |

### Empirical grounding (not guessed)
- Whole sheet -> ~220px/card: even Opus 4.8 reads only company + some names, not
  phone/email -> Opus fine-print floor ~350, the limiter is pixels not model IQ.
- Opus's 6-tile output (~400px/card) verified legible by reading fine print
  (addresses, fax, extensions) off a tile.
- Card-size estimator returns ~668-698px, matching manual measurement.

### Verification gate (run before this PR)
- `python3 -c "import ast; ast.parse(open('scripts/prep_cards.py').read())"` -> OK
- `--model opus|sonnet|haiku` dry-run grid selection on both sheets -> expected gradient
- end-to-end `--model claude-opus-4-8` write -> 6 tiles/sheet, manifest written
- `--help` shows new flags
Not run: no unit-test harness in this skill; checks above are the gate.
