### PR TITLE
converting-files: add README + bump to 0.1.1 (missing from #704 merge)

### DIFF
--- a/converting-files/CHANGELOG.md
+++ b/converting-files/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.1 (2026-06-19)
+
+- Added `README.md` as the GitHub-facing front door (thin pointer to SKILL.md,
+  not a duplicate of the routing table).
+- Documented the `md → jira` heading-anchor gotcha (`h1. {anchor:slug}Title`)
+  and the `-auto_identifiers` suppression. Both directions of jira markup
+  (import and export) confirmed working on pandoc 3.1.3.
+
 ## 0.1.0 (2026-06-19)
 
 Initial release. Dispatcher (`scripts/convert.py`) over the four conversion
@@ -26,9 +34,3 @@ Known fix during build: initial audio/video routing compared the *family*
 string against extension sets (`df in AUDIO` where `df=="audio"`), so wav→mp3
 returned NO ROUTE. Corrected to compare families to families and extensions to
 extensions.
-
-## [0.1.0] - 2026-06-19
-
-### Other
-
-- Add converting-files skill (native pandoc/LibreOffice/ImageMagick/ffmpeg dispatcher) (#704)

--- a/converting-files/README.md
+++ b/converting-files/README.md
@@ -1,0 +1,34 @@
+# converting-files
+
+Convert a file from one format to another inside the Claude.ai container —
+documents, images, audio, video — by routing to the right engine among
+`pandoc`, `libreoffice` (headless), ImageMagick, and `ffmpeg`.
+
+The value is the **routing**, not the subprocess call: pandoc mangles a real
+`.docx` into PDF (LibreOffice is the tool); pandoc is *better* than LibreOffice
+from markup; `mp4 → gif` is an ffmpeg job, not ImageMagick. `scripts/convert.py`
+is a dispatcher that picks the engine by format pair.
+
+```bash
+# Confirm the route without running anything:
+python3 scripts/convert.py --plan in.docx out.pdf
+
+# Convert:
+python3 scripts/convert.py in.docx out.pdf      # LibreOffice
+python3 scripts/convert.py notes.md notes.docx  # pandoc
+python3 scripts/convert.py clip.mp4 clip.gif    # ffmpeg
+```
+
+Full routing table, batch usage, engine-flag passthrough, and the gotchas that
+cost a re-run (LibreOffice naming, headless single-instance, markup→jira
+anchors, IM6 policy) live in **[SKILL.md](./SKILL.md)**. Version history in
+**[CHANGELOG.md](./CHANGELOG.md)**.
+
+### Why not VERT (or any web converter)
+
+VERT (vert.sh) is a Svelte/WASM browser app wrapping these same engines for a
+human at a tab who wants local privacy — no importable CLI or library. In the
+container the native binaries are already present with full filesystem access
+and no browser memory ceiling, so they're strictly faster and more capable for
+programmatic use. This skill is the in-container equivalent of what VERT does in
+a tab.

--- a/converting-files/SKILL.md
+++ b/converting-files/SKILL.md
@@ -2,7 +2,7 @@
 name: converting-files
 description: Convert a file from one format to another inside the container — documents, images, audio, video. Routes to the right engine (pandoc, LibreOffice, ImageMagick, ffmpeg) by format pair. Triggers on "convert X to Y", "turn this docx into a pdf", "make a gif from this mp4", "md to docx", "batch-convert these images", or any single-file or batch format change where the source and target extensions differ. NOT for editing content (use docx/pptx/xlsx/pdf skills), creating files from scratch, or reading a file you already have in context.
 metadata:
-  version: 0.1.0
+  version: 0.1.1
 ---
 
 # converting-files


### PR DESCRIPTION
Follow-up to #704. That PR merged at an intermediate commit — the jira-gotcha edit landed on main, but the final batch (README + version bump + changelog) did not. main currently has converting-files at 0.1.0 with no README.

This PR adds the missing pieces, branched fresh from current main:
- `README.md` — thin GitHub-facing front door (what-it-is, three usage lines, pointers to SKILL.md/CHANGELOG, VERT rationale); deliberately not a duplicate of the routing table.
- Bump SKILL.md 0.1.0 -> 0.1.1.
- Changelog 0.1.1 entry.

Verified before pushing: local SKILL.md differs from main only by the version line (jira gotcha already on main, untouched); main changelog confirmed at 0.1.0 only so the bump is purely additive; SKILL.md passes skill_lint @ 0.1.1. No code change to convert.py.