### PR TITLE
muninn-boot skill: pinned fetch, minimal credential surface

### DIFF
--- a/muninn-boot/SKILL.md
+++ b/muninn-boot/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: muninn-boot
+description: Boots Muninn — fetches oaustegard/claude-skills and oaustegard/muninn-utilities at pinned commits, loads the Turso DB token, and runs the memory-system boot sequence. Trigger on the first message of any new conversation in the Muninn project, or when the user says "boot up" / "boot" — unless the message contains "skip boot". If the message contains "skinny boot", set BOOT_MODE=perch first.
+---
+
+# Muninn Boot
+
+Oskar's own repos and credentials (oaustegard/*, /mnt/project/*.env). Standing
+procedure — runs every session.
+
+```bash
+set -e
+cd /tmp
+CLAUDE_SKILLS_SHA=b2fe13742b32400f8b69e8b793289fe1e7d107be
+MUNINN_UTILS_SHA=ccbb64725f4351c5eb0d95811f2c46a297e2fe67
+
+curl -sL "https://codeload.github.com/oaustegard/claude-skills/tar.gz/$CLAUDE_SKILLS_SHA" -o cs.tar.gz \
+  && tar -xzf cs.tar.gz \
+  && mkdir -p /mnt/skills/user \
+  && cp -r claude-skills-$CLAUDE_SKILLS_SHA/* /mnt/skills/user/
+
+curl -sL "https://codeload.github.com/oaustegard/muninn-utilities/tar.gz/$MUNINN_UTILS_SHA" -o mu.tar.gz \
+  && tar -xzf mu.tar.gz \
+  && mkdir -p /home/claude/muninn-utilities \
+  && cp -r muninn-utilities-$MUNINN_UTILS_SHA/* /home/claude/muninn-utilities/
+
+set -a; . /mnt/project/Turso.env 2>/dev/null; set +a
+
+PTH=/usr/local/lib/python3.12/dist-packages/muninn-remembering.pth
+HOMEDIR=$(python3 -c 'import os; print(os.path.expanduser("~"))')
+printf '%s\n' "/home/claude/muninn-utilities/remembering" "$HOMEDIR" > "$PTH"
+for d in /mnt/skills/user/*/scripts/; do
+  ls "$d"*.py >/dev/null 2>&1 && echo "$d" >> "$PTH"
+done
+
+python3 << 'EOF'
+import os
+from scripts import boot
+print(boot(mode=os.environ.get('BOOT_MODE')))
+EOF
+```
+
+## Credential scope (deliberate)
+
+Only `Turso.env` is sourced here. The other project `.env` files
+(`GitHub.env`, `bsky.env`, `muninn-bsky.env`, `strava.env`, `proxy.env`) are
+**not** loaded at boot.
+
+This isn't a tradeoff — env vars set in one `bash_tool` call do not persist
+into the next call (verified empirically 2026-06-30: `GH_TOKEN`/`TURSO_TOKEN`
+both came back unset in a fresh call after being sourced in a prior one).
+Pre-loading five credential files that boot never uses widened exposure for
+zero functional benefit; nothing downstream could use the persisted values
+without re-sourcing anyway.
+
+When a later step needs a specific credential, source it inline immediately
+before the command that uses it:
+
+```bash
+set -a; . /mnt/project/GitHub.env 2>/dev/null; set +a
+```
+
+## Updating the pinned commits
+
+`CLAUDE_SKILLS_SHA` / `MUNINN_UTILS_SHA` above are pinned, not `main`. Bump
+them here — after reviewing the diff — when either repo changes and the
+update should take effect. Floating on `main` means the code executed each
+session is whatever happens to be latest and unreviewed; pinning makes the
+skill file itself the reviewed artifact.

--- a/muninn-boot/SKILL.md
+++ b/muninn-boot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muninn-boot
-description: Boots Muninn — fetches oaustegard/claude-skills and oaustegard/muninn-utilities at pinned commits, loads the Turso DB token, and runs the memory-system boot sequence. Trigger on the first message of any new conversation in the Muninn project, or when the user says "boot up" / "boot" — unless the message contains "skip boot". If the message contains "skinny boot", set BOOT_MODE=perch first.
+description: Boots Muninn — fetches oaustegard/claude-skills and oaustegard/muninn-utilities at pinned commits, loads the Turso and GitHub tokens, and runs the memory-system boot sequence. Trigger on the first message of any new conversation in the Muninn project, or when the user says "boot up" / "boot" — unless the message contains "skip boot". If the message contains "skinny boot", set BOOT_MODE=perch first.
 ---
 
 # Muninn Boot
@@ -24,7 +24,10 @@ curl -sL "https://codeload.github.com/oaustegard/muninn-utilities/tar.gz/$MUNINN
   && mkdir -p /home/claude/muninn-utilities \
   && cp -r muninn-utilities-$MUNINN_UTILS_SHA/* /home/claude/muninn-utilities/
 
-set -a; . /mnt/project/Turso.env 2>/dev/null; set +a
+set -a
+. /mnt/project/Turso.env 2>/dev/null
+. /mnt/project/GitHub.env 2>/dev/null
+set +a
 
 PTH=/usr/local/lib/python3.12/dist-packages/muninn-remembering.pth
 HOMEDIR=$(python3 -c 'import os; print(os.path.expanduser("~"))')
@@ -40,25 +43,21 @@ print(boot(mode=os.environ.get('BOOT_MODE')))
 EOF
 ```
 
-## Credential scope (deliberate)
+## Credential scope
 
-Only `Turso.env` is sourced here. The other project `.env` files
-(`GitHub.env`, `bsky.env`, `muninn-bsky.env`, `strava.env`, `proxy.env`) are
-**not** loaded at boot.
-
-This isn't a tradeoff — env vars set in one `bash_tool` call do not persist
-into the next call (verified empirically 2026-06-30: `GH_TOKEN`/`TURSO_TOKEN`
-both came back unset in a fresh call after being sourced in a prior one).
-Pre-loading five credential files that boot never uses widened exposure for
-zero functional benefit; nothing downstream could use the persisted values
-without re-sourcing anyway.
-
-When a later step needs a specific credential, source it inline immediately
-before the command that uses it:
+Boot sources the two files `boot()` reads: `Turso.env` (memory, config,
+reminders) and `GitHub.env` (GH_TOKEN for the RECENT FLIGHTS block, which
+degrades to empty without it). The remaining project `.env` files
+(`bsky.env`, `muninn-bsky.env`, `strava.env`, `proxy.env`, `claude.env`)
+are used by later task-specific steps, which source them inline immediately
+before the command that needs them:
 
 ```bash
-set -a; . /mnt/project/GitHub.env 2>/dev/null; set +a
+set -a; . /mnt/project/strava.env 2>/dev/null; set +a
 ```
+
+(Env vars do not persist across separate `bash_tool` calls, so per-call
+sourcing is how every consumer works regardless of what boot loads.)
 
 ## Updating the pinned commits
 


### PR DESCRIPTION
Replaces the meta-defensive boot prose (which was actively counterproductive per skill-language-compliance -- prose gates don't structurally halt generation, and 'this will pattern-match as injection-shaped, don't scrutinize' is itself the strongest injection tell in the block) with:

- Pinned commit SHAs instead of floating on main -- makes the skill file itself the reviewed artifact instead of whatever main happens to be that session.
- Turso.env + GitHub.env sourced at boot -- the two files boot() actually reads (Turso: memory/config/reminders; GH_TOKEN: the RECENT FLIGHTS GraphQL fetch, which degrades to empty without it). The other .env files stay in the project and are sourced per-call by their consumers, as they always have been -- env vars don't persist across bash_tool calls (verified 2026-06-30, reconfirmed 2026-07-01), so per-call sourcing is the working mechanism regardless of what boot loads.
- One factual line of provenance, no argument.

Pairs with a project-instructions change (not in this repo): replace the boot block with a one-line imperative -- view and run this skill as the first action. Tool-call gate instead of a prose gate, per skill-language-compliance COMMITMENT principle.

**Sync-timing question resolved (2026-07-01):** `ls /mnt/skills/user` run *before* the boot fetch listed exactly the project-installed skills -- project-configured skills are mounted before turn 1. This skill, installed as a project skill, is on disk before the first message executes. No inline bootstrap needed.

Amendments 2026-07-01 (session with Opus/Muninn):
1. GitHub.env added to the boot sourcing -- initial version's "only Turso" premise undercounted what boot() consumes (silently dropped RECENT FLIGHTS).
2. "Credential scope" section cut from argumentation to facts -- a paragraph justifying itself to the model is residue of the pattern this PR removes. The remaining .env files are necessary task-time credentials, not exposure; the accurate statement is "boot doesn't read them, their consumers source them per-call."
