### PR TITLE
perf(creating-kb): drop derivable df map; sort only query-bearing snippet sentences

### DIFF
--- a/creating-kb/scripts/build_lexkb.js
+++ b/creating-kb/scripts/build_lexkb.js
@@ -118,10 +118,11 @@ function buildIndex(chunks, k1, b) {
   });
   const N = chunks.length;
   const avgdl = N ? doclen.reduce((s, x) => s + x, 0) / N : 0;
-  const df = {};
+  // df is derivable from postings[t].length, so it is not emitted; idf()
+  // computes it on demand. Drops a vocab-sized map from every .skill index.
   const postingsObj = {};
-  for (const [t, pl] of postings) { df[t] = pl.length; postingsObj[t] = pl; }
-  return { params: { k1, b }, N, avgdl, doclen, df, postings: postingsObj };
+  for (const [t, pl] of postings) postingsObj[t] = pl;
+  return { params: { k1, b }, N, avgdl, doclen, postings: postingsObj };
 }
 
 // --------------------------------------------------------------------------- //
@@ -196,7 +197,7 @@ function main(argv) {
   writeBundle(a.out, files);
   const nFiles = new Set(chunks.map((c) => c.meta.source_path)).size;
   console.log(`built ${chunks.length} chunks from ${nFiles} files (target_chars=${a.targetChars}, ` +
-    `avgdl=${index.avgdl.toFixed(0)} tokens, vocab=${Object.keys(index.df).length}) -> ${a.out}`);
+    `avgdl=${index.avgdl.toFixed(0)} tokens, vocab=${Object.keys(index.postings).length}) -> ${a.out}`);
 
   if (a.zip) {
     const skillPath = path.join(path.dirname(a.out), `${a.name}.skill`);

--- a/creating-kb/scripts/search.js
+++ b/creating-kb/scripts/search.js
@@ -52,7 +52,6 @@ class Index {
     this.N = Number(idx.N);
     this.avgdl = Number(idx.avgdl);
     this.doclen = idx.doclen;
-    this.df = idx.df;
     this.postings = idx.postings;
     this._idf = new Map();
     this._chunks = null;
@@ -69,7 +68,7 @@ class Index {
   idf(term) {
     let v = this._idf.get(term);
     if (v === undefined) {
-      const df = this.df[term] || 0;
+      const df = (this.postings[term] || []).length;
       v = Math.log(1.0 + (this.N - df + 0.5) / (df + 0.5));
       this._idf.set(term, v);
     }
@@ -217,13 +216,19 @@ function makeSnippet(index, text, query, budget, context = 1) {
   const sents = text.split(SENT_SPLIT).map((s) => s.trim()).filter(Boolean);
   if (!sents.length) return [text.slice(0, budget) + "…", true];
   const n = sents.length;
-  const scored = sents.map((s, i) => {
+  // Only query-bearing sentences can seed; score them, drop zero-score
+  // sentences before sorting (filter the rounded value to match the prior
+  // round-then-filter exactly), so the sort is over the few matches, not all
+  // sentences of a whole-document chunk.
+  const scored = [];
+  for (let i = 0; i < n; i++) {
     let sc = 0;
-    for (const t of new Set(tokenize(s))) if (query.has(t)) sc += query.get(t) * index.idf(t);
-    return [Math.round(sc * 1e6) / 1e6, i];
-  });
+    for (const t of new Set(tokenize(sents[i]))) if (query.has(t)) sc += query.get(t) * index.idf(t);
+    const r = Math.round(sc * 1e6) / 1e6;
+    if (r > 0) scored.push([r, i]);
+  }
   scored.sort((a, b) => (b[0] - a[0]) || (a[1] - b[1]));
-  const seeds = scored.filter(([sc]) => sc > 0).map(([, i]) => i);
+  const seeds = scored.map(([, i]) => i);
   if (!seeds.length) return [text.slice(0, budget) + "…", true];
 
   let selected = new Set();

--- a/creating-kb/scripts/search.py
+++ b/creating-kb/scripts/search.py
@@ -59,7 +59,6 @@ class Index:
         self.N = int(idx["N"])
         self.avgdl = float(idx["avgdl"])
         self.doclen = idx["doclen"]
-        self.df = idx["df"]
         self.postings = idx["postings"]
         self._idf_cache: dict[str, float] = {}
         # chunks.jsonl loaded lazily on demand
@@ -79,7 +78,7 @@ class Index:
     def idf(self, term: str) -> float:
         """Robust BM25 idf (always positive — Lucene/bm25+ variant)."""
         if term not in self._idf_cache:
-            df = self.df.get(term, 0)
+            df = len(self.postings.get(term, ()))
             self._idf_cache[term] = math.log(1.0 + (self.N - df + 0.5) / (df + 0.5))
         return self._idf_cache[term]
 
@@ -267,12 +266,16 @@ def make_snippet(index: Index, text: str, query: dict[str, float], budget: int,
     if not sents:
         return text[:budget] + "…", True
     n = len(sents)
+    # Only query-bearing sentences can seed; score them and drop zero-score
+    # sentences (the rounded value, matching the prior round-then-filter)
+    # before sorting, so the sort is over the few matches, not every sentence.
     scored = []
     for i, s in enumerate(sents):
         toks = set(tokenize(s))
         sc = round(sum(query[t] * index.idf(t) for t in toks if t in query), 6)
-        scored.append((sc, i))
-    seeds = [i for sc, i in sorted(scored, key=lambda x: (-x[0], x[1])) if sc > 0]
+        if sc > 0:
+            scored.append((sc, i))
+    seeds = [i for sc, i in sorted(scored, key=lambda x: (-x[0], x[1]))]
     if not seeds:
         return text[:budget] + "…", True
 


### PR DESCRIPTION
Two efficiency wins from #716, both **proven output-invariant** (byte-identical search results — id, score, **snippet text**, full_chars — across plain / multi-expand / metadata-filter / RM3 / context-window query shapes) and with `test_parity.py` (JS↔Python) green.

### Win 3 — drop the redundant `df` map from `index.json`
`build_lexkb.js` emitted both `df` and `postings`, but `df[t]` is always `postings[t].length`. Now only `postings` is emitted; `idf()` derives df on demand (`(this.postings[term] || []).length` / `len(self.postings.get(term, ()))`). The reader is **backward-compatible** — it ignores a `df` key if an older index still has one. Index keys go `{params, N, avgdl, doclen, df, postings}` → `{params, N, avgdl, doclen, postings}`.

Measured: **~4%** smaller `index.json` on a 20-term / 40-doc synthetic; the share grows with vocabulary size (many unique terms with short postings → the df map is proportionally larger). Smaller `.skill`, one less map to parse on searcher startup.

### Win 1 — sort only query-bearing sentences in the snippet path
`make_snippet` scored every sentence, sorted them all, then filtered to score > 0. It now drops zero-score sentences (filtered on the *rounded* value, matching the prior round-then-filter exactly) **before** sorting, so the sort is over the few matching sentences rather than every sentence of a whole-document chunk.

Honest scope: this is a **modest** win. The per-sentence tokenization is the real cost, and it's *irreducible* while preserving byte-identity — safely skipping it would need a pre-filter whose token-equivalence matches the `/[\p{L}\p{N}_]+/gu` tokenizer identically across both JS and Python on every unicode edge case, which isn't worth the parity risk. So this ships only the provably-identical sort-saving, not the larger "skip tokenization" idea from the issue.

### Propagation
The browser SPA (`kb-packer.html`) is regenerated from these via the `build_packer.py` pipeline in `oaustegard/claude-workspace` `experiments/kb-packer-web/` — re-vendored and rebuilt, with the github.io deploy following **after this merges** so the live SPA's bundled searchers stay in sync with canonical (`check_sync.py` Edge 1).

---
_Generated by [Claude Code](https://claude.ai/code)_