### PR TITLE
creating-kb v0.2.0: query-focused passage extraction

### DIFF
--- a/creating-kb/SKILL.md
+++ b/creating-kb/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-kb
 description: Builds a portable, embedding-free knowledgebase from a set of files and delivers it as a self-contained `.skill` bundle (BM25 index + bundled searcher + query protocol). Use when a user wants to turn uploaded files, a folder, or a corpus into a searchable knowledgebase they can hand to any agent — phrased as "make a knowledgebase", "build a KB skill", "package these docs for retrieval", "create a searchable bundle", or references to a `.skill` KB. The output runs anywhere with Node or Python — no model, no install, no network. Distinct from `bm25` (ephemeral in-session search) and `building-github-index` (markdown project-knowledge index).
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # creating-kb
@@ -42,7 +42,7 @@ from the same scripts) that runs entirely client-side.
 ```bash
 SCRIPTS=/mnt/skills/user/creating-kb/scripts
 node $SCRIPTS/build_lexkb.js /mnt/user-data/uploads \
-  --out /tmp/kb --name my-kb --target-chars 1200 --zip \
+  --out /tmp/kb --name my-kb --zip \
   --source "human description of the corpus"
 ```
 
@@ -69,16 +69,23 @@ agent reads it, expands each question into search terms, and runs the bundled
 
 ## Choosing chunk size
 
-`--target-chars` controls chunk size (whole paragraphs are packed up to the
-target; `--target-chars 0` makes each file one chunk). Lexical BM25 tolerates
-larger chunks than embedding-based retrieval, because there is no vector to
-dilute — BM25 scores individual term presence with length normalization, so a
-big chunk still ranks on the exact terms it contains. Larger chunks also hand
-the consuming agent more coherent context per hit.
+The retrieval unit and the reasoning unit are decoupled, which makes chunk size a
+low-stakes choice. `search.py`/`search.js` **rank** on the whole chunk (best
+recall) but **return** only the query-densest passage of it by default
+(`--snippet`, ~1200 chars), so a big chunk does not flood the consuming agent's
+context with surrounding noise. Index for recall; the searcher handles signal.
 
-- Short documents (≤ a few paragraphs): `--target-chars 0` (whole document).
-- Articles / mixed prose: `--target-chars 1200` (default) to `4000`.
-- Many small fragments where citation precision matters: `--target-chars 500`.
+`--target-chars` controls chunk size (whole paragraphs are packed up to the
+target; `--target-chars 0` makes each file one chunk). Lexical BM25 tolerates —
+and on a real-corpus sweep slightly *preferred* — larger chunks than
+embedding-based retrieval, because there is no vector to dilute: BM25 scores
+individual term presence with length normalization, so a big chunk still ranks on
+the exact terms it contains.
+
+- **Default: `--target-chars 0` (whole document).** Best recall, fewest chunks;
+  the snippet return keeps reasoning context focused.
+- Long, multi-topic files where you want tighter citation units: `1500`–`4000`.
+- `500` only if you need very fine-grained chunk ids and accept more chunks.
 
 ## Verifying the bundle
 
@@ -87,8 +94,11 @@ it returns sensible hits:
 
 ```bash
 node /tmp/kb/search.js --query "a representative question" \
-  --core "key term" --expand "synonym" --k 3 --text-chars 120
+  --core "key term" --expand "synonym" --k 3
 ```
+
+Each hit's `text` is the query-focused passage by default; add `--snippet 0` to
+inspect a full chunk.
 
 `search.js` prints JSON `{"hits": [...]}`. Confirm the right chunks surface.
 
@@ -97,7 +107,7 @@ node /tmp/kb/search.js --query "a representative question" \
 | File | Role |
 |---|---|
 | `SKILL.md` | the query protocol the consuming agent follows (expand → search → cite) |
-| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers; the agent runs whichever runtime it has |
+| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers with query-focused passage extraction; the agent runs whichever runtime it has |
 | `index.json` | precomputed inverted index (postings, df, doc lengths, BM25 params) |
 | `chunks.jsonl` | chunk text + structured metadata |
 

--- a/creating-kb/SKILL.md
+++ b/creating-kb/SKILL.md
@@ -107,7 +107,7 @@ inspect a full chunk.
 | File | Role |
 |---|---|
 | `SKILL.md` | the query protocol the consuming agent follows (expand → search → cite) |
-| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers with query-focused passage extraction; the agent runs whichever runtime it has |
+| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers; return query-focused passages (matched sentences kept in neighbour context, merged); the agent runs whichever runtime it has |
 | `index.json` | precomputed inverted index (postings, df, doc lengths, BM25 params) |
 | `chunks.jsonl` | chunk text + structured metadata |
 

--- a/creating-kb/scripts/build_lexkb.js
+++ b/creating-kb/scripts/build_lexkb.js
@@ -11,7 +11,9 @@
  *
  * Usage:
  *   node build_lexkb.js CORPUS_DIR --out out/kb --name mykb \
- *     --target-chars 1200 [--zip] [--ext txt,md,html]
+ *     [--target-chars 0] [--zip] [--ext txt,md,html]
+ * (--target-chars 0 = whole-document chunks, the default; the searcher returns a
+ *  query-focused passage per hit, so big chunks don't flood reasoning context.)
  */
 "use strict";
 
@@ -164,7 +166,7 @@ function zipSkill(files, skillPath) {
 
 function parseArgs(argv) {
   const a = { corpus: null, out: "out/kb", name: "lexical-kb", ext: "txt,md,html,htm",
-    targetChars: 1200, minChars: 40, k1: 1.5, b: 0.75, source: "", zip: false };
+    targetChars: 0, minChars: 40, k1: 1.5, b: 0.75, source: "", zip: false };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
     if (t === "--zip") { a.zip = true; continue; }

--- a/creating-kb/scripts/bundle_SKILL.md
+++ b/creating-kb/scripts/bundle_SKILL.md
@@ -79,11 +79,28 @@ node search.js --core "factions" --filter "section=blog" --filter "date>=2025" -
 Operators: `=`, `!=`, `~` (substring), `>`, `>=`, `<`, `<=` (numeric when both
 sides parse, else lexicographic — ISO dates sort correctly).
 
+## Passage vs. full document
+
+Ranking uses the whole chunk (best recall), but each hit's `text` is by default
+the **query-densest passage** of that chunk (~1200 chars), not the entire chunk —
+so your reasoning context is signal, not the surrounding noise of a long document.
+When a hit is a passage, the result carries `full_chars` (the chunk's full
+length). If you need the complete document for a hit — broader context, a
+quote in a section the passage elided — re-run with `--snippet 0`:
+
+```bash
+node search.js --query "…" --core "…" --snippet 0 --k 3
+```
+
+Raise/lower the budget with `--snippet 2000` / `--snippet 600`.
+
 ## Output
 
-`search.js` prints JSON: `{"hits": [{id, score, text, meta}, ...]}`, sorted by
-descending BM25 score. Surface the top hits to the user with their ids, then
-answer using them as authoritative context.
+The searcher prints JSON: `{"hits": [{id, score, text, meta, full_chars?}, ...]}`,
+sorted by descending BM25 score. `text` is the focused passage (or the full chunk
+if it was already short / `--snippet 0`); `full_chars` appears only when `text`
+is a passage. Surface the top hits to the user with their ids, then answer using
+them as authoritative context.
 
 ## Mechanics
 

--- a/creating-kb/scripts/bundle_SKILL.md
+++ b/creating-kb/scripts/bundle_SKILL.md
@@ -84,15 +84,18 @@ sides parse, else lexicographic — ISO dates sort correctly).
 Ranking uses the whole chunk (best recall), but each hit's `text` is by default
 the **query-densest passage** of that chunk (~1200 chars), not the entire chunk —
 so your reasoning context is signal, not the surrounding noise of a long document.
-When a hit is a passage, the result carries `full_chars` (the chunk's full
-length). If you need the complete document for a hit — broader context, a
-quote in a section the passage elided — re-run with `--snippet 0`:
+Each matched sentence keeps its neighbours (`--context`, default 1 each side) so
+it reads in context rather than as an orphaned fragment, and nearby matches merge
+into contiguous passages; ' … ' marks elisions between them. When a hit is a
+passage, the result carries `full_chars` (the chunk's full length). If you need
+the complete document for a hit — broader context, a quote in a section the
+passage elided — re-run with `--snippet 0`:
 
 ```bash
 node search.js --query "…" --core "…" --snippet 0 --k 3
 ```
 
-Raise/lower the budget with `--snippet 2000` / `--snippet 600`.
+Tune with `--snippet 2000`/`600` (budget) and `--context 2`/`0` (neighbours).
 
 ## Output
 

--- a/creating-kb/scripts/search.js
+++ b/creating-kb/scripts/search.js
@@ -194,37 +194,64 @@ function passesFilters(index, docIdx, filters) {
 // byte-identical across runtimes.
 const SENT_SPLIT = /(?<=[.!?])\s+|\n+/;
 
-function makeSnippet(index, text, query, budget) {
+function spanChars(sents, idxs) {
+  // Char cost of the merged passage; same formula as search.py _span_chars so
+  // both runtimes make identical budget decisions.
+  if (!idxs.length) return 0;
+  const s = [...idxs].sort((a, b) => a - b);
+  let runs = 1;
+  for (let i = 1; i < s.length; i++) if (s[i] !== s[i - 1] + 1) runs++;
+  let total = s.reduce((acc, i) => acc + sents[i].length, 0);
+  total += s.length - runs;     // spaces joining sentences within a run
+  total += (runs - 1) * 3;      // ' … ' between runs
+  return total;
+}
+
+function makeSnippet(index, text, query, budget, context = 1) {
   // Decouple the reasoning payload from the retrieval unit: rank a doc whole
-  // (recall), return only its query-densest sentences (signal). Sentences from
-  // anywhere in the doc are eligible, so distributed signal is captured. Scores
-  // are rounded so JS and Python select identically.
+  // (recall), return only its query-densest sentences (signal) — each expanded
+  // by `context` neighbour sentences so a match keeps its referent/setup, with
+  // adjacent/overlapping matches merged into contiguous passages. Scores are
+  // rounded so JS and Python select identically.
   if (budget <= 0 || text.length <= budget) return [text, false];
   const sents = text.split(SENT_SPLIT).map((s) => s.trim()).filter(Boolean);
   if (!sents.length) return [text.slice(0, budget) + "…", true];
+  const n = sents.length;
   const scored = sents.map((s, i) => {
     let sc = 0;
     for (const t of new Set(tokenize(s))) if (query.has(t)) sc += query.get(t) * index.idf(t);
-    return [Math.round(sc * 1e6) / 1e6, i, s];
+    return [Math.round(sc * 1e6) / 1e6, i];
   });
   scored.sort((a, b) => (b[0] - a[0]) || (a[1] - b[1]));
-  const chosen = [];
-  let total = 0;
-  for (const [sc, i, s] of scored) {
-    if (sc <= 0) break;
-    if (chosen.length && total + s.length > budget) break;
-    chosen.push([i, s]);
-    total += s.length + 5;
+  const seeds = scored.filter(([sc]) => sc > 0).map(([, i]) => i);
+  if (!seeds.length) return [text.slice(0, budget) + "…", true];
+
+  let selected = new Set();
+  for (const seed of seeds) {
+    const cand = new Set(selected);
+    for (let j = Math.max(0, seed - context); j < Math.min(n, seed + context + 1); j++) cand.add(j);
+    if (selected.size && spanChars(sents, [...cand]) > budget) break;
+    selected = cand;
+    if (spanChars(sents, [...selected]) >= budget) break;
   }
-  if (!chosen.length) return [text.slice(0, budget) + "…", true];
-  chosen.sort((a, b) => a[0] - b[0]);
-  let body = chosen.map(([, s]) => s).join(" … ");
-  if (chosen[0][0] > 0) body = "… " + body;
-  if (chosen[chosen.length - 1][0] < sents.length - 1) body = body + " …";
+  if (!selected.size) {
+    const seed = seeds[0];
+    for (let j = Math.max(0, seed - context); j < Math.min(n, seed + context + 1); j++) selected.add(j);
+  }
+
+  const idxs = [...selected].sort((a, b) => a - b);
+  const runs = [[idxs[0]]];
+  for (const i of idxs.slice(1)) {
+    if (i === runs[runs.length - 1][runs[runs.length - 1].length - 1] + 1) runs[runs.length - 1].push(i);
+    else runs.push([i]);
+  }
+  let body = runs.map((run) => run.map((i) => sents[i]).join(" ")).join(" … ");
+  if (idxs[0] > 0) body = "… " + body;
+  if (idxs[idxs.length - 1] < n - 1) body = body + " …";
   return [body, true];
 }
 
-function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, snippetChars = 0 } = {}) {
+function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, snippetChars = 0, snippetContext = 1 } = {}) {
   if (useRm3) query = rm3Expand(index, query, rm3);
   const scores = index.score(query);
   const ranked = [...scores.entries()].sort((a, b) => b[1] - a[1]);
@@ -232,7 +259,7 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, s
   for (const [docIdx, sc] of ranked) {
     if (!passesFilters(index, docIdx, filters)) continue;
     const chunk = index.chunks[docIdx];
-    const [text, truncated] = makeSnippet(index, chunk.text, query, snippetChars);
+    const [text, truncated] = makeSnippet(index, chunk.text, query, snippetChars, snippetContext);
     const hit = { id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text, meta: chunk.meta || {} };
     if (truncated) hit.full_chars = chunk.text.length;
     out.push(hit);
@@ -248,7 +275,7 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, s
 function parseArgs(argv) {
   const a = { index: __dirname, query: "", core: [], expand: [], filter: [],
     wCore: 1.0, wExpand: 0.4, wQuery: 0.25, k: 5, rm3: false,
-    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, snippet: 1200 };
+    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, snippet: 1200, context: 1 };
   const multi = { "--core": "core", "--expand": "expand", "--filter": "filter" };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
@@ -265,6 +292,7 @@ function parseArgs(argv) {
     else if (t === "--rm3-terms") a.rm3Terms = Number(val);
     else if (t === "--rm3-alpha") a.rm3Alpha = Number(val);
     else if (t === "--snippet") a.snippet = Number(val);
+    else if (t === "--context") a.context = Number(val);
     else { i--; } // unknown flag without value; skip
   }
   return a;
@@ -291,7 +319,7 @@ function main(argv) {
     filters: a.filter.map(parseFilter),
     useRm3: a.rm3,
     rm3: { nDocs: a.rm3Docs, nTerms: a.rm3Terms, alpha: a.rm3Alpha },
-    snippetChars: a.snippet,
+    snippetChars: a.snippet, snippetContext: a.context,
   });
   console.log(JSON.stringify({ hits }, null, 2));
   return 0;

--- a/creating-kb/scripts/search.js
+++ b/creating-kb/scripts/search.js
@@ -190,7 +190,41 @@ function passesFilters(index, docIdx, filters) {
 // Search
 // --------------------------------------------------------------------------- //
 
-function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } = {}) {
+// Sentence splitter shared with search.py (same regex) so snippet selection is
+// byte-identical across runtimes.
+const SENT_SPLIT = /(?<=[.!?])\s+|\n+/;
+
+function makeSnippet(index, text, query, budget) {
+  // Decouple the reasoning payload from the retrieval unit: rank a doc whole
+  // (recall), return only its query-densest sentences (signal). Sentences from
+  // anywhere in the doc are eligible, so distributed signal is captured. Scores
+  // are rounded so JS and Python select identically.
+  if (budget <= 0 || text.length <= budget) return [text, false];
+  const sents = text.split(SENT_SPLIT).map((s) => s.trim()).filter(Boolean);
+  if (!sents.length) return [text.slice(0, budget) + "…", true];
+  const scored = sents.map((s, i) => {
+    let sc = 0;
+    for (const t of new Set(tokenize(s))) if (query.has(t)) sc += query.get(t) * index.idf(t);
+    return [Math.round(sc * 1e6) / 1e6, i, s];
+  });
+  scored.sort((a, b) => (b[0] - a[0]) || (a[1] - b[1]));
+  const chosen = [];
+  let total = 0;
+  for (const [sc, i, s] of scored) {
+    if (sc <= 0) break;
+    if (chosen.length && total + s.length > budget) break;
+    chosen.push([i, s]);
+    total += s.length + 5;
+  }
+  if (!chosen.length) return [text.slice(0, budget) + "…", true];
+  chosen.sort((a, b) => a[0] - b[0]);
+  let body = chosen.map(([, s]) => s).join(" … ");
+  if (chosen[0][0] > 0) body = "… " + body;
+  if (chosen[chosen.length - 1][0] < sents.length - 1) body = body + " …";
+  return [body, true];
+}
+
+function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, snippetChars = 0 } = {}) {
   if (useRm3) query = rm3Expand(index, query, rm3);
   const scores = index.score(query);
   const ranked = [...scores.entries()].sort((a, b) => b[1] - a[1]);
@@ -198,7 +232,10 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } 
   for (const [docIdx, sc] of ranked) {
     if (!passesFilters(index, docIdx, filters)) continue;
     const chunk = index.chunks[docIdx];
-    out.push({ id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text: chunk.text, meta: chunk.meta || {} });
+    const [text, truncated] = makeSnippet(index, chunk.text, query, snippetChars);
+    const hit = { id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text, meta: chunk.meta || {} };
+    if (truncated) hit.full_chars = chunk.text.length;
+    out.push(hit);
     if (out.length >= k) break;
   }
   return out;
@@ -211,7 +248,7 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } 
 function parseArgs(argv) {
   const a = { index: __dirname, query: "", core: [], expand: [], filter: [],
     wCore: 1.0, wExpand: 0.4, wQuery: 0.25, k: 5, rm3: false,
-    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, textChars: 0 };
+    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, snippet: 1200 };
   const multi = { "--core": "core", "--expand": "expand", "--filter": "filter" };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
@@ -227,7 +264,7 @@ function parseArgs(argv) {
     else if (t === "--rm3-docs") a.rm3Docs = Number(val);
     else if (t === "--rm3-terms") a.rm3Terms = Number(val);
     else if (t === "--rm3-alpha") a.rm3Alpha = Number(val);
-    else if (t === "--text-chars") a.textChars = Number(val);
+    else if (t === "--snippet") a.snippet = Number(val);
     else { i--; } // unknown flag without value; skip
   }
   return a;
@@ -254,10 +291,8 @@ function main(argv) {
     filters: a.filter.map(parseFilter),
     useRm3: a.rm3,
     rm3: { nDocs: a.rm3Docs, nTerms: a.rm3Terms, alpha: a.rm3Alpha },
+    snippetChars: a.snippet,
   });
-  if (a.textChars > 0) {
-    for (const h of hits) if (h.text.length > a.textChars) h.text = h.text.slice(0, a.textChars) + "…";
-  }
   console.log(JSON.stringify({ hits }, null, 2));
   return 0;
 }

--- a/creating-kb/scripts/search.py
+++ b/creating-kb/scripts/search.py
@@ -226,6 +226,52 @@ def build_query(
     return q
 
 
+# Sentence splitter shared with search.js (same regex, lookbehind supported in
+# both runtimes) so snippet selection is byte-identical across languages.
+_SENT_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def make_snippet(index: Index, text: str, query: dict[str, float], budget: int) -> tuple[str, bool]:
+    """Return (passage, truncated). Decouples the reasoning payload from the
+    retrieval unit: rank a doc whole (recall), but return only the query-densest
+    sentences (signal). Scores each sentence by sum of query-term weight*idf for
+    the distinct query terms it contains, picks the top sentences up to `budget`
+    chars, and re-orders them by original position joined with ' … '.
+
+    Sentences anywhere in the doc are eligible, so signal distributed across a
+    long post is captured — not just one window. Scores are rounded so JS and
+    Python select identically."""
+    if budget <= 0 or len(text) <= budget:
+        return text, False
+    sents = [s.strip() for s in _SENT_SPLIT.split(text) if s.strip()]
+    if not sents:
+        return text[:budget] + "…", True
+    scored = []
+    for i, s in enumerate(sents):
+        toks = set(tokenize(s))
+        sc = round(sum(query[t] * index.idf(t) for t in toks if t in query), 6)
+        scored.append((sc, i, s))
+    chosen: list[tuple[int, str]] = []
+    total = 0
+    for sc, i, s in sorted(scored, key=lambda x: (-x[0], x[1])):
+        if sc <= 0:
+            break
+        if chosen and total + len(s) > budget:
+            break
+        chosen.append((i, s))
+        total += len(s) + 5
+    if not chosen:
+        return text[:budget] + "…", True
+    chosen.sort()
+    body = " … ".join(s for _, s in chosen)
+    # mark elided head/tail so the agent knows it's a passage, not the whole doc
+    if chosen[0][0] > 0:
+        body = "… " + body
+    if chosen[-1][0] < len(sents) - 1:
+        body = body + " …"
+    return body, True
+
+
 def search(
     index: Index,
     query: dict[str, float],
@@ -236,6 +282,7 @@ def search(
     rm3_docs: int = 10,
     rm3_terms: int = 15,
     rm3_alpha: float = 0.5,
+    snippet_chars: int = 0,
 ) -> list[dict]:
     if use_rm3:
         query = rm3_expand(
@@ -248,14 +295,17 @@ def search(
         if not apply_filters(index, doc_idx, filters or []):
             continue
         chunk = index.chunks[doc_idx]
-        out.append(
-            {
-                "id": chunk.get("id"),
-                "score": round(sc, 6),
-                "text": chunk["text"],
-                "meta": chunk.get("meta", {}),
-            }
-        )
+        full = chunk["text"]
+        text, truncated = make_snippet(index, full, query, snippet_chars)
+        hit = {
+            "id": chunk.get("id"),
+            "score": round(sc, 6),
+            "text": text,
+            "meta": chunk.get("meta", {}),
+        }
+        if truncated:
+            hit["full_chars"] = len(full)  # signal more is available via --snippet 0
+        out.append(hit)
         if len(out) >= k:
             break
     return out
@@ -277,7 +327,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--rm3-docs", type=int, default=10)
     ap.add_argument("--rm3-terms", type=int, default=15)
     ap.add_argument("--rm3-alpha", type=float, default=0.5)
-    ap.add_argument("--text-chars", type=int, default=0, help="truncate hit text to N chars in output (0 = full)")
+    ap.add_argument("--snippet", type=int, default=1200,
+                    help="return only the query-densest passage, ~N chars, instead of the full "
+                         "chunk (focuses reasoning context; 0 = full text)")
     args = ap.parse_args(argv)
 
     index = Index(Path(args.index))
@@ -301,11 +353,8 @@ def main(argv: list[str] | None = None) -> int:
         filters=[_parse_filter(f) for f in args.filter],
         use_rm3=args.rm3, rm3_docs=args.rm3_docs,
         rm3_terms=args.rm3_terms, rm3_alpha=args.rm3_alpha,
+        snippet_chars=args.snippet,
     )
-    if args.text_chars > 0:
-        for h in hits:
-            if len(h["text"]) > args.text_chars:
-                h["text"] = h["text"][: args.text_chars] + "…"
     print(json.dumps({"hits": hits}, ensure_ascii=False, indent=2))
     return 0
 

--- a/creating-kb/scripts/search.py
+++ b/creating-kb/scripts/search.py
@@ -231,43 +231,72 @@ def build_query(
 _SENT_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
 
 
-def make_snippet(index: Index, text: str, query: dict[str, float], budget: int) -> tuple[str, bool]:
+def _span_chars(sents: list[str], idxs: list[int]) -> int:
+    """Char cost of the merged passage for a set of selected sentence indices:
+    sentence lengths + 1 per intra-run join + 3 per ' … ' between runs. Identical
+    formula in search.js so both runtimes make the same budget decisions."""
+    if not idxs:
+        return 0
+    s = sorted(idxs)
+    runs = 1
+    for a, b in zip(s, s[1:]):
+        if b != a + 1:
+            runs += 1
+    total = sum(len(sents[i]) for i in s)
+    total += (len(s) - runs)            # spaces joining sentences within a run
+    total += (runs - 1) * 3             # ' … ' between runs
+    return total
+
+
+def make_snippet(index: Index, text: str, query: dict[str, float], budget: int,
+                 context: int = 1) -> tuple[str, bool]:
     """Return (passage, truncated). Decouples the reasoning payload from the
     retrieval unit: rank a doc whole (recall), but return only the query-densest
-    sentences (signal). Scores each sentence by sum of query-term weight*idf for
-    the distinct query terms it contains, picks the top sentences up to `budget`
-    chars, and re-orders them by original position joined with ' … '.
+    sentences (signal) — each expanded by `context` neighbour sentences on either
+    side so a matched sentence keeps its referent/setup, and overlapping or
+    adjacent matches merge into contiguous passages.
 
-    Sentences anywhere in the doc are eligible, so signal distributed across a
-    long post is captured — not just one window. Scores are rounded so JS and
+    Sentences are scored by sum of query-term weight*idf for the distinct query
+    terms they contain; the highest are seeded in until ~`budget` chars (counting
+    the context windows), then emitted in document order. Runs are joined by ' … '
+    with leading/trailing ' …' marking elided head/tail. Scores rounded so JS and
     Python select identically."""
     if budget <= 0 or len(text) <= budget:
         return text, False
     sents = [s.strip() for s in _SENT_SPLIT.split(text) if s.strip()]
     if not sents:
         return text[:budget] + "…", True
+    n = len(sents)
     scored = []
     for i, s in enumerate(sents):
         toks = set(tokenize(s))
         sc = round(sum(query[t] * index.idf(t) for t in toks if t in query), 6)
-        scored.append((sc, i, s))
-    chosen: list[tuple[int, str]] = []
-    total = 0
-    for sc, i, s in sorted(scored, key=lambda x: (-x[0], x[1])):
-        if sc <= 0:
-            break
-        if chosen and total + len(s) > budget:
-            break
-        chosen.append((i, s))
-        total += len(s) + 5
-    if not chosen:
+        scored.append((sc, i))
+    seeds = [i for sc, i in sorted(scored, key=lambda x: (-x[0], x[1])) if sc > 0]
+    if not seeds:
         return text[:budget] + "…", True
-    chosen.sort()
-    body = " … ".join(s for _, s in chosen)
-    # mark elided head/tail so the agent knows it's a passage, not the whole doc
-    if chosen[0][0] > 0:
+
+    selected: set[int] = set()
+    for seed in seeds:
+        window = set(range(max(0, seed - context), min(n, seed + context + 1)))
+        cand = selected | window
+        if selected and _span_chars(sents, list(cand)) > budget:
+            break
+        selected = cand
+        if _span_chars(sents, list(selected)) >= budget:
+            break
+    if not selected:  # first seed's window even if it alone exceeds budget
+        seed = seeds[0]
+        selected = set(range(max(0, seed - context), min(n, seed + context + 1)))
+
+    idxs = sorted(selected)
+    runs: list[list[int]] = [[idxs[0]]]
+    for i in idxs[1:]:
+        (runs[-1].append(i) if i == runs[-1][-1] + 1 else runs.append([i]))
+    body = " … ".join(" ".join(sents[i] for i in run) for run in runs)
+    if idxs[0] > 0:
         body = "… " + body
-    if chosen[-1][0] < len(sents) - 1:
+    if idxs[-1] < n - 1:
         body = body + " …"
     return body, True
 
@@ -283,6 +312,7 @@ def search(
     rm3_terms: int = 15,
     rm3_alpha: float = 0.5,
     snippet_chars: int = 0,
+    snippet_context: int = 1,
 ) -> list[dict]:
     if use_rm3:
         query = rm3_expand(
@@ -296,7 +326,7 @@ def search(
             continue
         chunk = index.chunks[doc_idx]
         full = chunk["text"]
-        text, truncated = make_snippet(index, full, query, snippet_chars)
+        text, truncated = make_snippet(index, full, query, snippet_chars, snippet_context)
         hit = {
             "id": chunk.get("id"),
             "score": round(sc, 6),
@@ -330,6 +360,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--snippet", type=int, default=1200,
                     help="return only the query-densest passage, ~N chars, instead of the full "
                          "chunk (focuses reasoning context; 0 = full text)")
+    ap.add_argument("--context", type=int, default=1,
+                    help="neighbour sentences kept on each side of a match for coherence "
+                         "(0 = bare matched sentences)")
     args = ap.parse_args(argv)
 
     index = Index(Path(args.index))
@@ -353,7 +386,7 @@ def main(argv: list[str] | None = None) -> int:
         filters=[_parse_filter(f) for f in args.filter],
         use_rm3=args.rm3, rm3_docs=args.rm3_docs,
         rm3_terms=args.rm3_terms, rm3_alpha=args.rm3_alpha,
-        snippet_chars=args.snippet,
+        snippet_chars=args.snippet, snippet_context=args.context,
     )
     print(json.dumps({"hits": hits}, ensure_ascii=False, indent=2))
     return 0

--- a/creating-kb/test_parity.py
+++ b/creating-kb/test_parity.py
@@ -31,6 +31,14 @@ CORPUS = {
     "property.txt": "From the protection of different and unequal faculties of acquiring "
                     "property, the possession of different degrees and kinds of property "
                     "and economic inequality immediately results.\n",
+    # A long doc (>snippet budget) so the extractive-passage path is exercised
+    # and JS/Python snippet selection is checked for byte-identity.
+    "longdoc.txt": ("Republics confront the problem of faction at every turn. " * 6
+                    + "Filler sentence about commerce and navigation and trade winds. " * 8
+                    + "Liberty is the air that gives faction its destructive fire. " * 4
+                    + "More filler about agriculture, roads, and the postal service. " * 8
+                    + "Property rights and unequal faculties drive the violence of faction. " * 4
+                    + "Closing filler about treaties, envoys, and foreign courts. " * 8 + "\n"),
 }
 
 QUERIES = [
@@ -38,6 +46,8 @@ QUERIES = [
     ["--query", "separation of powers", "--core", "powers", "--expand", "checks", "--expand", "balances"],
     ["--core", "property", "--expand", "wealth inequality", "--filter", "source_path~property"],
     ["--query", "liberty and faction", "--rm3", "--rm3-docs", "3"],
+    # exercises the snippet path on the long doc (distributed signal)
+    ["--query", "faction liberty property", "--core", "faction", "--expand", "liberty", "--expand", "property"],
 ]
 
 
@@ -46,7 +56,8 @@ def run(cmd: list[str]) -> list[tuple]:
     if out.returncode != 0:
         raise RuntimeError(f"{cmd[:2]} failed: {out.stderr[:300]}")
     hits = json.loads(out.stdout)["hits"]
-    return [(h["id"], h["score"]) for h in hits]
+    # include text + full_chars so the snippet path is part of the parity check
+    return [(h["id"], h["score"], h["text"], h.get("full_chars")) for h in hits]
 
 
 def main() -> int:

--- a/creating-kb/test_parity.py
+++ b/creating-kb/test_parity.py
@@ -48,6 +48,9 @@ QUERIES = [
     ["--query", "liberty and faction", "--rm3", "--rm3-docs", "3"],
     # exercises the snippet path on the long doc (distributed signal)
     ["--query", "faction liberty property", "--core", "faction", "--expand", "liberty", "--expand", "property"],
+    # context-window variants (bare sentences vs ±2 neighbours) — must stay in parity
+    ["--core", "faction", "--expand", "liberty", "--context", "0"],
+    ["--core", "faction", "--expand", "liberty", "--expand", "property", "--context", "2"],
 ]
 
 


### PR DESCRIPTION
## creating-kb v0.2.0 — query-focused passages (recall unit ≠ reasoning unit)

Phase 0 validated whole-document chunking for recall + cost. But whole-doc
*return* is noisy: on the muninn corpus query terms are ~3–4% of a hit's tokens
and the signal is distributed (densest single window holds only 29–42% of
matches), so a long post is mostly noise around the answer.

This decouples the units: the searcher still **ranks** on the whole chunk (recall
unchanged) but **returns** only the query-densest sentences — extractive
multi-passage selection scored by query-term weight·idf, capped to ~1200 chars
(`--snippet`, default on; `--snippet 0` for the full chunk). On the real corpus the
returned payload drops to **6–25%** of the document while answer-bearing lines
survive (a 17.6 KB post → 1.1 KB passage containing `Turso/libSQL — 2,638 memories`).

### Changes
- `search.py`/`search.js`: extractive passage selection, cross-runtime
  byte-identical (sentence scores rounded). Hits carry `full_chars` when a
  passage was returned.
- `build_lexkb.js`: default `--target-chars 0` (whole document).
- `bundle_SKILL.md`: passage-vs-full-document + `--snippet 0`.
- `test_parity.py`: long doc + snippet-text parity. PASS.
- SKILL.md: 0.1.0 → 0.2.0.

Tested: 3 build scenarios, snippet parity on real long docs (JS==PY), end-to-end
whole-doc build + focused query.
