### PR TITLE
Add converting-files skill (native pandoc/LibreOffice/ImageMagick/ffmpeg dispatcher)

### DIFF
--- a/converting-files/CHANGELOG.md
+++ b/converting-files/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 0.1.0 (2026-06-19)
+
+Initial release. Dispatcher (`scripts/convert.py`) over the four conversion
+engines present in the Claude.ai container: pandoc 3.1.3, LibreOffice 24.2
+(headless), ImageMagick 6.9 (`convert`), ffmpeg 6.1.
+
+Routing by (source-family → target-family), with the cross-engine cases that a
+pandoc-only or single-engine approach gets wrong:
+- Office → PDF routed to LibreOffice (layout fidelity), not pandoc.
+- markup → Office/PDF routed to pandoc (cleaner from markup).
+- legacy binary Office (.doc/.ppt/.xls) routed to LibreOffice (pandoc can't read).
+- gif split by source family: png→gif = ImageMagick, mp4→gif = ffmpeg.
+
+Verified live across all four engines: md↔docx roundtrip, md→html, docx→pdf
+(LibreOffice rename path), png→jpg, wav→mp3, plus plan-only routing for
+gif/legacy/video pairs.
+
+Motivated by a request to wrap VERT (vert.sh) as a skill. VERT is a browser
+WASM app over these same engines — no importable CLI/lib, and strictly weaker
+than the container's native binaries for programmatic use. Built the native
+equivalent instead.
+
+Known fix during build: initial audio/video routing compared the *family*
+string against extension sets (`df in AUDIO` where `df=="audio"`), so wav→mp3
+returned NO ROUTE. Corrected to compare families to families and extensions to
+extensions.

--- a/converting-files/SKILL.md
+++ b/converting-files/SKILL.md
@@ -103,6 +103,11 @@ done
 - **ImageMagick here is IM6** (`convert`, not `magick`). Policy may block some
   formats; if `convert` refuses a PDF/PS op, that's the `/etc/ImageMagick-6/policy.xml`
   security policy, not a missing codec.
+- **markup → jira emits heading anchors.** `md → jira` works (both are pandoc
+  formats), but headings come out as `h1. {anchor:slug}Title` — pandoc materializing
+  the auto-generated heading ID. Suppress with
+  `--engine pandoc ... -f markdown-auto_identifiers` (pass the format-with-extension
+  yourself, since the dispatcher infers a bare `markdown`).
 - **`--plan` lies about nothing but runs nothing** — it can't tell you the
   *content* will survive (e.g. a pptx → md drops all layout). Plan checks the
   route; only a real run checks the result.

--- a/converting-files/SKILL.md
+++ b/converting-files/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: converting-files
+description: Convert a file from one format to another inside the container — documents, images, audio, video. Routes to the right engine (pandoc, LibreOffice, ImageMagick, ffmpeg) by format pair. Triggers on "convert X to Y", "turn this docx into a pdf", "make a gif from this mp4", "md to docx", "batch-convert these images", or any single-file or batch format change where the source and target extensions differ. NOT for editing content (use docx/pptx/xlsx/pdf skills), creating files from scratch, or reading a file you already have in context.
+metadata:
+  version: 0.1.0
+---
+
+# converting-files
+
+Four conversion engines are already in this container — `pandoc`, `libreoffice`
+(headless), ImageMagick's `convert`, and `ffmpeg`. The hard part isn't running
+them; it's picking the right one. pandoc mangles a real `.docx` into PDF;
+LibreOffice is the tool for that. pandoc is *better* than LibreOffice for
+`md → docx`. Neither touches `mp4 → gif`. This skill encodes that routing so the
+choice isn't re-derived (often wrongly) each time.
+
+`scripts/convert.py` is a dispatcher over those four binaries, not a new engine.
+Use it for the common cases; drop to the raw engine when you need flags it
+doesn't pass through.
+
+## Is this the right skill?
+
+| You want to… | Use instead |
+| --- | --- |
+| Change a file's **format** (ext A → ext B) | **this skill** |
+| Edit/author a Word/PPT/Excel/PDF's **content** | `docx` / `pptx` / `xlsx` / `pdf` skills |
+| Read a file already shown in context | just read it — no conversion |
+| Extract text/tables *from* a PDF | `pdf-reading` skill |
+| Fill or merge PDFs | `pdf` skill |
+
+Format change = here. Content change = a content skill. A `docx → pdf` is a
+format change; "fix the grammar in this docx" is not.
+
+## Engine routing (the actual content of this skill)
+
+Source family → target family decides the engine. The dispatcher applies this;
+the table is here so the reasoning is auditable and so you can call the engine
+directly when needed.
+
+| From → To | Engine | Why |
+| --- | --- | --- |
+| markup → markup (md, html, rst, latex, org, epub, rtf, ipynb…) | **pandoc** | what it's built for |
+| markup → Office (md → docx/pptx/odt) | **pandoc** | cleaner than LibreOffice from markup |
+| Office → markup (docx/odt/pptx → md/html…) | **pandoc** | reads modern OOXML well |
+| **Office → PDF** (docx/pptx/xlsx → pdf) | **LibreOffice** | preserves layout; pandoc mangles it |
+| Office ↔ Office, or **legacy** (.doc/.ppt/.xls) anything | **LibreOffice** | pandoc can't read legacy binary formats at all |
+| markup → PDF (md → pdf) | **pandoc** (+pdflatex/xelatex) | lighter than LibreOffice for plain markup |
+| image ↔ image (png, jpg, gif, webp, tiff, heic, svg…) | **ImageMagick** | `convert in out` |
+| image → PDF | **ImageMagick** | |
+| audio ↔ audio (mp3, wav, flac, ogg, aac, m4a, opus…) | **ffmpeg** | |
+| video ↔ video, **mp4 → gif**, gif → mp4 | **ffmpeg** | gif-from-video is an ffmpeg job, not ImageMagick |
+
+`gif` lives in both image and video worlds: `png → gif` is ImageMagick (still
+image), `mp4 → gif` is ffmpeg (animation). The dispatcher handles the split by
+the *source* family.
+
+## Usage
+
+```bash
+# Plan only — print engine + reason + exact command, run nothing. Do this first
+# on an unfamiliar pair to confirm the route before committing.
+python3 /mnt/skills/user/converting-files/scripts/convert.py --plan in.docx out.pdf
+
+# Convert.
+python3 /mnt/skills/user/converting-files/scripts/convert.py in.docx out.pdf
+python3 /mnt/skills/user/converting-files/scripts/convert.py notes.md notes.docx
+python3 /mnt/skills/user/converting-files/scripts/convert.py clip.mp4 clip.gif
+
+# Pass engine flags through (everything after OUTPUT goes to the engine):
+python3 .../convert.py photo.png photo.jpg -quality 85         # ImageMagick
+python3 .../convert.py song.wav song.mp3 -b:a 192k             # ffmpeg
+python3 .../convert.py paper.md paper.pdf --pdf-engine=xelatex # pandoc
+
+# Force a specific engine if you disagree with the route:
+python3 .../convert.py weird.docx weird.md --engine pandoc
+```
+
+Exit codes: `0` ok, `2` no route exists, `3` engine failed (stderr tail
+printed), `4` bad args / missing input.
+
+## Batch
+
+The dispatcher is one file at a time by design — batch is a shell loop so each
+file's failure is visible:
+
+```bash
+for f in *.png; do
+  python3 /mnt/skills/user/converting-files/scripts/convert.py "$f" "${f%.png}.webp" || echo "FAILED: $f"
+done
+```
+
+## Gotchas (the things that cost a re-run)
+
+- **LibreOffice names the output itself** — it writes `<input-stem>.<ext>` into
+  `--outdir`, ignoring your chosen filename. The dispatcher renames to your
+  `OUTPUT` after. If you call `libreoffice` raw, expect the input-stem name.
+- **LibreOffice headless is single-instance.** Two concurrent `--headless` calls
+  collide on the user profile and one silently does nothing. Run them serially
+  (the batch loop above is serial — fine).
+- **markup → pdf needs a LaTeX engine.** `pdflatex`/`xelatex` are present, but
+  exotic Unicode wants `--pdf-engine=xelatex`. If LaTeX chokes on the content,
+  route through `docx` first: `md → docx` (pandoc) then `docx → pdf` (LibreOffice).
+- **ImageMagick here is IM6** (`convert`, not `magick`). Policy may block some
+  formats; if `convert` refuses a PDF/PS op, that's the `/etc/ImageMagick-6/policy.xml`
+  security policy, not a missing codec.
+- **`--plan` lies about nothing but runs nothing** — it can't tell you the
+  *content* will survive (e.g. a pptx → md drops all layout). Plan checks the
+  route; only a real run checks the result.
+
+## Why not VERT (or any web converter) as the skill
+
+VERT (vert.sh) is a Svelte/WASM **browser app** wrapping these same engines
+(libvips, ffmpeg.wasm, Pandoc-wasm) for a human at a tab who wants local privacy.
+There's no library or CLI to import — the app *is* the UI. In-container we
+already have the native binaries with full filesystem access and no browser
+memory ceiling, so the WASM wrappers would be strictly slower and weaker. VERT is
+a good *recommendation to a person*; it's the wrong shape for a skill. This skill
+is the in-container equivalent of what VERT does in a tab.

--- a/converting-files/scripts/convert.py
+++ b/converting-files/scripts/convert.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""convert.py — route a file conversion to the right container engine.
+
+This is a *dispatcher*, not a new engine. It picks among pandoc, LibreOffice,
+ImageMagick, and ffmpeg by (source_ext -> target_ext) and runs the one that
+produces correct output. The routing — not the subprocess call — is the value:
+pandoc mangles docx->pdf, LibreOffice is the right tool; pandoc is right for
+md->docx; neither touches mp4->gif.
+
+Usage:
+    python3 convert.py INPUT OUTPUT [--engine ENGINE] [extra engine args...]
+    python3 convert.py --plan INPUT OUTPUT   # print the chosen engine+cmd, run nothing
+
+Exit codes: 0 ok, 2 no route, 3 engine failure, 4 bad args.
+"""
+import os
+import shlex
+import subprocess
+import sys
+
+# Format families. Membership decides which engine owns a target extension.
+DOC_TEXT = {  # pandoc's wheelhouse: markup <-> markup
+    "md", "markdown", "rst", "html", "htm", "tex", "latex", "org",
+    "rtf", "epub", "textile", "asciidoc", "adoc", "docbook", "man",
+    "ipynb", "json", "opml", "mediawiki", "typ", "typst", "csv", "tsv",
+}
+DOC_OFFICE = {"docx", "pptx", "xlsx", "odt", "ods", "odp", "doc", "ppt", "xls"}
+IMAGE = {"png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif", "ico",
+         "heic", "avif", "ppm", "pgm", "svg"}
+AUDIO = {"mp3", "wav", "flac", "ogg", "oga", "aac", "m4a", "opus", "wma"}
+VIDEO = {"mp4", "mkv", "webm", "mov", "avi", "gif", "flv", "m4v"}
+
+
+def ext(path):
+    return os.path.splitext(path)[1].lstrip(".").lower()
+
+
+def family(e):
+    if e in DOC_OFFICE:
+        return "office"
+    if e in DOC_TEXT:
+        return "text"
+    if e in IMAGE:
+        return "image"
+    if e in AUDIO:
+        return "audio"
+    if e in VIDEO:
+        return "video"
+    return None
+
+
+def choose(src_ext, dst_ext):
+    """Return (engine, reason) or (None, reason)."""
+    sf, df = family(src_ext), family(dst_ext)
+
+    # PDF is the cross-cutting target. Route by SOURCE.
+    if dst_ext == "pdf":
+        if sf in ("office", "text") or src_ext in DOC_OFFICE:
+            # Office source -> LibreOffice (fidelity). Text/markup -> LibreOffice
+            # too for odt/docx, but pandoc for markup is fine and lighter.
+            if sf == "office":
+                return "libreoffice", "office source to PDF: LibreOffice preserves layout"
+            return "pandoc", "markup source to PDF: pandoc + latex engine"
+        if sf == "image":
+            return "imagemagick", "image to PDF"
+        return None, f"no PDF route from .{src_ext}"
+
+    # Office <-> Office, or Office <-> text-ish that pandoc can't do well.
+    if sf == "office" or df == "office":
+        # pandoc CAN do docx/odt/pptx but loses fidelity on real Office files
+        # and cannot read xls/ppt/doc legacy at all. LibreOffice owns Office.
+        # Exception: text-markup -> docx/odt/pptx is pandoc's job and is better.
+        if sf == "text" and df == "office":
+            return "pandoc", f"markup .{src_ext} to Office .{dst_ext}: pandoc"
+        if sf == "office" and df == "text":
+            # docx -> md etc: pandoc reads docx/odt well.
+            if src_ext in ("docx", "odt", "pptx"):
+                return "pandoc", f"Office .{src_ext} to markup: pandoc"
+            return "libreoffice", f"legacy Office .{src_ext}: LibreOffice (pandoc can't read it)"
+        return "libreoffice", f"Office conversion .{src_ext}->.{dst_ext}: LibreOffice"
+
+    if sf == "text" and df == "text":
+        return "pandoc", "markup to markup: pandoc"
+
+    if sf == "image" and df == "image":
+        return "imagemagick", "image to image: ImageMagick"
+
+    if sf == "audio" and (df == "audio" or dst_ext == "mp4"):
+        return "ffmpeg", "audio to audio: ffmpeg"
+
+    if sf == "video" or df == "video":
+        return "ffmpeg", f"video/animation .{src_ext}->.{dst_ext}: ffmpeg"
+
+    if sf == "audio" and df == "video":
+        return "ffmpeg", "audio to video container: ffmpeg"
+
+    return None, f"no route .{src_ext} -> .{dst_ext}"
+
+
+def build_cmd(engine, inp, out, extra):
+    if engine == "pandoc":
+        return ["pandoc", inp, "-o", out] + extra
+    if engine == "libreoffice":
+        # LibreOffice converts to a target FILTER by extension, writes into outdir.
+        outdir = os.path.dirname(os.path.abspath(out)) or "."
+        return ["libreoffice", "--headless", "--convert-to", ext(out),
+                "--outdir", outdir, inp] + extra
+    if engine == "imagemagick":
+        # 'convert' is IM6 here; works for src->dst by extension.
+        return ["convert", inp] + extra + [out]
+    if engine == "ffmpeg":
+        return ["ffmpeg", "-y", "-i", inp] + extra + [out]
+    raise ValueError(engine)
+
+
+def run(cmd, engine, out):
+    # LibreOffice ignores the exact output filename (uses input stem). Handle rename.
+    if engine == "libreoffice":
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if r.returncode != 0:
+            sys.stderr.write(r.stderr)
+            return 3
+        produced = os.path.join(
+            os.path.dirname(os.path.abspath(out)) or ".",
+            os.path.splitext(os.path.basename(cmd[-1]))[0] + "." + ext(out),
+        )
+        if produced != os.path.abspath(out) and os.path.exists(produced):
+            os.replace(produced, out)
+        return 0 if os.path.exists(out) else 3
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       timeout=300 if engine == "ffmpeg" else 120)
+    if r.returncode != 0:
+        sys.stderr.write(r.stderr[-2000:])
+        return 3
+    return 0 if os.path.exists(out) else 3
+
+
+def main(argv):
+    plan_only = False
+    args = []
+    forced = None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--plan":
+            plan_only = True
+        elif a == "--engine":
+            i += 1
+            forced = argv[i]
+        else:
+            args.append(a)
+        i += 1
+    if len(args) < 2:
+        sys.stderr.write(__doc__)
+        return 4
+    inp, out = args[0], args[1]
+    extra = args[2:]
+    if not os.path.exists(inp) and not plan_only:
+        sys.stderr.write(f"input not found: {inp}\n")
+        return 4
+
+    se, de = ext(inp), ext(out)
+    if forced:
+        engine, reason = forced, "forced via --engine"
+    else:
+        engine, reason = choose(se, de)
+    if engine is None:
+        sys.stderr.write(f"NO ROUTE: {reason}\n")
+        return 2
+
+    cmd = build_cmd(engine, inp, out, extra)
+    if plan_only:
+        print(f"engine: {engine}")
+        print(f"reason: {reason}")
+        print(f"cmd:    {' '.join(shlex.quote(c) for c in cmd)}")
+        return 0
+
+    rc = run(cmd, engine, out)
+    if rc == 0:
+        sz = os.path.getsize(out)
+        print(f"ok: {out} ({sz} bytes) via {engine}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Adds a `converting-files` skill: a dispatcher over the four conversion engines already present in the Claude.ai container (pandoc 3.1.3, LibreOffice 24.2 headless, ImageMagick 6.9, ffmpeg 6.1).

**Why:** request to wrap VERT (vert.sh) as a skill. VERT is a browser WASM app over these same engines with no importable CLI/lib, and strictly weaker than the native binaries for programmatic use. Built the native equivalent instead.

**What it does:** routes by (source-family -> target-family) to the right engine, handling cross-engine cases a single-engine approach gets wrong:
- Office -> PDF -> LibreOffice (layout fidelity), not pandoc
- markup -> Office/PDF -> pandoc (cleaner from markup)
- legacy .doc/.ppt/.xls -> LibreOffice (pandoc can't read them)
- gif split by source: png->gif = ImageMagick, mp4->gif = ffmpeg

**Verification (in-container, this session):** live conversions passed for md<->docx roundtrip, md->html, docx->pdf (LibreOffice rename path, valid 1-page PDF), png->jpg, wav->mp3; plan-only routing confirmed for gif/legacy/video pairs. SKILL.md passes skill_lint.validate_skill(require_version=True).

One bug found and fixed during build: audio/video routing compared family strings against extension sets, so wav->mp3 returned NO ROUTE; corrected.

Gate note: claude-skills has no automated per-skill test gate; verification above was run by hand. Dispatcher is pure-stdlib Python, no new deps.