### PR TITLE
container-layer: fix ARG_MAX crash building large snapshot tarballs

### DIFF
--- a/container-layer/scripts/layer_cache.py
+++ b/container-layer/scripts/layer_cache.py
@@ -209,12 +209,25 @@ def build_and_push(
     
     tarball = "/tmp/_layer_build.tar.gz"
     
-    # Build tarball with absolute paths (rooted at /)
-    paths_str = " ".join(f'"{p}"' for p in existing)
-    cmd = f'tar -czf "{tarball}" {paths_str} 2>&1'
-    
+    # Build tarball with absolute paths (rooted at /). Feed the path list to
+    # tar via a NUL-delimited -T file rather than the command line: a large
+    # snapshot (thousands of individual files) overflows the single argv string
+    # passed to `/bin/sh -c`, raising OSError [Errno 7] "Argument list too long"
+    # at exec — which aborts the layer build entirely. -T reads names from a
+    # file, so argv stays tiny regardless of how many paths are snapshotted.
+    # --null pairs with NUL separators so paths with spaces need no quoting.
+    filelist = "/tmp/_layer_build_files.txt"
+    with open(filelist, "wb") as fh:
+        fh.write(b"\0".join(os.fsencode(p) for p in existing))
+    cmd = f'tar -czf "{tarball}" --null -T "{filelist}" 2>&1'
+
     result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=300)
-    
+
+    try:
+        os.remove(filelist)
+    except OSError:
+        pass
+
     if not os.path.exists(tarball):
         print(f"  Tarball creation failed: {result.stderr.strip()}")
         return


### PR DESCRIPTION
## The bug

`build_and_push` in `container-layer/scripts/layer_cache.py` builds the layer tarball by joining every snapshot path into a single command string:

```python
paths_str = " ".join(f'"{p}"' for p in existing)
cmd = f'tar -czf "{tarball}" {paths_str} 2>&1'
result = subprocess.run(cmd, shell=True, ...)
```

When a layer snapshots many individual files (e.g. a `torch`/`torchvision` layer with thousands of entries), that single argv string handed to `/bin/sh -c` overflows the kernel's `MAX_ARG_STRLEN` (~128 KiB per argument), and `exec` raises:

```
OSError: [Errno 7] Argument list too long: '/bin/sh'
```

The whole layer build aborts.

## The fix

Write the paths to a NUL-delimited file and let `tar` read them via `--null -T <file>`. argv stays tiny regardless of how many paths are snapshotted; `--null` means paths with spaces need no quoting. The temp filelist is cleaned up after the run.

## Verification

Reproduced against a 5000-file synthetic snapshot (576 KiB command string, well over the 128 KiB limit):

```
files: 5000  cmd-string length: 576 KiB (MAX_ARG_STRLEN is 128 KiB)
OLD: FAILED as expected → OSError [Errno 7] Argument list too long
NEW: rc=0 tarball exists: True  files archived: 5000/5000
NEW: PASS
```

The old command-line form raises `Errno 7`; the `-T` form archives all 5000 files with `rc=0`. `ast.parse` on the edited module passes.

## Why this matters downstream

This crash aborted a consumer's cold-start boot mid-`compose` (the `fuse` layer never cached), and because the consumer's boot ran under `set -e`, the failure cascaded into a fully degraded session — no skills, no memory mount, no identity. Fixing it here lets cold layer builds actually cache instead of crashing. (The consumer is separately hardening its boot to treat a compose failure as non-fatal.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014L6rGtXBGUW4PrGjwZUYZc)_