### PR TITLE
creating-kb v0.3.0: browser SPA packer (client-side .skill)

### DIFF
--- a/creating-kb/SKILL.md
+++ b/creating-kb/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-kb
 description: Builds a portable, embedding-free knowledgebase from a set of files and delivers it as a self-contained `.skill` bundle (BM25 index + bundled searcher + query protocol). Use when a user wants to turn uploaded files, a folder, or a corpus into a searchable knowledgebase they can hand to any agent — phrased as "make a knowledgebase", "build a KB skill", "package these docs for retrieval", "create a searchable bundle", or references to a `.skill` KB. The output runs anywhere with Node or Python — no model, no install, no network. Distinct from `bm25` (ephemeral in-session search) and `building-github-index` (markdown project-knowledge index).
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # creating-kb
@@ -129,3 +129,21 @@ folded into the indexed text), which lets the consuming agent filter on it
   with the in-browser packer).
 - `scripts/bundle_SKILL.md` — the query-side SKILL.md template written into each
   bundle.
+- `scripts/lexkb-web.mjs` — browser build core for the SPA: an ES-module port of
+  the build pipeline (chunk → index → zip), byte-identical to `build_lexkb.js`
+  and pinned by `test_web_parity.mjs`.
+
+## Browser packer (no Claude needed)
+
+`spa/index.html` is a static, fully client-side version of the builder: drop
+files (or a folder) → it chunks, builds the BM25 index, and downloads a
+`.skill` — no upload, no model, no network, no server. It imports
+`scripts/lexkb-web.mjs` and fetches the canonical `scripts/search.js`,
+`scripts/search.py`, and `scripts/bundle_SKILL.md` to place in the bundle, so the
+shipped runtime is never duplicated. Deploy by serving the `creating-kb/` directory
+(e.g. GitHub Pages); open `spa/index.html`. A `.skill` built in the browser is
+byte-identical to one built by `build_lexkb.js`.
+
+Point a user here when they want to build a KB themselves without a Claude
+session. `spa/e2e-test.mjs` drives the page in headless Chromium (optional;
+needs `playwright-core`).

--- a/creating-kb/SKILL.md
+++ b/creating-kb/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-kb
 description: Builds a portable, embedding-free knowledgebase from a set of files and delivers it as a self-contained `.skill` bundle (BM25 index + bundled searcher + query protocol). Use when a user wants to turn uploaded files, a folder, or a corpus into a searchable knowledgebase they can hand to any agent — phrased as "make a knowledgebase", "build a KB skill", "package these docs for retrieval", "create a searchable bundle", or references to a `.skill` KB. The output runs anywhere with Node or Python — no model, no install, no network. Distinct from `bm25` (ephemeral in-session search) and `building-github-index` (markdown project-knowledge index).
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # creating-kb
@@ -42,7 +42,7 @@ from the same scripts) that runs entirely client-side.
 ```bash
 SCRIPTS=/mnt/skills/user/creating-kb/scripts
 node $SCRIPTS/build_lexkb.js /mnt/user-data/uploads \
-  --out /tmp/kb --name my-kb --target-chars 1200 --zip \
+  --out /tmp/kb --name my-kb --zip \
   --source "human description of the corpus"
 ```
 
@@ -69,16 +69,23 @@ agent reads it, expands each question into search terms, and runs the bundled
 
 ## Choosing chunk size
 
-`--target-chars` controls chunk size (whole paragraphs are packed up to the
-target; `--target-chars 0` makes each file one chunk). Lexical BM25 tolerates
-larger chunks than embedding-based retrieval, because there is no vector to
-dilute — BM25 scores individual term presence with length normalization, so a
-big chunk still ranks on the exact terms it contains. Larger chunks also hand
-the consuming agent more coherent context per hit.
+The retrieval unit and the reasoning unit are decoupled, which makes chunk size a
+low-stakes choice. `search.py`/`search.js` **rank** on the whole chunk (best
+recall) but **return** only the query-densest passage of it by default
+(`--snippet`, ~1200 chars), so a big chunk does not flood the consuming agent's
+context with surrounding noise. Index for recall; the searcher handles signal.
 
-- Short documents (≤ a few paragraphs): `--target-chars 0` (whole document).
-- Articles / mixed prose: `--target-chars 1200` (default) to `4000`.
-- Many small fragments where citation precision matters: `--target-chars 500`.
+`--target-chars` controls chunk size (whole paragraphs are packed up to the
+target; `--target-chars 0` makes each file one chunk). Lexical BM25 tolerates —
+and on a real-corpus sweep slightly *preferred* — larger chunks than
+embedding-based retrieval, because there is no vector to dilute: BM25 scores
+individual term presence with length normalization, so a big chunk still ranks on
+the exact terms it contains.
+
+- **Default: `--target-chars 0` (whole document).** Best recall, fewest chunks;
+  the snippet return keeps reasoning context focused.
+- Long, multi-topic files where you want tighter citation units: `1500`–`4000`.
+- `500` only if you need very fine-grained chunk ids and accept more chunks.
 
 ## Verifying the bundle
 
@@ -87,8 +94,11 @@ it returns sensible hits:
 
 ```bash
 node /tmp/kb/search.js --query "a representative question" \
-  --core "key term" --expand "synonym" --k 3 --text-chars 120
+  --core "key term" --expand "synonym" --k 3
 ```
+
+Each hit's `text` is the query-focused passage by default; add `--snippet 0` to
+inspect a full chunk.
 
 `search.js` prints JSON `{"hits": [...]}`. Confirm the right chunks surface.
 
@@ -97,7 +107,7 @@ node /tmp/kb/search.js --query "a representative question" \
 | File | Role |
 |---|---|
 | `SKILL.md` | the query protocol the consuming agent follows (expand → search → cite) |
-| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers; the agent runs whichever runtime it has |
+| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers with query-focused passage extraction; the agent runs whichever runtime it has |
 | `index.json` | precomputed inverted index (postings, df, doc lengths, BM25 params) |
 | `chunks.jsonl` | chunk text + structured metadata |
 

--- a/creating-kb/SKILL.md
+++ b/creating-kb/SKILL.md
@@ -107,7 +107,7 @@ inspect a full chunk.
 | File | Role |
 |---|---|
 | `SKILL.md` | the query protocol the consuming agent follows (expand → search → cite) |
-| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers with query-focused passage extraction; the agent runs whichever runtime it has |
+| `search.js` / `search.py` | equivalent BM25 + RM3 + metadata-filter searchers; return query-focused passages (matched sentences kept in neighbour context, merged); the agent runs whichever runtime it has |
 | `index.json` | precomputed inverted index (postings, df, doc lengths, BM25 params) |
 | `chunks.jsonl` | chunk text + structured metadata |
 

--- a/creating-kb/scripts/build_lexkb.js
+++ b/creating-kb/scripts/build_lexkb.js
@@ -11,7 +11,9 @@
  *
  * Usage:
  *   node build_lexkb.js CORPUS_DIR --out out/kb --name mykb \
- *     --target-chars 1200 [--zip] [--ext txt,md,html]
+ *     [--target-chars 0] [--zip] [--ext txt,md,html]
+ * (--target-chars 0 = whole-document chunks, the default; the searcher returns a
+ *  query-focused passage per hit, so big chunks don't flood reasoning context.)
  */
 "use strict";
 
@@ -164,7 +166,7 @@ function zipSkill(files, skillPath) {
 
 function parseArgs(argv) {
   const a = { corpus: null, out: "out/kb", name: "lexical-kb", ext: "txt,md,html,htm",
-    targetChars: 1200, minChars: 40, k1: 1.5, b: 0.75, source: "", zip: false };
+    targetChars: 0, minChars: 40, k1: 1.5, b: 0.75, source: "", zip: false };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
     if (t === "--zip") { a.zip = true; continue; }

--- a/creating-kb/scripts/bundle_SKILL.md
+++ b/creating-kb/scripts/bundle_SKILL.md
@@ -79,11 +79,28 @@ node search.js --core "factions" --filter "section=blog" --filter "date>=2025" -
 Operators: `=`, `!=`, `~` (substring), `>`, `>=`, `<`, `<=` (numeric when both
 sides parse, else lexicographic — ISO dates sort correctly).
 
+## Passage vs. full document
+
+Ranking uses the whole chunk (best recall), but each hit's `text` is by default
+the **query-densest passage** of that chunk (~1200 chars), not the entire chunk —
+so your reasoning context is signal, not the surrounding noise of a long document.
+When a hit is a passage, the result carries `full_chars` (the chunk's full
+length). If you need the complete document for a hit — broader context, a
+quote in a section the passage elided — re-run with `--snippet 0`:
+
+```bash
+node search.js --query "…" --core "…" --snippet 0 --k 3
+```
+
+Raise/lower the budget with `--snippet 2000` / `--snippet 600`.
+
 ## Output
 
-`search.js` prints JSON: `{"hits": [{id, score, text, meta}, ...]}`, sorted by
-descending BM25 score. Surface the top hits to the user with their ids, then
-answer using them as authoritative context.
+The searcher prints JSON: `{"hits": [{id, score, text, meta, full_chars?}, ...]}`,
+sorted by descending BM25 score. `text` is the focused passage (or the full chunk
+if it was already short / `--snippet 0`); `full_chars` appears only when `text`
+is a passage. Surface the top hits to the user with their ids, then answer using
+them as authoritative context.
 
 ## Mechanics
 

--- a/creating-kb/scripts/bundle_SKILL.md
+++ b/creating-kb/scripts/bundle_SKILL.md
@@ -84,15 +84,18 @@ sides parse, else lexicographic — ISO dates sort correctly).
 Ranking uses the whole chunk (best recall), but each hit's `text` is by default
 the **query-densest passage** of that chunk (~1200 chars), not the entire chunk —
 so your reasoning context is signal, not the surrounding noise of a long document.
-When a hit is a passage, the result carries `full_chars` (the chunk's full
-length). If you need the complete document for a hit — broader context, a
-quote in a section the passage elided — re-run with `--snippet 0`:
+Each matched sentence keeps its neighbours (`--context`, default 1 each side) so
+it reads in context rather than as an orphaned fragment, and nearby matches merge
+into contiguous passages; ' … ' marks elisions between them. When a hit is a
+passage, the result carries `full_chars` (the chunk's full length). If you need
+the complete document for a hit — broader context, a quote in a section the
+passage elided — re-run with `--snippet 0`:
 
 ```bash
 node search.js --query "…" --core "…" --snippet 0 --k 3
 ```
 
-Raise/lower the budget with `--snippet 2000` / `--snippet 600`.
+Tune with `--snippet 2000`/`600` (budget) and `--context 2`/`0` (neighbours).
 
 ## Output
 

--- a/creating-kb/scripts/lexkb-web.mjs
+++ b/creating-kb/scripts/lexkb-web.mjs
@@ -1,0 +1,231 @@
+/**
+ * lexkb-web.mjs — browser build core for the creating-kb packer SPA.
+ *
+ * A faithful ES-module port of the pure build logic in `build_lexkb.js` +
+ * `zipstore.js` (chunk -> BM25 index -> STORED zip), with no Node/`fs`
+ * dependency so it runs in the browser. The Node CLI stays canonical; this is
+ * the second implementation, pinned byte-identical by `test_web_parity.mjs`
+ * (same pattern as the search.js/search.py parity pin). The tokenizer is copied
+ * verbatim from search.js so the index matches what the shipped searchers read.
+ *
+ * The SPA fetches the canonical search.js / search.py / bundle_SKILL.md at
+ * runtime and passes them to bundleFiles(), so the shipped runtime is never
+ * duplicated here.
+ */
+
+const TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+
+export function tokenize(text) {
+  const out = [];
+  for (const m of String(text).toLowerCase().matchAll(TOKEN_RE)) out.push(m[0]);
+  return out;
+}
+
+// --- text extraction + structural chunking (string in, no fs) --------------- //
+
+export function extractText(name, raw) {
+  const dot = name.lastIndexOf(".");
+  const ext = dot >= 0 ? name.slice(dot).toLowerCase() : "";
+  const stem = dot >= 0 ? name.slice(0, dot) : name;
+  let title, body;
+  if (ext === ".html" || ext === ".htm") {
+    const m = raw.match(/<title>([\s\S]*?)<\/title>/i);
+    title = m ? m[1].trim() : stem;
+    body = raw.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+      .replace(/<[^>]+>/g, "\n")
+      .replace(/&[a-zA-Z#0-9]+;/g, " ");
+  } else {
+    title = stem;
+    body = raw;
+    for (const line of raw.split("\n")) {
+      if (line.trim()) {
+        const t = line.trim().replace(/^#+\s*/, "").trim();
+        title = t.length > 80 ? t.slice(0, 80) + "…" : t;
+        break;
+      }
+    }
+  }
+  const lines = body.split("\n").map((ln) => ln.replace(/[ \t]+/g, " ").replace(/\s+$/, ""));
+  return { title, text: lines.join("\n") };
+}
+
+export function chunkText(text, targetChars) {
+  text = text.trim();
+  if (!text) return [];
+  if (targetChars <= 0) return [text];
+  const paras = text.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const chunks = [];
+  let buf = "";
+  for (const p of paras) {
+    if (!buf) buf = p;
+    else if (buf.length + 2 + p.length <= targetChars) buf += "\n\n" + p;
+    else { chunks.push(buf); buf = p; }
+  }
+  if (buf) chunks.push(buf);
+  return chunks;
+}
+
+/** files: [{name, text}] (relative name with forward slashes). */
+export function collectChunks(files, exts, targetChars, minChars) {
+  const sorted = [...files].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const chunks = [];
+  for (const f of sorted) {
+    const dot = f.name.lastIndexOf(".");
+    const ext = dot >= 0 ? f.name.slice(dot + 1).toLowerCase() : "";
+    if (!exts.has(ext)) continue;
+    const rel = f.name;
+    const { title, text } = extractText(f.name, f.text);
+    chunkText(text, targetChars).forEach((piece, j) => {
+      if (piece.length < minChars) return;
+      chunks.push({
+        id: `${rel}#chunk-${j}`,
+        text: piece,
+        meta: { title, source_path: rel, section: rel.includes("/") ? rel.split("/")[0] : "" },
+      });
+    });
+  }
+  return chunks;
+}
+
+// --- BM25 inverted index ---------------------------------------------------- //
+
+export function buildIndex(chunks, k1, b) {
+  const postings = new Map();
+  const doclen = [];
+  chunks.forEach((ch, i) => {
+    const toks = tokenize(ch.text);
+    doclen.push(toks.length);
+    const tf = new Map();
+    for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
+    for (const [term, c] of tf) {
+      if (!postings.has(term)) postings.set(term, []);
+      postings.get(term).push([i, c]);
+    }
+  });
+  const N = chunks.length;
+  const avgdl = N ? doclen.reduce((s, x) => s + x, 0) / N : 0;
+  const df = {};
+  const postingsObj = {};
+  for (const [t, pl] of postings) { df[t] = pl.length; postingsObj[t] = pl; }
+  return { params: { k1, b }, N, avgdl, doclen, df, postings: postingsObj };
+}
+
+// --- bundle assembly -------------------------------------------------------- //
+
+/** runtime = {searchJs, searchPy, bundleSkillMd} fetched by the caller. */
+export function bundleFiles(chunks, index, sourceDesc, runtime) {
+  const chunksJsonl = chunks.map((ch) => JSON.stringify(ch)).join("\n") + "\n";
+  const skillMd = runtime.bundleSkillMd
+    .split("{{SOURCE}}").join(sourceDesc)
+    .split("{{CHUNK_COUNT}}").join(String(chunks.length));
+  return {
+    "chunks.jsonl": chunksJsonl,
+    "index.json": JSON.stringify(index),
+    "search.js": runtime.searchJs,
+    "search.py": runtime.searchPy,
+    "SKILL.md": skillMd,
+  };
+}
+
+// --- STORED zip writer (ported verbatim from zipstore.js) ------------------- //
+
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function toBytes(data) {
+  if (typeof data === "string") return new TextEncoder().encode(data);
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+const DOS_TIME = 0;
+const DOS_DATE = 0x0021; // 1980-01-01
+
+export function zipStore(files) {
+  const entries = files.map((f) => {
+    const nameBytes = new TextEncoder().encode(f.name);
+    const data = toBytes(f.data);
+    return { nameBytes, data, crc: crc32(data) };
+  });
+  const chunks = [];
+  let offset = 0;
+  const central = [];
+  for (const e of entries) {
+    const local = new ArrayBuffer(30 + e.nameBytes.length);
+    const dv = new DataView(local);
+    dv.setUint32(0, 0x04034b50, true);
+    dv.setUint16(4, 20, true);
+    dv.setUint16(6, 0, true);
+    dv.setUint16(8, 0, true);
+    dv.setUint16(10, DOS_TIME, true);
+    dv.setUint16(12, DOS_DATE, true);
+    dv.setUint32(14, e.crc, true);
+    dv.setUint32(18, e.data.length, true);
+    dv.setUint32(22, e.data.length, true);
+    dv.setUint16(26, e.nameBytes.length, true);
+    dv.setUint16(28, 0, true);
+    const lh = new Uint8Array(local);
+    lh.set(e.nameBytes, 30);
+    chunks.push(lh, e.data);
+    e.offset = offset;
+    offset += lh.length + e.data.length;
+  }
+  for (const e of entries) {
+    const cd = new ArrayBuffer(46 + e.nameBytes.length);
+    const dv = new DataView(cd);
+    dv.setUint32(0, 0x02014b50, true);
+    dv.setUint16(4, 20, true);
+    dv.setUint16(6, 20, true);
+    dv.setUint16(8, 0, true);
+    dv.setUint16(10, 0, true);
+    dv.setUint16(12, DOS_TIME, true);
+    dv.setUint16(14, DOS_DATE, true);
+    dv.setUint32(16, e.crc, true);
+    dv.setUint32(20, e.data.length, true);
+    dv.setUint32(24, e.data.length, true);
+    dv.setUint16(28, e.nameBytes.length, true);
+    dv.setUint16(30, 0, true);
+    dv.setUint16(32, 0, true);
+    dv.setUint16(34, 0, true);
+    dv.setUint16(36, 0, true);
+    dv.setUint32(38, 0, true);
+    dv.setUint32(42, e.offset, true);
+    const c = new Uint8Array(cd);
+    c.set(e.nameBytes, 46);
+    central.push(c);
+  }
+  const centralSize = central.reduce((s, c) => s + c.length, 0);
+  const centralOffset = offset;
+  const eocd = new ArrayBuffer(22);
+  const dv = new DataView(eocd);
+  dv.setUint32(0, 0x06054b50, true);
+  dv.setUint16(8, entries.length, true);
+  dv.setUint16(10, entries.length, true);
+  dv.setUint32(12, centralSize, true);
+  dv.setUint32(16, centralOffset, true);
+  const all = [...chunks, ...central, new Uint8Array(eocd)];
+  const totalLen = all.reduce((s, c) => s + c.length, 0);
+  const result = new Uint8Array(totalLen);
+  let p = 0;
+  for (const c of all) { result.set(c, p); p += c.length; }
+  return result;
+}
+
+/** Assemble a .skill zip; entries placed under a top-level <root>/ folder. */
+export function zipSkill(files, root) {
+  const entries = Object.entries(files).sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([name, content]) => ({ name: `${root}/${name}`, data: content }));
+  return zipStore(entries);
+}

--- a/creating-kb/scripts/search.js
+++ b/creating-kb/scripts/search.js
@@ -194,37 +194,64 @@ function passesFilters(index, docIdx, filters) {
 // byte-identical across runtimes.
 const SENT_SPLIT = /(?<=[.!?])\s+|\n+/;
 
-function makeSnippet(index, text, query, budget) {
+function spanChars(sents, idxs) {
+  // Char cost of the merged passage; same formula as search.py _span_chars so
+  // both runtimes make identical budget decisions.
+  if (!idxs.length) return 0;
+  const s = [...idxs].sort((a, b) => a - b);
+  let runs = 1;
+  for (let i = 1; i < s.length; i++) if (s[i] !== s[i - 1] + 1) runs++;
+  let total = s.reduce((acc, i) => acc + sents[i].length, 0);
+  total += s.length - runs;     // spaces joining sentences within a run
+  total += (runs - 1) * 3;      // ' … ' between runs
+  return total;
+}
+
+function makeSnippet(index, text, query, budget, context = 1) {
   // Decouple the reasoning payload from the retrieval unit: rank a doc whole
-  // (recall), return only its query-densest sentences (signal). Sentences from
-  // anywhere in the doc are eligible, so distributed signal is captured. Scores
-  // are rounded so JS and Python select identically.
+  // (recall), return only its query-densest sentences (signal) — each expanded
+  // by `context` neighbour sentences so a match keeps its referent/setup, with
+  // adjacent/overlapping matches merged into contiguous passages. Scores are
+  // rounded so JS and Python select identically.
   if (budget <= 0 || text.length <= budget) return [text, false];
   const sents = text.split(SENT_SPLIT).map((s) => s.trim()).filter(Boolean);
   if (!sents.length) return [text.slice(0, budget) + "…", true];
+  const n = sents.length;
   const scored = sents.map((s, i) => {
     let sc = 0;
     for (const t of new Set(tokenize(s))) if (query.has(t)) sc += query.get(t) * index.idf(t);
-    return [Math.round(sc * 1e6) / 1e6, i, s];
+    return [Math.round(sc * 1e6) / 1e6, i];
   });
   scored.sort((a, b) => (b[0] - a[0]) || (a[1] - b[1]));
-  const chosen = [];
-  let total = 0;
-  for (const [sc, i, s] of scored) {
-    if (sc <= 0) break;
-    if (chosen.length && total + s.length > budget) break;
-    chosen.push([i, s]);
-    total += s.length + 5;
+  const seeds = scored.filter(([sc]) => sc > 0).map(([, i]) => i);
+  if (!seeds.length) return [text.slice(0, budget) + "…", true];
+
+  let selected = new Set();
+  for (const seed of seeds) {
+    const cand = new Set(selected);
+    for (let j = Math.max(0, seed - context); j < Math.min(n, seed + context + 1); j++) cand.add(j);
+    if (selected.size && spanChars(sents, [...cand]) > budget) break;
+    selected = cand;
+    if (spanChars(sents, [...selected]) >= budget) break;
   }
-  if (!chosen.length) return [text.slice(0, budget) + "…", true];
-  chosen.sort((a, b) => a[0] - b[0]);
-  let body = chosen.map(([, s]) => s).join(" … ");
-  if (chosen[0][0] > 0) body = "… " + body;
-  if (chosen[chosen.length - 1][0] < sents.length - 1) body = body + " …";
+  if (!selected.size) {
+    const seed = seeds[0];
+    for (let j = Math.max(0, seed - context); j < Math.min(n, seed + context + 1); j++) selected.add(j);
+  }
+
+  const idxs = [...selected].sort((a, b) => a - b);
+  const runs = [[idxs[0]]];
+  for (const i of idxs.slice(1)) {
+    if (i === runs[runs.length - 1][runs[runs.length - 1].length - 1] + 1) runs[runs.length - 1].push(i);
+    else runs.push([i]);
+  }
+  let body = runs.map((run) => run.map((i) => sents[i]).join(" ")).join(" … ");
+  if (idxs[0] > 0) body = "… " + body;
+  if (idxs[idxs.length - 1] < n - 1) body = body + " …";
   return [body, true];
 }
 
-function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, snippetChars = 0 } = {}) {
+function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, snippetChars = 0, snippetContext = 1 } = {}) {
   if (useRm3) query = rm3Expand(index, query, rm3);
   const scores = index.score(query);
   const ranked = [...scores.entries()].sort((a, b) => b[1] - a[1]);
@@ -232,7 +259,7 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, s
   for (const [docIdx, sc] of ranked) {
     if (!passesFilters(index, docIdx, filters)) continue;
     const chunk = index.chunks[docIdx];
-    const [text, truncated] = makeSnippet(index, chunk.text, query, snippetChars);
+    const [text, truncated] = makeSnippet(index, chunk.text, query, snippetChars, snippetContext);
     const hit = { id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text, meta: chunk.meta || {} };
     if (truncated) hit.full_chars = chunk.text.length;
     out.push(hit);
@@ -248,7 +275,7 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, s
 function parseArgs(argv) {
   const a = { index: __dirname, query: "", core: [], expand: [], filter: [],
     wCore: 1.0, wExpand: 0.4, wQuery: 0.25, k: 5, rm3: false,
-    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, snippet: 1200 };
+    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, snippet: 1200, context: 1 };
   const multi = { "--core": "core", "--expand": "expand", "--filter": "filter" };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
@@ -265,6 +292,7 @@ function parseArgs(argv) {
     else if (t === "--rm3-terms") a.rm3Terms = Number(val);
     else if (t === "--rm3-alpha") a.rm3Alpha = Number(val);
     else if (t === "--snippet") a.snippet = Number(val);
+    else if (t === "--context") a.context = Number(val);
     else { i--; } // unknown flag without value; skip
   }
   return a;
@@ -291,7 +319,7 @@ function main(argv) {
     filters: a.filter.map(parseFilter),
     useRm3: a.rm3,
     rm3: { nDocs: a.rm3Docs, nTerms: a.rm3Terms, alpha: a.rm3Alpha },
-    snippetChars: a.snippet,
+    snippetChars: a.snippet, snippetContext: a.context,
   });
   console.log(JSON.stringify({ hits }, null, 2));
   return 0;

--- a/creating-kb/scripts/search.js
+++ b/creating-kb/scripts/search.js
@@ -190,7 +190,41 @@ function passesFilters(index, docIdx, filters) {
 // Search
 // --------------------------------------------------------------------------- //
 
-function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } = {}) {
+// Sentence splitter shared with search.py (same regex) so snippet selection is
+// byte-identical across runtimes.
+const SENT_SPLIT = /(?<=[.!?])\s+|\n+/;
+
+function makeSnippet(index, text, query, budget) {
+  // Decouple the reasoning payload from the retrieval unit: rank a doc whole
+  // (recall), return only its query-densest sentences (signal). Sentences from
+  // anywhere in the doc are eligible, so distributed signal is captured. Scores
+  // are rounded so JS and Python select identically.
+  if (budget <= 0 || text.length <= budget) return [text, false];
+  const sents = text.split(SENT_SPLIT).map((s) => s.trim()).filter(Boolean);
+  if (!sents.length) return [text.slice(0, budget) + "…", true];
+  const scored = sents.map((s, i) => {
+    let sc = 0;
+    for (const t of new Set(tokenize(s))) if (query.has(t)) sc += query.get(t) * index.idf(t);
+    return [Math.round(sc * 1e6) / 1e6, i, s];
+  });
+  scored.sort((a, b) => (b[0] - a[0]) || (a[1] - b[1]));
+  const chosen = [];
+  let total = 0;
+  for (const [sc, i, s] of scored) {
+    if (sc <= 0) break;
+    if (chosen.length && total + s.length > budget) break;
+    chosen.push([i, s]);
+    total += s.length + 5;
+  }
+  if (!chosen.length) return [text.slice(0, budget) + "…", true];
+  chosen.sort((a, b) => a[0] - b[0]);
+  let body = chosen.map(([, s]) => s).join(" … ");
+  if (chosen[0][0] > 0) body = "… " + body;
+  if (chosen[chosen.length - 1][0] < sents.length - 1) body = body + " …";
+  return [body, true];
+}
+
+function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {}, snippetChars = 0 } = {}) {
   if (useRm3) query = rm3Expand(index, query, rm3);
   const scores = index.score(query);
   const ranked = [...scores.entries()].sort((a, b) => b[1] - a[1]);
@@ -198,7 +232,10 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } 
   for (const [docIdx, sc] of ranked) {
     if (!passesFilters(index, docIdx, filters)) continue;
     const chunk = index.chunks[docIdx];
-    out.push({ id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text: chunk.text, meta: chunk.meta || {} });
+    const [text, truncated] = makeSnippet(index, chunk.text, query, snippetChars);
+    const hit = { id: chunk.id, score: Math.round(sc * 1e6) / 1e6, text, meta: chunk.meta || {} };
+    if (truncated) hit.full_chars = chunk.text.length;
+    out.push(hit);
     if (out.length >= k) break;
   }
   return out;
@@ -211,7 +248,7 @@ function search(index, query, { k = 5, filters = [], useRm3 = false, rm3 = {} } 
 function parseArgs(argv) {
   const a = { index: __dirname, query: "", core: [], expand: [], filter: [],
     wCore: 1.0, wExpand: 0.4, wQuery: 0.25, k: 5, rm3: false,
-    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, textChars: 0 };
+    rm3Docs: 10, rm3Terms: 15, rm3Alpha: 0.5, snippet: 1200 };
   const multi = { "--core": "core", "--expand": "expand", "--filter": "filter" };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
@@ -227,7 +264,7 @@ function parseArgs(argv) {
     else if (t === "--rm3-docs") a.rm3Docs = Number(val);
     else if (t === "--rm3-terms") a.rm3Terms = Number(val);
     else if (t === "--rm3-alpha") a.rm3Alpha = Number(val);
-    else if (t === "--text-chars") a.textChars = Number(val);
+    else if (t === "--snippet") a.snippet = Number(val);
     else { i--; } // unknown flag without value; skip
   }
   return a;
@@ -254,10 +291,8 @@ function main(argv) {
     filters: a.filter.map(parseFilter),
     useRm3: a.rm3,
     rm3: { nDocs: a.rm3Docs, nTerms: a.rm3Terms, alpha: a.rm3Alpha },
+    snippetChars: a.snippet,
   });
-  if (a.textChars > 0) {
-    for (const h of hits) if (h.text.length > a.textChars) h.text = h.text.slice(0, a.textChars) + "…";
-  }
   console.log(JSON.stringify({ hits }, null, 2));
   return 0;
 }

--- a/creating-kb/scripts/search.py
+++ b/creating-kb/scripts/search.py
@@ -226,6 +226,52 @@ def build_query(
     return q
 
 
+# Sentence splitter shared with search.js (same regex, lookbehind supported in
+# both runtimes) so snippet selection is byte-identical across languages.
+_SENT_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def make_snippet(index: Index, text: str, query: dict[str, float], budget: int) -> tuple[str, bool]:
+    """Return (passage, truncated). Decouples the reasoning payload from the
+    retrieval unit: rank a doc whole (recall), but return only the query-densest
+    sentences (signal). Scores each sentence by sum of query-term weight*idf for
+    the distinct query terms it contains, picks the top sentences up to `budget`
+    chars, and re-orders them by original position joined with ' … '.
+
+    Sentences anywhere in the doc are eligible, so signal distributed across a
+    long post is captured — not just one window. Scores are rounded so JS and
+    Python select identically."""
+    if budget <= 0 or len(text) <= budget:
+        return text, False
+    sents = [s.strip() for s in _SENT_SPLIT.split(text) if s.strip()]
+    if not sents:
+        return text[:budget] + "…", True
+    scored = []
+    for i, s in enumerate(sents):
+        toks = set(tokenize(s))
+        sc = round(sum(query[t] * index.idf(t) for t in toks if t in query), 6)
+        scored.append((sc, i, s))
+    chosen: list[tuple[int, str]] = []
+    total = 0
+    for sc, i, s in sorted(scored, key=lambda x: (-x[0], x[1])):
+        if sc <= 0:
+            break
+        if chosen and total + len(s) > budget:
+            break
+        chosen.append((i, s))
+        total += len(s) + 5
+    if not chosen:
+        return text[:budget] + "…", True
+    chosen.sort()
+    body = " … ".join(s for _, s in chosen)
+    # mark elided head/tail so the agent knows it's a passage, not the whole doc
+    if chosen[0][0] > 0:
+        body = "… " + body
+    if chosen[-1][0] < len(sents) - 1:
+        body = body + " …"
+    return body, True
+
+
 def search(
     index: Index,
     query: dict[str, float],
@@ -236,6 +282,7 @@ def search(
     rm3_docs: int = 10,
     rm3_terms: int = 15,
     rm3_alpha: float = 0.5,
+    snippet_chars: int = 0,
 ) -> list[dict]:
     if use_rm3:
         query = rm3_expand(
@@ -248,14 +295,17 @@ def search(
         if not apply_filters(index, doc_idx, filters or []):
             continue
         chunk = index.chunks[doc_idx]
-        out.append(
-            {
-                "id": chunk.get("id"),
-                "score": round(sc, 6),
-                "text": chunk["text"],
-                "meta": chunk.get("meta", {}),
-            }
-        )
+        full = chunk["text"]
+        text, truncated = make_snippet(index, full, query, snippet_chars)
+        hit = {
+            "id": chunk.get("id"),
+            "score": round(sc, 6),
+            "text": text,
+            "meta": chunk.get("meta", {}),
+        }
+        if truncated:
+            hit["full_chars"] = len(full)  # signal more is available via --snippet 0
+        out.append(hit)
         if len(out) >= k:
             break
     return out
@@ -277,7 +327,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--rm3-docs", type=int, default=10)
     ap.add_argument("--rm3-terms", type=int, default=15)
     ap.add_argument("--rm3-alpha", type=float, default=0.5)
-    ap.add_argument("--text-chars", type=int, default=0, help="truncate hit text to N chars in output (0 = full)")
+    ap.add_argument("--snippet", type=int, default=1200,
+                    help="return only the query-densest passage, ~N chars, instead of the full "
+                         "chunk (focuses reasoning context; 0 = full text)")
     args = ap.parse_args(argv)
 
     index = Index(Path(args.index))
@@ -301,11 +353,8 @@ def main(argv: list[str] | None = None) -> int:
         filters=[_parse_filter(f) for f in args.filter],
         use_rm3=args.rm3, rm3_docs=args.rm3_docs,
         rm3_terms=args.rm3_terms, rm3_alpha=args.rm3_alpha,
+        snippet_chars=args.snippet,
     )
-    if args.text_chars > 0:
-        for h in hits:
-            if len(h["text"]) > args.text_chars:
-                h["text"] = h["text"][: args.text_chars] + "…"
     print(json.dumps({"hits": hits}, ensure_ascii=False, indent=2))
     return 0
 

--- a/creating-kb/scripts/search.py
+++ b/creating-kb/scripts/search.py
@@ -231,43 +231,72 @@ def build_query(
 _SENT_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
 
 
-def make_snippet(index: Index, text: str, query: dict[str, float], budget: int) -> tuple[str, bool]:
+def _span_chars(sents: list[str], idxs: list[int]) -> int:
+    """Char cost of the merged passage for a set of selected sentence indices:
+    sentence lengths + 1 per intra-run join + 3 per ' … ' between runs. Identical
+    formula in search.js so both runtimes make the same budget decisions."""
+    if not idxs:
+        return 0
+    s = sorted(idxs)
+    runs = 1
+    for a, b in zip(s, s[1:]):
+        if b != a + 1:
+            runs += 1
+    total = sum(len(sents[i]) for i in s)
+    total += (len(s) - runs)            # spaces joining sentences within a run
+    total += (runs - 1) * 3             # ' … ' between runs
+    return total
+
+
+def make_snippet(index: Index, text: str, query: dict[str, float], budget: int,
+                 context: int = 1) -> tuple[str, bool]:
     """Return (passage, truncated). Decouples the reasoning payload from the
     retrieval unit: rank a doc whole (recall), but return only the query-densest
-    sentences (signal). Scores each sentence by sum of query-term weight*idf for
-    the distinct query terms it contains, picks the top sentences up to `budget`
-    chars, and re-orders them by original position joined with ' … '.
+    sentences (signal) — each expanded by `context` neighbour sentences on either
+    side so a matched sentence keeps its referent/setup, and overlapping or
+    adjacent matches merge into contiguous passages.
 
-    Sentences anywhere in the doc are eligible, so signal distributed across a
-    long post is captured — not just one window. Scores are rounded so JS and
+    Sentences are scored by sum of query-term weight*idf for the distinct query
+    terms they contain; the highest are seeded in until ~`budget` chars (counting
+    the context windows), then emitted in document order. Runs are joined by ' … '
+    with leading/trailing ' …' marking elided head/tail. Scores rounded so JS and
     Python select identically."""
     if budget <= 0 or len(text) <= budget:
         return text, False
     sents = [s.strip() for s in _SENT_SPLIT.split(text) if s.strip()]
     if not sents:
         return text[:budget] + "…", True
+    n = len(sents)
     scored = []
     for i, s in enumerate(sents):
         toks = set(tokenize(s))
         sc = round(sum(query[t] * index.idf(t) for t in toks if t in query), 6)
-        scored.append((sc, i, s))
-    chosen: list[tuple[int, str]] = []
-    total = 0
-    for sc, i, s in sorted(scored, key=lambda x: (-x[0], x[1])):
-        if sc <= 0:
-            break
-        if chosen and total + len(s) > budget:
-            break
-        chosen.append((i, s))
-        total += len(s) + 5
-    if not chosen:
+        scored.append((sc, i))
+    seeds = [i for sc, i in sorted(scored, key=lambda x: (-x[0], x[1])) if sc > 0]
+    if not seeds:
         return text[:budget] + "…", True
-    chosen.sort()
-    body = " … ".join(s for _, s in chosen)
-    # mark elided head/tail so the agent knows it's a passage, not the whole doc
-    if chosen[0][0] > 0:
+
+    selected: set[int] = set()
+    for seed in seeds:
+        window = set(range(max(0, seed - context), min(n, seed + context + 1)))
+        cand = selected | window
+        if selected and _span_chars(sents, list(cand)) > budget:
+            break
+        selected = cand
+        if _span_chars(sents, list(selected)) >= budget:
+            break
+    if not selected:  # first seed's window even if it alone exceeds budget
+        seed = seeds[0]
+        selected = set(range(max(0, seed - context), min(n, seed + context + 1)))
+
+    idxs = sorted(selected)
+    runs: list[list[int]] = [[idxs[0]]]
+    for i in idxs[1:]:
+        (runs[-1].append(i) if i == runs[-1][-1] + 1 else runs.append([i]))
+    body = " … ".join(" ".join(sents[i] for i in run) for run in runs)
+    if idxs[0] > 0:
         body = "… " + body
-    if chosen[-1][0] < len(sents) - 1:
+    if idxs[-1] < n - 1:
         body = body + " …"
     return body, True
 
@@ -283,6 +312,7 @@ def search(
     rm3_terms: int = 15,
     rm3_alpha: float = 0.5,
     snippet_chars: int = 0,
+    snippet_context: int = 1,
 ) -> list[dict]:
     if use_rm3:
         query = rm3_expand(
@@ -296,7 +326,7 @@ def search(
             continue
         chunk = index.chunks[doc_idx]
         full = chunk["text"]
-        text, truncated = make_snippet(index, full, query, snippet_chars)
+        text, truncated = make_snippet(index, full, query, snippet_chars, snippet_context)
         hit = {
             "id": chunk.get("id"),
             "score": round(sc, 6),
@@ -330,6 +360,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--snippet", type=int, default=1200,
                     help="return only the query-densest passage, ~N chars, instead of the full "
                          "chunk (focuses reasoning context; 0 = full text)")
+    ap.add_argument("--context", type=int, default=1,
+                    help="neighbour sentences kept on each side of a match for coherence "
+                         "(0 = bare matched sentences)")
     args = ap.parse_args(argv)
 
     index = Index(Path(args.index))
@@ -353,7 +386,7 @@ def main(argv: list[str] | None = None) -> int:
         filters=[_parse_filter(f) for f in args.filter],
         use_rm3=args.rm3, rm3_docs=args.rm3_docs,
         rm3_terms=args.rm3_terms, rm3_alpha=args.rm3_alpha,
-        snippet_chars=args.snippet,
+        snippet_chars=args.snippet, snippet_context=args.context,
     )
     print(json.dumps({"hits": hits}, ensure_ascii=False, indent=2))
     return 0

--- a/creating-kb/spa/e2e-test.mjs
+++ b/creating-kb/spa/e2e-test.mjs
@@ -1,0 +1,75 @@
+// End-to-end SPA test: real headless Chromium drives the packer, we verify the
+// downloaded .skill unzips and is queryable.
+//
+// Optional/manual (browser dep). Requires `npm i playwright-core` and a Chromium
+// binary; set $CHROMIUM to its path (defaults to the CCotw preinstalled build).
+// The durable, dependency-free pin is test_web_parity.mjs (Node-only).
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { chromium } from "playwright-core";
+
+const ROOT = "/home/user/claude-workspace/.spokes/claude-skills/creating-kb";
+const CHROME = process.env.CHROMIUM || "/opt/pw-browsers/chromium-1194/chrome-linux/chrome";
+const MIME = { ".html": "text/html", ".mjs": "text/javascript", ".js": "text/javascript",
+  ".py": "text/plain", ".md": "text/markdown", ".json": "application/json" };
+
+const server = http.createServer((req, res) => {
+  const fp = path.join(ROOT, decodeURIComponent(req.url.split("?")[0]));
+  if (!fp.startsWith(ROOT) || !fs.existsSync(fp) || fs.statSync(fp).isDirectory()) { res.writeHead(404); res.end(); return; }
+  res.writeHead(200, { "content-type": MIME[path.extname(fp)] || "application/octet-stream" });
+  fs.createReadStream(fp).pipe(res);
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+const corpus = path.join(tmp, "corpus");
+fs.mkdirSync(corpus);
+fs.writeFileSync(path.join(corpus, "redis.md"), "# Redis\n\nRedis is an in-memory key-value store used for caching and queues.\n");
+fs.writeFileSync(path.join(corpus, "postgres.md"), "# Postgres\n\nPostgreSQL is a relational database with strong ACID guarantees and SQL.\n");
+
+const browser = await chromium.launch({ executablePath: CHROME, args: ["--no-sandbox"] });
+const ctx = await browser.newContext({ acceptDownloads: true });
+const page = await ctx.newPage();
+const errs = [];
+page.on("pageerror", (e) => errs.push(String(e)));
+await page.goto(`http://localhost:${port}/spa/index.html`);
+
+await page.setInputFiles("#picker", [path.join(corpus, "redis.md"), path.join(corpus, "postgres.md")]);
+await page.fill("#name", "e2e-kb");
+await page.fill("#target", "0");
+
+await page.click("#build");
+await page.waitForSelector("a.dl");
+const status = await page.textContent("#status");
+const [download] = await Promise.all([
+  page.waitForEvent("download"),
+  page.click("a.dl"),
+]);
+const out = path.join(tmp, "e2e-kb.skill");
+await download.saveAs(out);
+await browser.close();
+server.close();
+
+// verify the downloaded .skill
+const names = execFileSync("python3", ["-c",
+  `import zipfile;print('\\n'.join(zipfile.ZipFile('${out}').namelist()))`], { encoding: "utf8" }).trim();
+const bundle = path.join(tmp, "unz");
+execFileSync("python3", ["-c",
+  `import zipfile;zipfile.ZipFile('${out}').extractall('${bundle}')`]);
+const hit = execFileSync("python3", [path.join(bundle, "e2e-kb", "search.py"),
+  "--index", path.join(bundle, "e2e-kb"), "--core", "database", "--expand", "relational SQL", "--k", "1"], { encoding: "utf8" });
+const hitId = JSON.parse(hit).hits[0].id;
+
+console.log("status:", status.replace(/\n/g, " "));
+console.log("zip entries:\n" + names);
+console.log("query 'database' top hit:", hitId);
+const ok = errs.length === 0 && /Built 2 chunks/.test(status) && names.includes("e2e-kb/search.js")
+  && names.includes("e2e-kb/search.py") && names.includes("e2e-kb/index.json") && hitId === "postgres.md#chunk-0";
+if (errs.length) console.log("PAGE ERRORS:", errs);
+console.log("\nE2E SPA:", ok ? "PASS" : "FAIL");
+fs.rmSync(tmp, { recursive: true, force: true });
+process.exit(ok ? 0 : 1);

--- a/creating-kb/spa/index.html
+++ b/creating-kb/spa/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>creating-kb · build a portable knowledgebase</title>
+<style>
+  :root { --bg:#0f1115; --card:#181b22; --ink:#e7e9ee; --mut:#9aa3b2; --acc:#6ea8fe; --ok:#5ad19a; --warn:#e0a96d; --line:#2a2f3a; }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink); font:15px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+  main { max-width:760px; margin:0 auto; padding:40px 20px 80px; }
+  h1 { font-size:22px; margin:0 0 4px; }
+  .sub { color:var(--mut); margin:0 0 28px; }
+  .card { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:22px; margin-bottom:18px; }
+  #drop { border:2px dashed var(--line); border-radius:12px; padding:38px 20px; text-align:center; color:var(--mut);
+          transition:.15s; cursor:pointer; }
+  #drop.hot { border-color:var(--acc); background:#1c2230; color:var(--ink); }
+  #drop strong { color:var(--ink); }
+  .row { display:flex; gap:16px; flex-wrap:wrap; margin-top:18px; }
+  label { display:block; font-size:12px; color:var(--mut); margin-bottom:4px; }
+  input[type=text],input[type=number] { background:#0f1219; border:1px solid var(--line); color:var(--ink);
+          border-radius:8px; padding:8px 10px; width:100%; font:inherit; }
+  .field { flex:1 1 140px; }
+  button { background:var(--acc); color:#0b1020; border:0; border-radius:9px; padding:11px 18px; font:600 15px/1 inherit;
+           cursor:pointer; margin-top:20px; }
+  button:disabled { opacity:.5; cursor:default; }
+  #status { margin-top:16px; font-size:14px; white-space:pre-wrap; }
+  .ok { color:var(--ok); } .warn { color:var(--warn); }
+  ul.files { max-height:150px; overflow:auto; margin:14px 0 0; padding:0; list-style:none; font:12px ui-monospace,monospace; color:var(--mut); }
+  ul.files li { padding:1px 0; }
+  a.dl { display:inline-block; margin-top:18px; background:var(--ok); color:#08130d; text-decoration:none; padding:11px 18px; border-radius:9px; font-weight:600; }
+  code { background:#0f1219; padding:1px 5px; border-radius:4px; font-size:13px; }
+  .note { color:var(--mut); font-size:13px; margin-top:10px; }
+</style>
+</head>
+<body>
+<main>
+  <h1>creating-kb</h1>
+  <p class="sub">Drop files → get a portable, embedding-free <code>.skill</code> knowledgebase. Everything runs in your browser — no upload, no model, no network.</p>
+
+  <div class="card">
+    <div id="drop">
+      <strong>Drop files or a folder here</strong><br>
+      or click to choose · <code>.txt .md .html</code> by default
+      <input id="picker" type="file" multiple hidden>
+      <input id="pickerDir" type="file" webkitdirectory hidden>
+    </div>
+    <ul class="files" id="filelist"></ul>
+
+    <div class="row">
+      <div class="field"><label>KB name</label><input id="name" type="text" value="my-kb"></div>
+      <div class="field"><label>Extensions</label><input id="ext" type="text" value="txt,md,html,htm"></div>
+      <div class="field"><label>Chunk size (chars, 0 = whole doc)</label><input id="target" type="number" value="0" min="0"></div>
+    </div>
+    <div class="row">
+      <div class="field" style="flex:1 1 100%"><label>Source description (optional)</label><input id="source" type="text" placeholder="what this corpus is"></div>
+    </div>
+
+    <button id="build" disabled>Build .skill</button>
+    <div id="status"></div>
+    <div id="dl"></div>
+  </div>
+
+  <p class="note">The bundle ships a query protocol + two searchers (<code>search.js</code> / <code>search.py</code>) and a BM25 index. Drop it into any agent's skill folder; the agent expands the query and runs the bundled searcher — no embedding model required.</p>
+</main>
+
+<script type="module">
+import { collectChunks, buildIndex, bundleFiles, zipSkill } from "../scripts/lexkb-web.mjs";
+
+const $ = (id) => document.getElementById(id);
+const drop = $("drop"), status = $("status"), dlBox = $("dl");
+let files = [];        // [{name, text}]
+let runtime = null;    // {searchJs, searchPy, bundleSkillMd}
+
+async function loadRuntime() {
+  if (runtime) return runtime;
+  const get = async (f) => {
+    const r = await fetch(f);
+    if (!r.ok) throw new Error(`could not fetch ${f} (${r.status})`);
+    return r.text();
+  };
+  runtime = {
+    searchJs: await get("../scripts/search.js"),
+    searchPy: await get("../scripts/search.py"),
+    bundleSkillMd: await get("../scripts/bundle_SKILL.md"),
+  };
+  return runtime;
+}
+
+function setStatus(msg, cls) { status.className = cls || ""; status.textContent = msg; }
+
+function renderFiles() {
+  $("filelist").innerHTML = files.map((f) => `<li>${f.name} · ${f.text.length}c</li>`).join("");
+  $("build").disabled = files.length === 0;
+}
+
+async function addFileList(fileObjs) {
+  const next = [];
+  for (const file of fileObjs) {
+    const name = file.webkitRelativePath || file.name;
+    next.push({ name, text: await file.text() });
+  }
+  // de-dup by name, last wins
+  const byName = new Map(files.map((f) => [f.name, f]));
+  for (const f of next) byName.set(f.name, f);
+  files = [...byName.values()];
+  renderFiles();
+  setStatus(`${files.length} file(s) staged.`);
+}
+
+// drag & drop (supports folders via webkitGetAsEntry)
+drop.addEventListener("click", () => $("picker").click());
+$("picker").addEventListener("change", (e) => addFileList(e.target.files));
+["dragenter", "dragover"].forEach((ev) => drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.add("hot"); }));
+["dragleave", "drop"].forEach((ev) => drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.remove("hot"); }));
+
+async function walkEntry(entry, prefix, out) {
+  if (entry.isFile) {
+    await new Promise((res) => entry.file((f) => { f._rel = prefix + f.name; out.push(f); res(); }));
+  } else if (entry.isDirectory) {
+    const reader = entry.createReader();
+    const ents = await new Promise((res) => reader.readEntries(res));
+    for (const e of ents) await walkEntry(e, prefix + entry.name + "/", out);
+  }
+}
+
+drop.addEventListener("drop", async (e) => {
+  const items = [...(e.dataTransfer.items || [])].map((it) => it.webkitGetAsEntry && it.webkitGetAsEntry()).filter(Boolean);
+  if (items.length) {
+    const collected = [];
+    for (const it of items) await walkEntry(it, "", collected);
+    // collected File objects carry _rel for nested paths
+    const objs = collected.map((f) => ({ name: f._rel || f.name, text: f.text() }));
+    const resolved = [];
+    for (const o of objs) resolved.push({ name: o.name, text: await o.text });
+    const byName = new Map(files.map((f) => [f.name, f]));
+    for (const f of resolved) byName.set(f.name, f);
+    files = [...byName.values()];
+    renderFiles();
+    setStatus(`${files.length} file(s) staged.`);
+  } else {
+    await addFileList(e.dataTransfer.files);
+  }
+});
+
+$("build").addEventListener("click", async () => {
+  try {
+    setStatus("Loading runtime…");
+    const rt = await loadRuntime();
+    const exts = new Set($("ext").value.split(",").map((s) => s.trim().replace(/^\./, "").toLowerCase()).filter(Boolean));
+    const target = Number($("target").value) || 0;
+    const name = ($("name").value.trim() || "my-kb").replace(/[^a-zA-Z0-9._-]/g, "-");
+    const chunks = collectChunks(files, exts, target, 40);
+    if (!chunks.length) { setStatus("No chunks produced — check your extensions filter.", "warn"); return; }
+    const index = buildIndex(chunks, 1.5, 0.75);
+    const bundle = bundleFiles(chunks, index, $("source").value.trim() || `${name} corpus`, rt);
+    const bytes = zipSkill(bundle, name);
+    const nFiles = new Set(chunks.map((c) => c.meta.source_path)).size;
+    setStatus(`Built ${chunks.length} chunks from ${nFiles} file(s) · vocab ${Object.keys(index.df).length} · ${(bytes.length / 1024).toFixed(1)} KB`, "ok");
+    const url = URL.createObjectURL(new Blob([bytes], { type: "application/zip" }));
+    dlBox.innerHTML = `<a class="dl" download="${name}.skill" href="${url}">Download ${name}.skill</a>`;
+  } catch (err) {
+    setStatus("Error: " + err.message + (location.protocol === "file:" ? "\n(serve over http:// — file:// blocks fetching the runtime files)" : ""), "warn");
+  }
+});
+</script>
+</body>
+</html>

--- a/creating-kb/test_parity.py
+++ b/creating-kb/test_parity.py
@@ -31,6 +31,14 @@ CORPUS = {
     "property.txt": "From the protection of different and unequal faculties of acquiring "
                     "property, the possession of different degrees and kinds of property "
                     "and economic inequality immediately results.\n",
+    # A long doc (>snippet budget) so the extractive-passage path is exercised
+    # and JS/Python snippet selection is checked for byte-identity.
+    "longdoc.txt": ("Republics confront the problem of faction at every turn. " * 6
+                    + "Filler sentence about commerce and navigation and trade winds. " * 8
+                    + "Liberty is the air that gives faction its destructive fire. " * 4
+                    + "More filler about agriculture, roads, and the postal service. " * 8
+                    + "Property rights and unequal faculties drive the violence of faction. " * 4
+                    + "Closing filler about treaties, envoys, and foreign courts. " * 8 + "\n"),
 }
 
 QUERIES = [
@@ -38,6 +46,8 @@ QUERIES = [
     ["--query", "separation of powers", "--core", "powers", "--expand", "checks", "--expand", "balances"],
     ["--core", "property", "--expand", "wealth inequality", "--filter", "source_path~property"],
     ["--query", "liberty and faction", "--rm3", "--rm3-docs", "3"],
+    # exercises the snippet path on the long doc (distributed signal)
+    ["--query", "faction liberty property", "--core", "faction", "--expand", "liberty", "--expand", "property"],
 ]
 
 
@@ -46,7 +56,8 @@ def run(cmd: list[str]) -> list[tuple]:
     if out.returncode != 0:
         raise RuntimeError(f"{cmd[:2]} failed: {out.stderr[:300]}")
     hits = json.loads(out.stdout)["hits"]
-    return [(h["id"], h["score"]) for h in hits]
+    # include text + full_chars so the snippet path is part of the parity check
+    return [(h["id"], h["score"], h["text"], h.get("full_chars")) for h in hits]
 
 
 def main() -> int:

--- a/creating-kb/test_parity.py
+++ b/creating-kb/test_parity.py
@@ -48,6 +48,9 @@ QUERIES = [
     ["--query", "liberty and faction", "--rm3", "--rm3-docs", "3"],
     # exercises the snippet path on the long doc (distributed signal)
     ["--query", "faction liberty property", "--core", "faction", "--expand", "liberty", "--expand", "property"],
+    # context-window variants (bare sentences vs ±2 neighbours) — must stay in parity
+    ["--core", "faction", "--expand", "liberty", "--context", "0"],
+    ["--core", "faction", "--expand", "liberty", "--expand", "property", "--context", "2"],
 ]
 
 

--- a/creating-kb/test_web_parity.mjs
+++ b/creating-kb/test_web_parity.mjs
@@ -1,0 +1,80 @@
+/**
+ * Parity pin: the browser build core (lexkb-web.mjs) must produce byte-identical
+ * output to the canonical Node builder (build_lexkb.js + zipstore.js). Same
+ * pattern as test_parity.py (two impls, one pin). Run: node test_web_parity.mjs
+ *
+ * Asserts identical chunks.jsonl, index.json, the full bundle file map, and the
+ * final .skill zip bytes for the same corpus. Exit 0 on parity, 1 otherwise.
+ */
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const node = require("./scripts/build_lexkb.js");
+const { zipStore } = require("./scripts/zipstore.js");
+const web = await import("./scripts/lexkb-web.mjs");
+
+const CORPUS = {
+  "factions.txt": "Liberty is to faction what air is to fire. The latent causes of faction are sown in the nature of man.\n",
+  "powers.txt": "The accumulation of all powers, legislative, executive, and judiciary, in the same hands is tyranny.\n",
+  "sub/property.html": "<html><head><title>Property</title></head><body><article>Unequal faculties of acquiring property produce economic inequality.</article></body></html>\n",
+};
+const EXTS = new Set(["txt", "html"]);
+
+function eq(label, a, b) {
+  const ok = a === b;
+  console.log(`${ok ? "OK  " : "DIFF"} ${label}`);
+  if (!ok) {
+    console.log("  node:", JSON.stringify(a).slice(0, 200));
+    console.log("  web :", JSON.stringify(b).slice(0, 200));
+  }
+  return ok;
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "webparity-"));
+try {
+  // write corpus to disk for the Node reader; keep in-memory for the web core
+  const files = [];
+  for (const [name, text] of Object.entries(CORPUS)) {
+    const full = path.join(tmp, name);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, text);
+    files.push({ name, text });
+  }
+
+  const chunksN = node.collectChunks(tmp, EXTS, 0, 40);
+  const idxN = node.buildIndex(chunksN, 1.5, 0.75);
+  const filesN = node.bundleFiles(chunksN, idxN, "test corpus");
+
+  const chunksW = web.collectChunks(files, EXTS, 0, 40);
+  const idxW = web.buildIndex(chunksW, 1.5, 0.75);
+  const runtime = {
+    searchJs: fs.readFileSync(path.join(HERE, "scripts/search.js"), "utf8"),
+    searchPy: fs.readFileSync(path.join(HERE, "scripts/search.py"), "utf8"),
+    bundleSkillMd: fs.readFileSync(path.join(HERE, "scripts/bundle_SKILL.md"), "utf8"),
+  };
+  const filesW = web.bundleFiles(chunksW, idxW, "test corpus", runtime);
+
+  // node-side zip (same root/entry construction as build_lexkb.zipSkill)
+  const root = "mykb";
+  const entriesN = Object.entries(filesN).sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([name, content]) => ({ name: `${root}/${name}`, data: content }));
+  const zipN = zipStore(entriesN);
+  const zipW = web.zipSkill(filesW, root);
+
+  let ok = true;
+  ok &= eq("chunks.jsonl", JSON.stringify(chunksN), JSON.stringify(chunksW));
+  ok &= eq("index.json", JSON.stringify(idxN), JSON.stringify(idxW));
+  ok &= eq("bundle file map", JSON.stringify(filesN), JSON.stringify(filesW));
+  ok &= eq("zip length", String(zipN.length), String(zipW.length));
+  ok &= eq("zip bytes", Buffer.from(zipN).toString("base64"), Buffer.from(zipW).toString("base64"));
+
+  console.log("\nWEB PARITY:", ok ? "PASS" : "FAIL");
+  process.exit(ok ? 0 : 1);
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## creating-kb v0.3.0 — browser SPA packer (no Claude needed)

`spa/index.html`: a static, fully client-side builder. Drop files or a folder →
chunk → BM25 index → download a `.skill`. No upload, no model, no network, no
server — the embedding-free design is what makes a pure-browser packer possible
(this is the realisation of remax_kb#12 minus the embedding half).

### No drift
- `scripts/lexkb-web.mjs` is an ES-module port of the build pipeline
  (chunk → index → STORED zip). `test_web_parity.mjs` pins it **byte-identical**
  to `build_lexkb.js` + `zipstore.js` — same chunks.jsonl, index.json, bundle map,
  and final `.skill` zip bytes. (Same two-impls-one-pin pattern as
  search.js/search.py.)
- The SPA imports that core and **fetches** the canonical `search.js` /
  `search.py` / `bundle_SKILL.md` to place in each bundle, so the shipped runtime
  is never duplicated.

### Tested
- `test_web_parity.mjs`: PASS (browser core == Node builder, byte-for-byte incl zip).
- `spa/e2e-test.mjs`: real headless Chromium drives the page — stages 2 files,
  builds, downloads the `.skill`; the bundle unzips to the right structure and is
  queryable by the shipped `search.py` (`database` → `postgres.md`). PASS.

### Deploy
Serve the `creating-kb/` dir (e.g. GitHub Pages); open `spa/index.html` (it fetches
`../scripts/`). A browser-built `.skill` is byte-identical to a Node-built one.

_Stacks on #713 (v0.2.0 passages); merge that first._
