### PR TITLE
Add creating-kb skill (portable embedding-free KB builder)

### DIFF
--- a/creating-kb/SKILL.md
+++ b/creating-kb/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: creating-kb
+description: Builds a portable, embedding-free knowledgebase from a set of files and delivers it as a self-contained `.skill` bundle (BM25 index + bundled searcher + query protocol). Use when a user wants to turn uploaded files, a folder, or a corpus into a searchable knowledgebase they can hand to any agent — phrased as "make a knowledgebase", "build a KB skill", "package these docs for retrieval", "create a searchable bundle", or references to a `.skill` KB. The output runs anywhere with Node or Python — no model, no install, no network. Distinct from `bm25` (ephemeral in-session search) and `building-github-index` (markdown project-knowledge index).
+metadata:
+  version: 0.1.0
+---
+
+# creating-kb
+
+Turn a pile of files into a **portable, deployable knowledgebase**. The output
+is a `.skill` bundle — an ordinary zip — containing a BM25 inverted index, the
+chunk text, a pure-Node searcher, and a query protocol. It has no embedding
+model and no semantic search: retrieval is lexical, and the consuming agent
+supplies the semantic layer by expanding the query at search time. That is what
+makes the bundle portable — any agent that can run `node` can query it with no
+`npm install`, no model download, and no network.
+
+The whole toolchain is JavaScript so one implementation serves both this builder
+and the in-browser packer. Build with the bundled script; do not hand-roll the
+index.
+
+```
+SCRIPTS=/mnt/skills/user/creating-kb/scripts
+node $SCRIPTS/build_lexkb.js CORPUS_DIR --out /tmp/kb --name my-kb --zip
+```
+
+## Workflow
+
+### 1. Gather the sources
+
+Collect the files into one directory. In a Claude.ai chat, uploads land in
+`/mnt/user-data/uploads/` — point the builder there. Otherwise use any path the
+user names. Supported extensions default to `txt,md,html,htm`; pass `--ext` to
+change them.
+
+This MVP interface is bounded by how many files a chat can accept. For a large
+corpus, stage the files in a directory first, or use the browser packer (built
+from the same scripts) that runs entirely client-side.
+
+### 2. Build the bundle
+
+```bash
+SCRIPTS=/mnt/skills/user/creating-kb/scripts
+node $SCRIPTS/build_lexkb.js /mnt/user-data/uploads \
+  --out /tmp/kb --name my-kb --target-chars 1200 --zip \
+  --source "human description of the corpus"
+```
+
+The script chunks each file, builds the BM25 index, writes the bundle dir
+(`SKILL.md` + `search.js` + `index.json` + `chunks.jsonl`), and — with `--zip` —
+emits `my-kb.skill` next to `--out`.
+
+### 3. Deliver
+
+Move the `.skill` to the outputs directory and give the user a download link:
+
+```bash
+cp /tmp/my-kb.skill /mnt/user-data/outputs/
+```
+
+```markdown
+[Download my-kb.skill](computer:///mnt/user-data/outputs/my-kb.skill)
+```
+
+Tell the user how to deploy it: unzip into an agent's skill directory (or upload
+it as a skill). The bundle's own `SKILL.md` then drives querying — the consuming
+agent reads it, expands each question into search terms, and runs the bundled
+`search.js`. No further setup.
+
+## Choosing chunk size
+
+`--target-chars` controls chunk size (whole paragraphs are packed up to the
+target; `--target-chars 0` makes each file one chunk). Lexical BM25 tolerates
+larger chunks than embedding-based retrieval, because there is no vector to
+dilute — BM25 scores individual term presence with length normalization, so a
+big chunk still ranks on the exact terms it contains. Larger chunks also hand
+the consuming agent more coherent context per hit.
+
+- Short documents (≤ a few paragraphs): `--target-chars 0` (whole document).
+- Articles / mixed prose: `--target-chars 1200` (default) to `4000`.
+- Many small fragments where citation precision matters: `--target-chars 500`.
+
+## Verifying the bundle
+
+Test before delivering. Run a query against the freshly built bundle and confirm
+it returns sensible hits:
+
+```bash
+node /tmp/kb/search.js --query "a representative question" \
+  --core "key term" --expand "synonym" --k 3 --text-chars 120
+```
+
+`search.js` prints JSON `{"hits": [...]}`. Confirm the right chunks surface.
+
+## What ships in the bundle
+
+| File | Role |
+|---|---|
+| `SKILL.md` | the query protocol the consuming agent follows (expand → search → cite) |
+| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers; the agent runs whichever runtime it has |
+| `index.json` | precomputed inverted index (postings, df, doc lengths, BM25 params) |
+| `chunks.jsonl` | chunk text + structured metadata |
+
+Both searchers are thin readers of the same neutral JSON index, so the bundle
+runs in a Node-only or a Python-only consumer. Metadata stays structured (not
+folded into the indexed text), which lets the consuming agent filter on it
+(`--filter section=blog`, `--filter date>=2025`).
+
+## Scripts
+
+- `scripts/build_lexkb.js` — chunker + BM25 index builder + `.skill` writer.
+- `scripts/search.js` — the JS runtime searcher, copied verbatim into every
+  bundle. It owns the tokenizer; the builder imports it so index and queries
+  tokenize identically.
+- `scripts/search.py` — the Python runtime searcher, copied verbatim into every
+  bundle; a thin reader of the same neutral JSON index, parity-pinned to
+  `search.js` (identical results on a shared index).
+- `scripts/zipstore.js` — pure-JS ZIP-STORED writer (used by the builder; shared
+  with the in-browser packer).
+- `scripts/bundle_SKILL.md` — the query-side SKILL.md template written into each
+  bundle.

--- a/creating-kb/scripts/build_lexkb.js
+++ b/creating-kb/scripts/build_lexkb.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Build a portable, embedding-free lexical KB `.skill` bundle — pure Node, no deps.
+ *
+ * Pipeline: collect files -> structural chunk -> BM25 inverted index -> write a
+ * bundle dir (chunks.jsonl + index.json + SKILL.md + search.js) -> optionally zip
+ * to `<name>.skill` (an ordinary zip with a renamed extension).
+ *
+ * The shipped search.js owns the tokenizer; this builder imports it so the index
+ * and queries tokenize identically. The same logic runs in the browser SPA.
+ *
+ * Usage:
+ *   node build_lexkb.js CORPUS_DIR --out out/kb --name mykb \
+ *     --target-chars 1200 [--zip] [--ext txt,md,html]
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { tokenize } = require("./search.js");
+const { zipStore } = require("./zipstore.js");
+
+const TEMPLATE_DIR = __dirname;
+const BUNDLE_SKILL = "bundle_SKILL.md";
+
+// --------------------------------------------------------------------------- //
+// Text extraction + structural chunking
+// --------------------------------------------------------------------------- //
+
+function extractText(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  const ext = path.extname(file).toLowerCase();
+  let title, body;
+  if (ext === ".html" || ext === ".htm") {
+    const m = raw.match(/<title>([\s\S]*?)<\/title>/i);
+    title = m ? m[1].trim() : path.basename(file, ext);
+    body = raw.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+      .replace(/<[^>]+>/g, "\n")
+      .replace(/&[a-zA-Z#0-9]+;/g, " ");
+  } else {
+    title = path.basename(file, ext);
+    body = raw;
+    for (const line of raw.split("\n")) {
+      if (line.trim()) {
+        const t = line.trim().replace(/^#+\s*/, "").trim();
+        title = t.length > 80 ? t.slice(0, 80) + "…" : t;
+        break;
+      }
+    }
+  }
+  const lines = body.split("\n").map((ln) => ln.replace(/[ \t]+/g, " ").replace(/\s+$/, ""));
+  return { title, text: lines.join("\n") };
+}
+
+function chunkText(text, targetChars) {
+  text = text.trim();
+  if (!text) return [];
+  if (targetChars <= 0) return [text];
+  const paras = text.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const chunks = [];
+  let buf = "";
+  for (const p of paras) {
+    if (!buf) buf = p;
+    else if (buf.length + 2 + p.length <= targetChars) buf += "\n\n" + p;
+    else { chunks.push(buf); buf = p; }
+  }
+  if (buf) chunks.push(buf);
+  return chunks;
+}
+
+function walk(dir, exts) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full, exts));
+    else if (exts.has(path.extname(entry.name).toLowerCase().replace(/^\./, ""))) out.push(full);
+  }
+  return out;
+}
+
+function collectChunks(corpus, exts, targetChars, minChars) {
+  const files = walk(corpus, exts).sort();
+  const chunks = [];
+  for (const file of files) {
+    const rel = path.relative(corpus, file).split(path.sep).join("/");
+    const { title, text } = extractText(file);
+    const pieces = chunkText(text, targetChars);
+    pieces.forEach((piece, j) => {
+      if (piece.length < minChars) return;
+      chunks.push({
+        id: `${rel}#chunk-${j}`,
+        text: piece,
+        meta: { title, source_path: rel, section: rel.includes("/") ? rel.split("/")[0] : "" },
+      });
+    });
+  }
+  return chunks;
+}
+
+// --------------------------------------------------------------------------- //
+// BM25 inverted index
+// --------------------------------------------------------------------------- //
+
+function buildIndex(chunks, k1, b) {
+  const postings = new Map(); // term -> [[docIdx, tf], ...]
+  const doclen = [];
+  chunks.forEach((ch, i) => {
+    const toks = tokenize(ch.text);
+    doclen.push(toks.length);
+    const tf = new Map();
+    for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
+    for (const [term, c] of tf) {
+      if (!postings.has(term)) postings.set(term, []);
+      postings.get(term).push([i, c]);
+    }
+  });
+  const N = chunks.length;
+  const avgdl = N ? doclen.reduce((s, x) => s + x, 0) / N : 0;
+  const df = {};
+  const postingsObj = {};
+  for (const [t, pl] of postings) { df[t] = pl.length; postingsObj[t] = pl; }
+  return { params: { k1, b }, N, avgdl, doclen, df, postings: postingsObj };
+}
+
+// --------------------------------------------------------------------------- //
+// Bundle writer
+// --------------------------------------------------------------------------- //
+
+function bundleFiles(chunks, index, sourceDesc) {
+  const chunksJsonl = chunks.map((ch) => JSON.stringify(ch)).join("\n") + "\n";
+  const indexJson = JSON.stringify(index);
+  // Ship both searchers (thin readers of the same neutral JSON index). The
+  // consuming agent runs whichever runtime it has — node or python3.
+  const searchJs = fs.readFileSync(path.join(TEMPLATE_DIR, "search.js"), "utf8");
+  const searchPy = fs.readFileSync(path.join(TEMPLATE_DIR, "search.py"), "utf8");
+  let skillMd = fs.readFileSync(path.join(TEMPLATE_DIR, BUNDLE_SKILL), "utf8");
+  skillMd = skillMd.split("{{SOURCE}}").join(sourceDesc).split("{{CHUNK_COUNT}}").join(String(chunks.length));
+  return {
+    "chunks.jsonl": chunksJsonl,
+    "index.json": indexJson,
+    "search.js": searchJs,
+    "search.py": searchPy,
+    "SKILL.md": skillMd,
+  };
+}
+
+function writeBundle(outDir, files) {
+  fs.mkdirSync(outDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(outDir, name), content);
+  }
+}
+
+function zipSkill(files, skillPath) {
+  const root = path.basename(skillPath, path.extname(skillPath));
+  const entries = Object.entries(files).sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([name, content]) => ({ name: `${root}/${name}`, data: content }));
+  fs.writeFileSync(skillPath, zipStore(entries));
+}
+
+// --------------------------------------------------------------------------- //
+// CLI
+// --------------------------------------------------------------------------- //
+
+function parseArgs(argv) {
+  const a = { corpus: null, out: "out/kb", name: "lexical-kb", ext: "txt,md,html,htm",
+    targetChars: 1200, minChars: 40, k1: 1.5, b: 0.75, source: "", zip: false };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === "--zip") { a.zip = true; continue; }
+    if (!t.startsWith("--")) { a.corpus = t; continue; }
+    const val = argv[++i];
+    if (t === "--out") a.out = val;
+    else if (t === "--name") a.name = val;
+    else if (t === "--ext") a.ext = val;
+    else if (t === "--target-chars") a.targetChars = Number(val);
+    else if (t === "--min-chars") a.minChars = Number(val);
+    else if (t === "--k1") a.k1 = Number(val);
+    else if (t === "--b") a.b = Number(val);
+    else if (t === "--source") a.source = val;
+  }
+  return a;
+}
+
+function main(argv) {
+  const a = parseArgs(argv);
+  if (!a.corpus) { console.error("usage: node build_lexkb.js CORPUS_DIR [--out ...] [--zip]"); return 1; }
+  const exts = new Set(a.ext.split(",").map((e) => e.trim().replace(/^\./, "").toLowerCase()).filter(Boolean));
+  const chunks = collectChunks(a.corpus, exts, a.targetChars, a.minChars);
+  if (!chunks.length) { console.error(`no chunks produced from ${a.corpus} (exts=${[...exts]})`); return 1; }
+  const index = buildIndex(chunks, a.k1, a.b);
+  const files = bundleFiles(chunks, index, a.source || `${path.basename(a.corpus)} corpus`);
+
+  writeBundle(a.out, files);
+  const nFiles = new Set(chunks.map((c) => c.meta.source_path)).size;
+  console.log(`built ${chunks.length} chunks from ${nFiles} files (target_chars=${a.targetChars}, ` +
+    `avgdl=${index.avgdl.toFixed(0)} tokens, vocab=${Object.keys(index.df).length}) -> ${a.out}`);
+
+  if (a.zip) {
+    const skillPath = path.join(path.dirname(a.out), `${a.name}.skill`);
+    zipSkill(files, skillPath);
+    console.log(`zipped -> ${skillPath} (${(fs.statSync(skillPath).size / 1024).toFixed(1)} KB)`);
+  }
+  return 0;
+}
+
+module.exports = { extractText, chunkText, collectChunks, buildIndex, bundleFiles };
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/creating-kb/scripts/bundle_SKILL.md
+++ b/creating-kb/scripts/bundle_SKILL.md
@@ -1,0 +1,95 @@
+---
+name: lexical-kb
+description: Query a portable, embedding-free lexical knowledgebase bundled as a `.skill`. Use when the user references this KB or asks a question whose answer is in its corpus ({{SOURCE}}). Retrieval is BM25 over a precomputed inverted index — there is no embedding model, so YOU expand the query into search terms before searching. Bundle holds index.json + chunks.jsonl + search.js + search.py; pure stdlib, no install, no network.
+---
+
+# lexical-kb — query an embedding-free knowledgebase
+
+This KB has **no semantic search and no embedding model**. Retrieval is pure
+lexical BM25 over a precomputed inverted index. That design moves one job onto
+you: bridging the gap between how the user phrases a question and how the corpus
+phrases the answer. An embedding model would do this with a vector; here **you
+are the semantic layer** — you expand the query into terms before searching.
+
+Corpus: {{SOURCE}} ({{CHUNK_COUNT}} chunks).
+
+## The retrieval protocol — follow every step
+
+A raw user question fed straight to BM25 underperforms: it matches only the
+exact words the user happened to use. The expansion step is what makes lexical
+retrieval competitive with embeddings. Do not skip it.
+
+1. **Read the question. Extract `core` terms** — the essential nouns, proper
+   nouns, and identifiers the answer MUST contain. These carry full weight.
+
+2. **Generate `expand` terms** — synonyms, morphological variants (plural/verb
+   forms), acronym expansions and contractions, and adjacent concepts. These
+   carry lower weight. This is the work the missing embedding model would have
+   done. Be generous: 5–15 expansion terms is normal.
+
+3. **Run the searcher.** It ships in this bundle in two equivalent runtimes —
+   `node search.js` or `python3 search.py`, identical flags and identical
+   results. Use whichever your environment has. Pass the user's original
+   question via `--query` AND your term groups — expansion is **additive**, it
+   never replaces the user's words:
+
+   ```bash
+   node search.js \
+     --query "how does centered simhash differ from random projection?" \
+     --core "simhash" --core "centered" \
+     --expand "random projection" --expand "hyperplane" --expand "LSH" \
+     --expand "binary quantization" --expand "hamming distance" \
+     --k 5
+   ```
+
+   `--core`/`--expand` are repeatable; pass phrases, the searcher tokenizes
+   them. The `--query` terms contribute at a low floor weight so a curated
+   synonym can lift a result but can never drop a doc the literal question would
+   have matched. Defaults: core 1.0, expand 0.4, query-floor 0.25, top-k 5.
+   Keep expansion targeted — terms too generic ("system", "process") leak into
+   unrelated chunks and blur the ranking.
+
+4. **Read the returned chunks. Answer from them, and cite chunk ids inline.**
+   The chunks are the source of truth the user installed. When a chunk
+   contradicts your prior knowledge, the chunk wins — say so. When the chunks
+   do not contain the answer, say that plainly rather than filling the gap from
+   memory.
+
+## When you cannot expand — RM3 fallback
+
+If the query is outside any domain you can expand confidently, pass it raw with
+pseudo-relevance feedback. The searcher harvests expansion terms from the
+corpus's own top hits — model-free, weaker than your expansion, and prone to
+drift when the first pass is off-topic, so prefer real expansion when you can:
+
+```bash
+node search.js --query "the user's raw question" --rm3 --k 5
+```
+
+## Metadata filtering
+
+Each chunk carries structured `meta` (e.g. `title`, `source_path`, `section`).
+Filter on it with `--filter` (repeatable). Filtering narrows by attribute; it
+does not rank — combine it with term search.
+
+```bash
+node search.js --core "factions" --filter "section=blog" --filter "date>=2025" --k 5
+```
+
+Operators: `=`, `!=`, `~` (substring), `>`, `>=`, `<`, `<=` (numeric when both
+sides parse, else lexicographic — ISO dates sort correctly).
+
+## Output
+
+`search.js` prints JSON: `{"hits": [{id, score, text, meta}, ...]}`, sorted by
+descending BM25 score. Surface the top hits to the user with their ids, then
+answer using them as authoritative context.
+
+## Mechanics
+
+- Pure stdlib — Node or Python. No `npm install` / `pip install`, no model
+  download, no network.
+- The bundle is self-contained: `search.js` + `search.py` (pick one),
+  `index.json`, `chunks.jsonl`. Run the searcher from inside the bundle
+  directory (it defaults `--index` to its own location) or pass
+  `--index /path/to/bundle`.

--- a/creating-kb/scripts/search.js
+++ b/creating-kb/scripts/search.js
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Lexical KB searcher — pure-Node BM25 over a portable, embedding-free index.
+ *
+ * Ships *inside* a `.skill` bundle alongside index.json + chunks.jsonl. Zero
+ * dependencies (Node stdlib only): any agent that can run `node` can query the
+ * KB with no install, no model download, no network.
+ *
+ * The semantic layer lives in the calling agent, not here. There is no embedding
+ * model to bridge the query<->document vocabulary gap; the agent does that by
+ * expanding the query into --core (essential terms) and --expand (synonyms,
+ * morphological variants, acronym expansions, adjacent concepts). When no
+ * expansion is supplied, --rm3 runs corpus-driven pseudo-relevance feedback as a
+ * weaker, model-free fallback.
+ *
+ * The tokenizer here is the single source of truth: build_lexkb.js imports it so
+ * the index and the query tokenize identically.
+ *
+ * Usage:
+ *   node search.js --query "..." --core term --expand syn --k 5
+ *   node search.js --query "..." --rm3 --k 5
+ *   node search.js --core x --filter "section=blog" --filter "date>=2025"
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// --------------------------------------------------------------------------- //
+// Tokenizer — single source of truth (builder imports this).
+// Matches search.py: lowercase, Unicode \w+ runs.
+// --------------------------------------------------------------------------- //
+
+const TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+
+function tokenize(text) {
+  const out = [];
+  for (const m of String(text).toLowerCase().matchAll(TOKEN_RE)) out.push(m[0]);
+  return out;
+}
+
+// --------------------------------------------------------------------------- //
+// Index
+// --------------------------------------------------------------------------- //
+
+class Index {
+  constructor(dir) {
+    this.dir = dir;
+    const idx = JSON.parse(fs.readFileSync(path.join(dir, "index.json"), "utf8"));
+    this.k1 = Number(idx.params.k1);
+    this.b = Number(idx.params.b);
+    this.N = Number(idx.N);
+    this.avgdl = Number(idx.avgdl);
+    this.doclen = idx.doclen;
+    this.df = idx.df;
+    this.postings = idx.postings;
+    this._idf = new Map();
+    this._chunks = null;
+  }
+
+  get chunks() {
+    if (this._chunks === null) {
+      const raw = fs.readFileSync(path.join(this.dir, "chunks.jsonl"), "utf8");
+      this._chunks = raw.split("\n").filter((l) => l.trim()).map((l) => JSON.parse(l));
+    }
+    return this._chunks;
+  }
+
+  idf(term) {
+    let v = this._idf.get(term);
+    if (v === undefined) {
+      const df = this.df[term] || 0;
+      v = Math.log(1.0 + (this.N - df + 0.5) / (df + 0.5));
+      this._idf.set(term, v);
+    }
+    return v;
+  }
+
+  termDocScore(term, docIdx, tf) {
+    const dl = this.doclen[docIdx];
+    const denom = tf + this.k1 * (1.0 - this.b + (this.b * dl) / this.avgdl);
+    return (this.idf(term) * (tf * (this.k1 + 1.0))) / denom;
+  }
+
+  // weightedTerms: Map<term, weight> -> Map<docIdx, score>
+  score(weightedTerms) {
+    const scores = new Map();
+    for (const [term, weight] of weightedTerms) {
+      const plist = this.postings[term];
+      if (!plist) continue;
+      for (const [docIdx, tf] of plist) {
+        scores.set(docIdx, (scores.get(docIdx) || 0) + weight * this.termDocScore(term, docIdx, tf));
+      }
+    }
+    return scores;
+  }
+}
+
+// --------------------------------------------------------------------------- //
+// Query construction — expansion is strictly additive over the raw query.
+// --------------------------------------------------------------------------- //
+
+function buildQuery(core, expand, wCore, wExpand, backstop, wBackstop) {
+  const q = new Map();
+  const groups = [
+    [expand || [], wExpand],
+    [backstop || [], wBackstop],
+    [core || [], wCore],
+  ];
+  for (const [group, w] of groups) {
+    for (const phrase of group) {
+      for (const tok of tokenize(phrase)) {
+        q.set(tok, Math.max(q.get(tok) || 0, w));
+      }
+    }
+  }
+  return q;
+}
+
+// --------------------------------------------------------------------------- //
+// RM3 pseudo-relevance feedback (model-free fallback expansion)
+// --------------------------------------------------------------------------- //
+
+function rm3Expand(index, seed, { nDocs = 10, nTerms = 15, alpha = 0.5 } = {}) {
+  const first = index.score(seed);
+  if (first.size === 0) return seed;
+  const top = [...first.entries()].sort((a, b) => b[1] - a[1]).slice(0, nDocs);
+  const total = top.reduce((s, [, v]) => s + v, 0) || 1.0;
+
+  const fb = new Map();
+  for (const [docIdx, docScore] of top) {
+    const toks = tokenize(index.chunks[docIdx].text);
+    if (toks.length === 0) continue;
+    const w = docScore / total;
+    const tfLocal = new Map();
+    for (const t of toks) tfLocal.set(t, (tfLocal.get(t) || 0) + 1);
+    const invLen = 1.0 / toks.length;
+    for (const [t, c] of tfLocal) fb.set(t, (fb.get(t) || 0) + w * c * invLen);
+  }
+
+  const ranked = [...fb.entries()]
+    .filter(([t]) => !seed.has(t))
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, nTerms);
+  const fbTotal = ranked.reduce((s, [, m]) => s + m, 0) || 1.0;
+
+  const merged = new Map();
+  for (const [t, w] of seed) merged.set(t, alpha * w);
+  for (const [t, m] of ranked) merged.set(t, (merged.get(t) || 0) + (1.0 - alpha) * (m / fbTotal));
+  return merged;
+}
+
+// --------------------------------------------------------------------------- //
+// Metadata filtering
+// --------------------------------------------------------------------------- //
+
+function parseFilter(expr) {
+  for (const op of ["!=", ">=", "<=", "~", "=", ">", "<"]) {
+    const i = expr.indexOf(op);
+    if (i !== -1) return [expr.slice(0, i).trim(), op, expr.slice(i + op.length).trim()];
+  }
+  throw new Error(`unparseable filter: ${expr}`);
+}
+
+function matchFilter(meta, key, op, val) {
+  const actual = meta[key];
+  if (actual === undefined || actual === null) return false;
+  const a = String(actual);
+  if (op === "=") return a === val;
+  if (op === "!=") return a !== val;
+  if (op === "~") return a.toLowerCase().includes(val.toLowerCase());
+  const af = Number(a), vf = Number(val);
+  const numeric = a.trim() !== "" && val.trim() !== "" && !Number.isNaN(af) && !Number.isNaN(vf);
+  const x = numeric ? af : a;
+  const y = numeric ? vf : val;
+  if (op === ">") return x > y;
+  if (op === ">=") return x >= y;
+  if (op === "<") return x < y;
+  if (op === "<=") return x <= y;
+  return false;
+}
+
+function passesFilters(index, docIdx, filters) {
+  if (!filters.length) return true;
+  const meta = index.chunks[docIdx].meta || {};
+  return filters.every(([k, op, v]) => matchFilter(meta, k, op, v));
+}
+
+// --------------------------------------------------------------------------- //
+// Search
+// --------------------------------------------------------------------------- //
+
+function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } = {}) {
+  if (useRm3) query = rm3Expand(index, query, rm3);
+  const scores = index.score(query);
+  const ranked = [...scores.entries()].sort((a, b) => b[1] - a[1]);
+  const out = [];
+  for (const [docIdx, sc] of ranked) {
+    if (!passesFilters(index, docIdx, filters)) continue;
+    const chunk = index.chunks[docIdx];
+    out.push({ id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text: chunk.text, meta: chunk.meta || {} });
+    if (out.length >= k) break;
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------- //
+// CLI
+// --------------------------------------------------------------------------- //
+
+function parseArgs(argv) {
+  const a = { index: __dirname, query: "", core: [], expand: [], filter: [],
+    wCore: 1.0, wExpand: 0.4, wQuery: 0.25, k: 5, rm3: false,
+    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, textChars: 0 };
+  const multi = { "--core": "core", "--expand": "expand", "--filter": "filter" };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === "--rm3") { a.rm3 = true; continue; }
+    const val = argv[++i];
+    if (multi[t]) a[multi[t]].push(val);
+    else if (t === "--index") a.index = val;
+    else if (t === "--query") a.query = val;
+    else if (t === "--w-core") a.wCore = Number(val);
+    else if (t === "--w-expand") a.wExpand = Number(val);
+    else if (t === "--w-query") a.wQuery = Number(val);
+    else if (t === "--k") a.k = Number(val);
+    else if (t === "--rm3-docs") a.rm3Docs = Number(val);
+    else if (t === "--rm3-terms") a.rm3Terms = Number(val);
+    else if (t === "--rm3-alpha") a.rm3Alpha = Number(val);
+    else if (t === "--text-chars") a.textChars = Number(val);
+    else { i--; } // unknown flag without value; skip
+  }
+  return a;
+}
+
+function main(argv) {
+  const a = parseArgs(argv);
+  const index = new Index(a.index);
+
+  let core = [...a.core];
+  let backstop = [];
+  if (a.query) {
+    if (!core.length && !a.expand.length) core = [a.query];
+    else backstop = [a.query];
+  }
+  const query = buildQuery(core, a.expand, a.wCore, a.wExpand, backstop, a.wQuery);
+  if (query.size === 0) {
+    console.log(JSON.stringify({ error: "empty query: pass --core/--expand or --query" }));
+    return 2;
+  }
+
+  const hits = search(index, query, {
+    k: a.k,
+    filters: a.filter.map(parseFilter),
+    useRm3: a.rm3,
+    rm3: { nDocs: a.rm3Docs, nTerms: a.rm3Terms, alpha: a.rm3Alpha },
+  });
+  if (a.textChars > 0) {
+    for (const h of hits) if (h.text.length > a.textChars) h.text = h.text.slice(0, a.textChars) + "…";
+  }
+  console.log(JSON.stringify({ hits }, null, 2));
+  return 0;
+}
+
+module.exports = { tokenize, Index, buildQuery, rm3Expand, parseFilter, search };
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/creating-kb/scripts/search.py
+++ b/creating-kb/scripts/search.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Lexical KB searcher — pure stdlib BM25 over a portable, embedding-free index.
+
+This is the runtime half of a `.skill` lexical knowledgebase bundle. It ships
+*inside* the bundle alongside `index.json` and `chunks.jsonl`, so it has zero
+third-party dependencies: any agent that can run `python3` can query the KB
+with no `pip install`, no model download, no network.
+
+The semantic layer lives in the calling agent, not here. There is no embedding
+model to bridge the query<->document vocabulary gap; the agent does that by
+expanding the query into `--core` (essential terms) and `--expand` (synonyms,
+morphological variants, acronym expansions, adjacent concepts) before calling.
+When no expansion is supplied, `--rm3` runs corpus-driven pseudo-relevance
+feedback as a weaker, model-free fallback.
+
+Index format (see build_lexkb.py for the writer):
+  index.json   {params:{k1,b}, N, avgdl, doclen:[...], df:{term:df},
+                postings:{term:[[doc_idx, tf], ...]}}
+  chunks.jsonl one JSON object per line: {id, text, meta}; line number == doc_idx
+
+The tokenizer defined here is the single source of truth: build_lexkb.py imports
+it so the index and the query are tokenized identically.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Tokenizer — single source of truth (builder imports this).
+# --------------------------------------------------------------------------- #
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase, split on Unicode word boundaries. No stemming, no stopwords —
+    the agent supplies morphological variants in --expand."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+# --------------------------------------------------------------------------- #
+# Index loading
+# --------------------------------------------------------------------------- #
+
+
+class Index:
+    def __init__(self, index_dir: Path):
+        self.dir = index_dir
+        with (index_dir / "index.json").open(encoding="utf-8") as fh:
+            idx = json.load(fh)
+        self.k1 = float(idx["params"]["k1"])
+        self.b = float(idx["params"]["b"])
+        self.N = int(idx["N"])
+        self.avgdl = float(idx["avgdl"])
+        self.doclen = idx["doclen"]
+        self.df = idx["df"]
+        self.postings = idx["postings"]
+        self._idf_cache: dict[str, float] = {}
+        # chunks.jsonl loaded lazily on demand
+        self._chunks: list[dict] | None = None
+
+    @property
+    def chunks(self) -> list[dict]:
+        if self._chunks is None:
+            self._chunks = []
+            with (self.dir / "chunks.jsonl").open(encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        self._chunks.append(json.loads(line))
+        return self._chunks
+
+    def idf(self, term: str) -> float:
+        """Robust BM25 idf (always positive — Lucene/bm25+ variant)."""
+        if term not in self._idf_cache:
+            df = self.df.get(term, 0)
+            self._idf_cache[term] = math.log(1.0 + (self.N - df + 0.5) / (df + 0.5))
+        return self._idf_cache[term]
+
+    def _term_doc_score(self, term: str, doc_idx: int, tf: int) -> float:
+        dl = self.doclen[doc_idx]
+        denom = tf + self.k1 * (1.0 - self.b + self.b * dl / self.avgdl)
+        return self.idf(term) * (tf * (self.k1 + 1.0)) / denom
+
+    def score(self, weighted_terms: dict[str, float]) -> dict[int, float]:
+        """Score every candidate doc against {term: weight}. Returns {doc_idx: score}."""
+        scores: dict[int, float] = defaultdict(float)
+        for term, weight in weighted_terms.items():
+            plist = self.postings.get(term)
+            if not plist:
+                continue
+            for doc_idx, tf in plist:
+                scores[doc_idx] += weight * self._term_doc_score(term, doc_idx, tf)
+        return scores
+
+
+# --------------------------------------------------------------------------- #
+# RM3 pseudo-relevance feedback (model-free fallback expansion)
+# --------------------------------------------------------------------------- #
+
+
+def rm3_expand(
+    index: Index,
+    seed_terms: dict[str, float],
+    *,
+    n_docs: int = 10,
+    n_terms: int = 15,
+    alpha: float = 0.5,
+) -> dict[str, float]:
+    """Two-pass RM3. First pass ranks with seed_terms; harvest characteristic
+    terms from the top n_docs; interpolate back with the original query.
+
+    Returns a new weighted-term dict (original terms weighted alpha, feedback
+    terms weighted (1-alpha)*normalized). Weaker than agent expansion and prone
+    to drift when the first pass is off-topic — strictly a no-agent fallback."""
+    first = index.score(seed_terms)
+    if not first:
+        return seed_terms
+    top = sorted(first.items(), key=lambda kv: kv[1], reverse=True)[:n_docs]
+    total = sum(s for _, s in top) or 1.0
+
+    # Feedback term mass: relevance-weighted term frequency over the top docs.
+    fb: dict[str, float] = defaultdict(float)
+    for doc_idx, doc_score in top:
+        toks = tokenize(index.chunks[doc_idx]["text"])
+        if not toks:
+            continue
+        w = doc_score / total
+        tf_local: dict[str, int] = defaultdict(int)
+        for t in toks:
+            tf_local[t] += 1
+        inv_len = 1.0 / len(toks)
+        for t, c in tf_local.items():
+            fb[t] += w * c * inv_len
+
+    # Keep the most characteristic feedback terms, drop ones already in the seed.
+    ranked = sorted(
+        ((t, m) for t, m in fb.items() if t not in seed_terms),
+        key=lambda kv: kv[1],
+        reverse=True,
+    )[:n_terms]
+    fb_total = sum(m for _, m in ranked) or 1.0
+
+    merged: dict[str, float] = {t: alpha * w for t, w in seed_terms.items()}
+    for t, m in ranked:
+        merged[t] = merged.get(t, 0.0) + (1.0 - alpha) * (m / fb_total)
+    return merged
+
+
+# --------------------------------------------------------------------------- #
+# Metadata filtering
+# --------------------------------------------------------------------------- #
+
+
+def _parse_filter(expr: str) -> tuple[str, str, str]:
+    """`key=value`, `key!=value`, `key>value`, `key<value`, `key~substr`."""
+    for op in ("!=", ">=", "<=", "~", "=", ">", "<"):
+        if op in expr:
+            key, val = expr.split(op, 1)
+            return key.strip(), op, val.strip()
+    raise ValueError(f"unparseable filter: {expr!r}")
+
+
+def _match(meta: dict, key: str, op: str, val: str) -> bool:
+    actual = meta.get(key)
+    if actual is None:
+        return False
+    a = str(actual)
+    if op == "=":
+        return a == val
+    if op == "!=":
+        return a != val
+    if op == "~":
+        return val.lower() in a.lower()
+    # ordered comparisons: numeric if both parse, else lexicographic (ISO dates work)
+    try:
+        af, vf = float(a), float(val)
+        if op in (">", ">="):
+            return af > vf if op == ">" else af >= vf
+        return af < vf if op == "<" else af <= vf
+    except ValueError:
+        if op in (">", ">="):
+            return a > val if op == ">" else a >= val
+        return a < val if op == "<" else a <= val
+
+
+def apply_filters(index: Index, doc_idx: int, filters: list[tuple[str, str, str]]) -> bool:
+    if not filters:
+        return True
+    meta = index.chunks[doc_idx].get("meta", {})
+    return all(_match(meta, k, op, v) for k, op, v in filters)
+
+
+# --------------------------------------------------------------------------- #
+# Search
+# --------------------------------------------------------------------------- #
+
+
+def build_query(
+    core: list[str],
+    expand: list[str],
+    w_core: float,
+    w_expand: float,
+    backstop: list[str] | None = None,
+    w_backstop: float = 0.25,
+) -> dict[str, float]:
+    """Tokenize term groups into one weighted-term dict; a term's weight is the
+    max across the groups it appears in.
+
+    `backstop` carries the user's *original* query terms at a low floor weight so
+    expansion is strictly additive — curated synonyms can lift a result but can
+    never drop a doc the literal question would have matched. (Diagnosed on the
+    tiny corpus: substitutive expansion sent a gold doc to score 0.)"""
+    q: dict[str, float] = {}
+    groups = [(expand, w_expand), (backstop or [], w_backstop), (core, w_core)]
+    for group, w in groups:
+        for phrase in group:
+            for tok in tokenize(phrase):
+                q[tok] = max(q.get(tok, 0.0), w)
+    return q
+
+
+def search(
+    index: Index,
+    query: dict[str, float],
+    *,
+    k: int = 5,
+    filters: list[tuple[str, str, str]] | None = None,
+    use_rm3: bool = False,
+    rm3_docs: int = 10,
+    rm3_terms: int = 15,
+    rm3_alpha: float = 0.5,
+) -> list[dict]:
+    if use_rm3:
+        query = rm3_expand(
+            index, query, n_docs=rm3_docs, n_terms=rm3_terms, alpha=rm3_alpha
+        )
+    scores = index.score(query)
+    ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    out: list[dict] = []
+    for doc_idx, sc in ranked:
+        if not apply_filters(index, doc_idx, filters or []):
+            continue
+        chunk = index.chunks[doc_idx]
+        out.append(
+            {
+                "id": chunk.get("id"),
+                "score": round(sc, 6),
+                "text": chunk["text"],
+                "meta": chunk.get("meta", {}),
+            }
+        )
+        if len(out) >= k:
+            break
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--index", default=str(Path(__file__).resolve().parent),
+                    help="bundle dir holding index.json + chunks.jsonl (default: script dir)")
+    ap.add_argument("--query", default="", help="raw query text (fallback / RM3 seed)")
+    ap.add_argument("--core", action="append", default=[], help="essential term/phrase (repeatable)")
+    ap.add_argument("--expand", action="append", default=[], help="expansion term/phrase (repeatable)")
+    ap.add_argument("--w-core", type=float, default=1.0)
+    ap.add_argument("--w-expand", type=float, default=0.4)
+    ap.add_argument("--w-query", type=float, default=0.25, help="floor weight for --query terms when expanding")
+    ap.add_argument("--k", type=int, default=5)
+    ap.add_argument("--filter", action="append", default=[], help="meta filter, e.g. section=blog or date>=2025 (repeatable)")
+    ap.add_argument("--rm3", action="store_true", help="run pseudo-relevance feedback (no-agent fallback)")
+    ap.add_argument("--rm3-docs", type=int, default=10)
+    ap.add_argument("--rm3-terms", type=int, default=15)
+    ap.add_argument("--rm3-alpha", type=float, default=0.5)
+    ap.add_argument("--text-chars", type=int, default=0, help="truncate hit text to N chars in output (0 = full)")
+    args = ap.parse_args(argv)
+
+    index = Index(Path(args.index))
+
+    core = list(args.core)
+    backstop: list[str] = []
+    if args.query:
+        if not core and not args.expand:
+            core = [args.query]  # raw-only: the query IS the core
+        else:
+            backstop = [args.query]  # additive floor under core+expand
+
+    query = build_query(core, args.expand, args.w_core, args.w_expand,
+                        backstop, args.w_query)
+    if not query:
+        print(json.dumps({"error": "empty query: pass --core/--expand or --query"}))
+        return 2
+
+    hits = search(
+        index, query, k=args.k,
+        filters=[_parse_filter(f) for f in args.filter],
+        use_rm3=args.rm3, rm3_docs=args.rm3_docs,
+        rm3_terms=args.rm3_terms, rm3_alpha=args.rm3_alpha,
+    )
+    if args.text_chars > 0:
+        for h in hits:
+            if len(h["text"]) > args.text_chars:
+                h["text"] = h["text"][: args.text_chars] + "…"
+    print(json.dumps({"hits": hits}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/creating-kb/scripts/zipstore.js
+++ b/creating-kb/scripts/zipstore.js
@@ -1,0 +1,116 @@
+"use strict";
+/**
+ * Minimal ZIP writer — STORED (no compression), pure JS, no dependencies.
+ *
+ * A `.skill` is an ordinary zip; STORED keeps the writer trivial and identical
+ * across Node and the browser (no zlib / CompressionStream split), at a
+ * negligible size cost for KB-scale knowledgebases. Output is deterministic
+ * (fixed 1980-01-01 timestamps), so the same inputs produce a byte-identical
+ * archive. This is the same writer the browser SPA / remax_kb#12 reader pairs
+ * with (the reader's ZipStored is read-only).
+ *
+ * zipStore([{name, data}]) -> Uint8Array, where data is a Uint8Array/Buffer or
+ * a string (encoded UTF-8).
+ */
+
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function toBytes(data) {
+  if (typeof data === "string") return new TextEncoder().encode(data);
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+const DOS_TIME = 0;
+const DOS_DATE = 0x0021; // 1980-01-01
+
+function zipStore(files) {
+  const entries = files.map((f) => {
+    const nameBytes = new TextEncoder().encode(f.name);
+    const data = toBytes(f.data);
+    return { nameBytes, data, crc: crc32(data) };
+  });
+
+  const chunks = [];
+  let offset = 0;
+  const central = [];
+
+  for (const e of entries) {
+    const local = new ArrayBuffer(30 + e.nameBytes.length);
+    const dv = new DataView(local);
+    dv.setUint32(0, 0x04034b50, true); // local file header sig
+    dv.setUint16(4, 20, true); // version needed
+    dv.setUint16(6, 0, true); // flags
+    dv.setUint16(8, 0, true); // method = STORED
+    dv.setUint16(10, DOS_TIME, true);
+    dv.setUint16(12, DOS_DATE, true);
+    dv.setUint32(14, e.crc, true);
+    dv.setUint32(18, e.data.length, true); // compressed size
+    dv.setUint32(22, e.data.length, true); // uncompressed size
+    dv.setUint16(26, e.nameBytes.length, true);
+    dv.setUint16(28, 0, true); // extra len
+    const lh = new Uint8Array(local);
+    lh.set(e.nameBytes, 30);
+    chunks.push(lh, e.data);
+    e.offset = offset;
+    offset += lh.length + e.data.length;
+  }
+
+  for (const e of entries) {
+    const cd = new ArrayBuffer(46 + e.nameBytes.length);
+    const dv = new DataView(cd);
+    dv.setUint32(0, 0x02014b50, true); // central dir sig
+    dv.setUint16(4, 20, true); // version made by
+    dv.setUint16(6, 20, true); // version needed
+    dv.setUint16(8, 0, true);
+    dv.setUint16(10, 0, true); // STORED
+    dv.setUint16(12, DOS_TIME, true);
+    dv.setUint16(14, DOS_DATE, true);
+    dv.setUint32(16, e.crc, true);
+    dv.setUint32(20, e.data.length, true);
+    dv.setUint32(24, e.data.length, true);
+    dv.setUint16(28, e.nameBytes.length, true);
+    dv.setUint16(30, 0, true); // extra
+    dv.setUint16(32, 0, true); // comment
+    dv.setUint16(34, 0, true); // disk
+    dv.setUint16(36, 0, true); // internal attrs
+    dv.setUint32(38, 0, true); // external attrs
+    dv.setUint32(42, e.offset, true);
+    const c = new Uint8Array(cd);
+    c.set(e.nameBytes, 46);
+    central.push(c);
+  }
+
+  const centralSize = central.reduce((s, c) => s + c.length, 0);
+  const centralOffset = offset;
+
+  const eocd = new ArrayBuffer(22);
+  const dv = new DataView(eocd);
+  dv.setUint32(0, 0x06054b50, true);
+  dv.setUint16(8, entries.length, true);
+  dv.setUint16(10, entries.length, true);
+  dv.setUint32(12, centralSize, true);
+  dv.setUint32(16, centralOffset, true);
+
+  const all = [...chunks, ...central, new Uint8Array(eocd)];
+  const totalLen = all.reduce((s, c) => s + c.length, 0);
+  const result = new Uint8Array(totalLen);
+  let p = 0;
+  for (const c of all) { result.set(c, p); p += c.length; }
+  return result;
+}
+
+module.exports = { zipStore, crc32 };

--- a/creating-kb/test_parity.py
+++ b/creating-kb/test_parity.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Parity pin: the bundled search.js and search.py must return identical results.
+
+Both searchers are thin readers of the same neutral JSON index built by the
+JS packer. This test builds a small bundle with build_lexkb.js, then runs both
+searchers over several query shapes (plain, multi-expand, metadata filter, RM3)
+and asserts identical (id, score) lists. Run from the skill directory:
+
+    python3 test_parity.py
+
+Exit 0 on full parity, 1 otherwise. Requires `node` and `python3` on PATH.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE / "scripts"
+
+CORPUS = {
+    "factions.txt": "Liberty is to faction what air is to fire. The latent causes of "
+                    "faction are sown in the nature of man; controlling factions and "
+                    "their majority or minority interests is the work of government.\n",
+    "powers.txt": "The accumulation of all powers, legislative, executive, and judiciary, "
+                  "in the same hands is the very definition of tyranny. Separation of "
+                  "powers with checks and balances guards liberty.\n",
+    "property.txt": "From the protection of different and unequal faculties of acquiring "
+                    "property, the possession of different degrees and kinds of property "
+                    "and economic inequality immediately results.\n",
+}
+
+QUERIES = [
+    ["--query", "controlling factions", "--core", "factions", "--expand", "faction"],
+    ["--query", "separation of powers", "--core", "powers", "--expand", "checks", "--expand", "balances"],
+    ["--core", "property", "--expand", "wealth inequality", "--filter", "source_path~property"],
+    ["--query", "liberty and faction", "--rm3", "--rm3-docs", "3"],
+]
+
+
+def run(cmd: list[str]) -> list[tuple]:
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        raise RuntimeError(f"{cmd[:2]} failed: {out.stderr[:300]}")
+    hits = json.loads(out.stdout)["hits"]
+    return [(h["id"], h["score"]) for h in hits]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = Path(tmp) / "corpus"
+        corpus.mkdir()
+        for name, text in CORPUS.items():
+            (corpus / name).write_text(text, encoding="utf-8")
+        bundle = Path(tmp) / "kb"
+        subprocess.run(
+            ["node", str(SCRIPTS / "build_lexkb.js"), str(corpus),
+             "--ext", "txt", "--out", str(bundle), "--target-chars", "0"],
+            check=True, capture_output=True, text=True,
+        )
+
+        all_ok = True
+        for q in QUERIES:
+            js = run(["node", str(bundle / "search.js"), "--index", str(bundle), *q, "--k", "5"])
+            py = run(["python3", str(bundle / "search.py"), "--index", str(bundle), *q, "--k", "5"])
+            ok = js == py
+            all_ok &= ok
+            print(("OK   " if ok else "DIFF ") + " ".join(q))
+            if not ok:
+                print("  js:", js)
+                print("  py:", py)
+
+    print("\nPARITY:", "PASS" if all_ok else "FAIL")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/registry/categories.json
+++ b/registry/categories.json
@@ -91,6 +91,7 @@
       "skills": [
         "asking-questions",
         "cloning-project",
+        "creating-kb",
         "iterating",
         "remembering",
         "updating-knowledge"


### PR DESCRIPTION
## creating-kb — build portable, embedding-free knowledgebases

Turns a set of files into a self-contained `.skill` bundle: BM25 inverted index
+ chunk text + bundled searchers + query protocol. No embedding model, no
semantic search — retrieval is lexical, and the **consuming agent supplies the
semantic layer** by expanding the query (`--core`/`--expand`) at search time.
Any agent that can run `node` *or* `python3` queries it with no install, no
model download, no network.

### Design
- **JS packer** (one implementation serves this builder and the future
  in-browser packer; aligns with remax_kb's `js/kb-reader.js`).
- **Both searchers shipped** in every bundle (`search.js` + `search.py`) — thin
  readers of the same neutral JSON index, so the bundle runs in a node-only or
  python-only consumer. Parity is pinned by `test_parity.py` (identical results
  across plain / multi-expand / metadata-filter / RM3 queries).
- Deterministic pure-JS ZIP-STORED writer (`zipstore.js`), reused by the browser
  packer.

### Contents
`SKILL.md` (builder workflow + chunk-size guidance), `scripts/build_lexkb.js`,
`scripts/search.js`, `scripts/search.py`, `scripts/zipstore.js`,
`scripts/bundle_SKILL.md` (query-side protocol written into each bundle),
`test_parity.py`. Registered under `knowledge-and-memory`.

### Tested
Three build scenarios (txt; mixed md+html with metadata filter; empty-dir edge),
cross-runtime parity PASS, and a produced `.skill` verified to contain both
searchers and to be readable by the standard `unzip`.

Distinct from `bm25` (ephemeral in-session search) and `building-github-index`
(markdown project-knowledge index): this produces a *portable, deployable*
artifact.

_Supersedes #711 (renamed packing-lexical-kb → creating-kb)._
