### PR TITLE
fix(exploring-codebases): step 0 installs tree-sitter core, not language-pack

### DIFF
--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   the divergent "what's here?" skill — for targeted "where is X?" queries,
   use searching-codebases instead.
 metadata:
-  version: 2.3.0
+  version: 2.3.1
 ---
 
 # Exploring Codebases
@@ -25,15 +25,16 @@ Five numbered steps, in order. Do not skip step 0.
 
 ```bash
 uv venv /home/claude/.venv 2>/dev/null
-uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
+uv pip install tree-sitter --python /home/claude/.venv/bin/python
 export PYTHON=/home/claude/.venv/bin/python
 export TREESIT=/mnt/skills/user/tree-sitting/scripts/treesit.py
 export GATHER=/mnt/skills/user/featuring/scripts/gather.py
 ```
 
 If step 2's `--stats` later reports `Scanned 0 files ... Errors: 1`, the
-language pack isn't loaded — come back here and install. Treesit fails
-silently on missing deps; it does not raise a useful error.
+`tree-sitter` core package isn't installed — come back here and install it
+(the engine bundles its own grammars and does NOT use tree-sitter-language-pack).
+Treesit fails silently on missing deps; it does not raise a useful error.
 
 ### 1. Get the repo (tarball, not per-file)
 


### PR DESCRIPTION
## Problem

`exploring-codebases` step 0 installs `tree-sitter-language-pack` into the venv but never installs `tree-sitter` core. The tree-sitting engine loads grammars from its own bundled `.so` files via ctypes and calls `from tree_sitter import Parser` / `Language` — it does NOT use the language-pack (engine.py line 15: *"We deliberately do NOT depend on tree-sitter-language-pack"*).

Result: in a fresh `uv venv`, `from tree_sitter import Parser` raises `ImportError`, `_get_parser` returns `None`, every file is skipped silently. `treesit --stats` reports `Scanned 0 files (NNN KB) ... 0 errors` — bytes are counted before the parse, so KB shows but `files=0`, no error surfaced. Found when a treesit scan of a Rust repo returned 0 symbols.

## Fix

Step-0 install line: `tree-sitter-language-pack` → `tree-sitter`. Also corrects the stale diagnostic note (it told the reader to install the language pack) and bumps the version 2.3.0 → 2.3.1.

No engine.py change: the engine was already correct, and tree-sitting's own SKILL.md Setup already installs `tree-sitter`. Only this skill's setup named the wrong dependency.

## Verification

Clean `uv venv`, core only, no language-pack:
```
$ uv pip install tree-sitter
$ python treesit.py <rust-repo> --stats
Scanned 20 files (239 KB) in 553ms
Symbols: 66 | Languages: markdown, python, rust
```