### PR TITLE
exploring-data: use absolute path for check_install.sh in Step 2

### DIFF
--- a/exploring-data/SKILL.md
+++ b/exploring-data/SKILL.md
@@ -17,7 +17,7 @@ Returns: `installed` or `not_installed`
 
 ### 2. Install if needed (one-time, ~19s)
 ```bash
-if [ "$(bash check_install.sh)" = "not_installed" ]; then
+if [ "$(bash /mnt/skills/user/exploring-data/scripts/check_install.sh)" = "not_installed" ]; then
     bash /mnt/skills/user/exploring-data/scripts/install_ydata.sh
 fi
 ```


### PR DESCRIPTION
Fixes https://github.com/oaustegard/claude-skills/issues/709.

Step 1 calls `check_install.sh` by absolute path, but Step 2 used a
relative path with no preceding `cd`, which fails whenever the working
directory is not the scripts folder. Switch Step 2 to the same absolute
path.