### PR TITLE
creating-kb: polysemy caveat in query-expansion protocol

### DIFF
--- a/creating-kb/scripts/bundle_SKILL.md
+++ b/creating-kb/scripts/bundle_SKILL.md
@@ -47,7 +47,12 @@ retrieval competitive with embeddings. Do not skip it.
    synonym can lift a result but can never drop a doc the literal question would
    have matched. Defaults: core 1.0, expand 0.4, query-floor 0.25, top-k 5.
    Keep expansion targeted — terms too generic ("system", "process") leak into
-   unrelated chunks and blur the ranking.
+   unrelated chunks and blur the ranking. A precise word can mislead too if it
+   is polysemous: prefer the disambiguating phrase as one `--core` term (e.g.
+   `--core "centered simhash"`) over a bare ambiguous word (`--core "centered"`,
+   which also matches "centered around …" in unrelated chunks). The passage
+   extractor is lexical too, so it will highlight the wrong sense rather than
+   correct it.
 
 4. **Read the returned chunks. Answer from them, and cite chunk ids inline.**
    The chunks are the source of truth the user installed. When a chunk


### PR DESCRIPTION
Adds a polysemy caveat to the query-expansion protocol emitted into every `.skill` bundle.

**Why.** The existing caveat warns against *generic* terms ("system", "process") that leak by frequency. A precise but *polysemous* `--core` term passes that check and still poisons the query: testing the spring-reading KB, `--core "centered"` (intended: centered simhash) top-ranked a System Card chunk via "centered around feature steering", and the lexical passage extractor then highlighted that wrong sense. New text tells the agent to prefer the disambiguating phrase as one `--core` term.

**Scope.** Template prose only (`bundle_SKILL.md`). No searcher/index change; `test_parity.py` (searcher js/py parity) is unaffected. Companion PR on oaustegard.github.io edits the byte-identical copy embedded in `kb-packer.html` so browser-built and CLI-built `.skill` bundles stay identical.

**Verification.** `old` block matched exactly once in each file; +365 bytes; caveat text byte-identical across both repos (verified via cross-file diff).