### PR TITLE
Add agent-routing skill; update down-skilling with 2026-07-15 Haiku 4.5 calibration

### DIFF
--- a/agent-routing/SKILL.md
+++ b/agent-routing/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: agent-routing
+description: Decide which model (Haiku/Sonnet/Opus) and effort level each subagent gets, when to cascade cheap-first behind a verifier, and how to run improvement loops safely (evaluator-as-selector, stop on regression). Use when spawning subagents via the Agent or Workflow tools, when fanning out more than a handful of agents, or when the user asks which model or effort a task should route to. Grounded in measured calibration data (references/calibration-2026-07-15.md), not vibes.
+compatibility: Designed for Claude Code / Claude Code on the Web — assumes an orchestrator with Agent/Workflow subagent tools exposing per-call model and effort options. Not applicable to claude.ai chat use.
+metadata:
+  author: Oskar Austegard and Claude (Fable 5)
+  version: "1.0.0"
+---
+
+# Agent Routing — model + effort selection for subagents
+
+One question decides most routing: **is the task mechanically checkable, or does
+it require judgment?** Checkable tasks go to Haiku with a verifier. Judgment
+tasks go up-tier. Everything else here is refinement of that split.
+
+For turning a judgment-shaped task INTO a Haiku-executable one (explicit
+procedures, n-shot examples), use the sibling `down-skilling` skill; this skill
+decides the routing, that one engineers the prompt.
+
+## Priors that measured data overturned (2026-07-15)
+
+- **Haiku 4.5 does not need help on closed-form work.** 240/240 across nested
+  mod-23 arithmetic (16-leaf trees), 30-hop function chains, 25-op state
+  tracking, trap-laden word math, and 5-constraint sentence generation
+  (including a lipogram) — even with chain-of-thought suppressed and
+  `effort: 'low'`. Do not route these up-tier "to be safe"; the safety is
+  imaginary and the cost is 3–5×.
+- **Bigger is not automatically more precise.** In the same battery Sonnet at
+  low effort went 17/20, miscounting exact-word-count constraints twice and
+  breaking a no-letter-'e' constraint once. Small n — treat as "no evidence of
+  up-tier benefit," not "Sonnet is worse" — but the burden of proof now sits on
+  routing *up*, not down.
+- **Effort didn't move Haiku on mechanical tasks** (low == high == 100%).
+  Default subagents to `effort: 'low'` for anything checkable; spend effort,
+  not parameters, only where reasoning depth demonstrably falls short.
+- **Blind self-improvement loops are identity-or-drift.** Re-running a fixed
+  prompt on a correct answer returned the identity in 96/96 loop-pairs; the
+  one task whose output did change (a 5-7-5 haiku) got *worse* on loop 2 and
+  froze on the broken text for all remaining loops. Loops only pay when an
+  out-of-band evaluator selects among iterations.
+
+## Routing table
+
+| Task shape | Model | Effort | Verify with |
+|---|---|---|---|
+| Extraction, classification, format transforms, schema-bound output | `haiku` | `low` | schema / spot-check |
+| Closed-form computation, state tracking, multi-hop lookup | `haiku` | `low` | deterministic check |
+| Constraint-bound generation (exact counts, required tokens, lipograms) | `haiku` | `low` | mechanical checker |
+| Bulk scans/greps, per-file summaries, fan-out reads | `haiku` | `low` | sample audit |
+| Code edits with tests available | `haiku` first | `low`–`medium` | run the tests |
+| Judging / scoring another model's output | `sonnet`+ | `medium` | — (judge ≠ worker) |
+| Ambiguity resolution, novel synthesis, architecture, taste | `sonnet`/`opus` | `high` | human or panel |
+| Long-horizon multi-step agentic work, cross-file reasoning | `sonnet`/`opus` | `high`/`xhigh` | milestone checks |
+
+## The cascade (default composition)
+
+When a cheap verifier exists, never choose between Haiku and Sonnet — compose:
+
+```
+result = haiku(task, effort=low)
+if verify(result) fails:  result = sonnet(task)      # escalate on evidence
+if verify(result) fails:  result = opus(task)         # rare
+```
+
+Pricing (per MTok, 2026-07): Haiku $1/$5 · Sonnet $3/$15 · Opus 4.8 $5/$25.
+Expected cascade cost ≈ `c_haiku + p_fail × c_sonnet`, so with a reliable
+near-free verifier the cascade beats Sonnet-direct whenever Haiku's failure
+rate is **below ~2/3**, and beats Opus-direct below ~4/5. Every checkable task
+measured so far has Haiku failure ≈ 0 — the cascade is nearly pure savings.
+No verifier ⇒ no cascade: route by the table instead, because silent Haiku
+errors compound downstream.
+
+## Loop discipline (evaluator as exit gate)
+
+Derived from a Looped-Mamba replication (arXiv 2607.10110, run 2026-07-15 with
+Haiku subagents as the shared recurrent block): an LLM call already unrolls its
+own depth as chain-of-thought, so re-applying the same prompt to its own output
+is the identity at best and regression-then-freeze at worst.
+
+1. **Never blind-loop.** Only loop with an out-of-band evaluator scoring every
+   iteration — ground truth, mechanical checker, or an up-tier judge.
+2. **Select, don't trust the last.** `final = argmax_r eval(answer_r)` — never
+   ship iteration N just because it's newest.
+3. **Stop on first regression.** If `eval(r) < eval(r-1)`, stop; empirically
+   loops froze on the degraded output rather than recovering, so the
+   local-minimum risk of stopping early is smaller than the drift risk of
+   continuing.
+4. **Loop for diversity, not depth.** Vary the prompt/angle per iteration if
+   you want the loop to explore; identical re-application converges instantly.
+5. **"Improve this" with no headroom is the danger zone.** Asking a model to
+   improve an already-good answer pressures it to change something; without a
+   selector that change ships. With one, it's harmless.
+
+## Judge rules
+
+- Judge model ≠ worker model; judge at least one tier up (Sonnet judging
+  Haiku, Opus judging Sonnet). Same-model self-assessment was not tested here —
+  don't assume it works.
+- Prefer mechanical checkers over judges wherever a spec can be executed
+  (word counts, schemas, tests, regex). They're free, deterministic, and the
+  calibration used zero judge tokens.
+- Judges are for rubric quality, not arithmetic — don't ask Sonnet to verify a
+  sum a Python one-liner can check.
+
+## Escalation triggers (route up despite the table)
+
+- The verifier fails twice at the same tier.
+- The task requires weighing trade-offs with no checkable ground truth.
+- Output will be shipped verbatim to a human without review.
+- The subagent must plan its own multi-step tool strategy over many turns.
+
+## Known unknowns (recalibrate when these bite)
+
+- Boundary location: no deterministic task has made Haiku fail yet, so the
+  cliff is *somewhere past* this battery — probe with harder instances before
+  trusting Haiku on a genuinely novel task family.
+- Multi-turn agentic tool use was not calibrated — the table's up-tier rows
+  there are prior, not measurement.
+- Model versions move: re-run the battery in
+  [references/calibration-2026-07-15.md](references/calibration-2026-07-15.md)
+  when Haiku or Sonnet rev bumps.

--- a/agent-routing/references/calibration-2026-07-15.md
+++ b/agent-routing/references/calibration-2026-07-15.md
@@ -1,0 +1,78 @@
+# Calibration evidence — 2026-07-15
+
+Data behind the routing heuristics in SKILL.md. Collected in one CCotw session
+(Fable 5 orchestrator, Workflow tool, session `bf6d02ee`), ~12.3M subagent
+tokens total across four workflow runs, zero agent errors. All numeric grading
+was deterministic (Python scorers against generated ground truth); the only
+judge tokens were Sonnet scoring open-ended text in Experiment 1.
+
+## Experiment 1 — Looped Haiku subagents (Looped-Mamba analog, arXiv 2607.10110)
+
+Design: `answer_r = Haiku(task, answer_{r-1})`, R=5, out-of-band eval per loop.
+
+| Task family | Instances × loops | Result |
+|---|---|---|
+| Nested mod-23 arithmetic, depth-3 trees | 5 × 5 | 100% at r=1, flat, 0 churn |
+| p-hop function chains (n=7, 8–12 hops) | 5 × 5 | 100% at r=1, flat, 0 churn |
+| Harder: depth-4 trees (16 leaves) | 8 × 5 | 100% at r=1, flat, 0 churn |
+| Harder: n=12 chains, 20–30 hops | 8 × 5 | 100% at r=1, flat, 0 churn |
+| Answer-only control (CoT suppressed, effort=low), depth-4 trees | 8 × 5 | still 100% at r=1, 0 churn |
+| Open-ended (Sonnet judge /10): prime one-liner | 1 × 5 | [10,10,10,10,10] |
+| Open-ended: sky-blue explanation | 1 × 5 | [9,9,9,9,9] |
+| Open-ended: 5-7-5 haiku | 1 × 5 | **[9,3,3,3,3]** — loop 2 broke the middle line to 8 syllables, loops 3–5 froze on identical broken text |
+
+Interpretation: a single LLM call spends variable internal compute (CoT), so
+`answer_1` is already a fixed point on checkable tasks — the paper's
+fixed-compute-per-step premise doesn't hold for LLM subagents. The exit-gate
+idea *does* transfer: the evaluator-as-selector recovers the loop-1 haiku and
+skips wasted loops elsewhere. Answer churn across all deterministic loop-pairs:
+0/96 flips.
+
+## Experiment 2 — Single-shot routing calibration (60 agents)
+
+20 tasks × 3 configs, single shot, deterministic local scoring:
+
+Tasks: 9 constraint-stack sentences (K=3/4/5 simultaneous constraints: exact
+word count, begin-word, include-word, end-word, no letter 'e'), 4 trap-laden
+word-math problems (distractor numbers), 3 state-tracking problems (3 boxes,
+25 operations), 4 constraint-preserving revisions (exact N words, fixed
+first/last word, ≥2 changes).
+
+| Config | stack | trap | state | revision | total |
+|---|---|---|---|---|---|
+| haiku, effort=low | 9/9 | 4/4 | 3/3 | 4/4 | **20/20** |
+| haiku, effort=high | 9/9 | 4/4 | 3/3 | 4/4 | **20/20** |
+| sonnet, effort=low | 6/9 | 4/4 | 3/3 | 4/4 | **17/20** |
+
+Sonnet-low failures (hand-verified, real):
+- `stack-K3-1`: 15 words where exactly 14 required
+- `stack-K4-0`: 13 words where exactly 12 required
+- `stack-K5-0`: used "quiet" in a no-letter-'e' sentence
+
+Notes:
+- n=20/config: 17 vs 20 is not statistically significant. The defensible claim
+  is "no evidence of up-tier benefit on mechanical tasks," which is enough to
+  invert the default (burden of proof on routing up).
+- Haiku's K5 lipogram outputs were flawless, e.g. "Our distant stars hang
+  bright and high throughout dark night" (10 words, begins "our", includes
+  "stars", ends "night", zero e's).
+- Effort had no measurable effect on Haiku here (both 100%) — consistent with
+  Experiment 1's answer-only/effort-low control also scoring 100%.
+
+## Pricing basis (2026-07, per MTok in/out)
+
+Haiku 4.5 $1/$5 · Sonnet 5 $3/$15 ($2/$10 intro through 2026-08-31) ·
+Opus 4.8 $5/$25. Cascade break-even: Haiku-first beats Sonnet-direct while
+p_fail(Haiku) < 1 − c_H/c_S ≈ 2/3; beats Opus-direct while < 4/5 (verifier
+assumed near-free, which held — all Experiment 2 scoring was local Python).
+
+## What has NOT been measured
+
+- A deterministic task family where Haiku actually fails (the cliff).
+- Multi-turn agentic tool-use quality per tier.
+- Same-model self-judging reliability.
+- Haiku at higher K (>5 simultaneous constraints) or longer state chains.
+
+Re-run: generators + scorer live in the session scratchpad pattern
+(`gen.py`/`gen2.py`/`gen3.py`, `score.py`); regenerate with new seeds and a
+current model rev before trusting the table across model versions.

--- a/down-skilling/CHANGELOG.md
+++ b/down-skilling/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `down-skilling` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3.0] - 2026-07-15
+
+### Added
+
+- **"Before Distilling: Check Whether the Task Needs It"** triage section.
+  A 2026-07-15 empirical calibration (300 Haiku 4.5 calls; evidence in the
+  `agent-routing` skill's `references/calibration-2026-07-15.md`) measured
+  Haiku 4.5 at 240/240 on mechanically checkable work — nested arithmetic,
+  30-hop chains, 25-op state tracking, trap math, 5-constraint generation —
+  at low effort, beating Sonnet-low (17/20) on the same battery. For
+  checkable outputs, a minimal prompt + deterministic verifier +
+  escalate-on-fail now beats example-heavy distillation; distill fully only
+  for judgment-shaped outputs.
+- **Iteration warning**: blind self-improvement loops measured as
+  identity-or-drift (0/96 changes on correct answers; regression-then-freeze
+  on the one output that did change). Loop only with an out-of-band scorer,
+  keep argmax, stop on first regression.
+
+### Changed
+
+- **Economics** section repriced to current models: Haiku 4.5 $1/$5,
+  Opus 4.8 $5/$25 per MTok (5× both sides; was stated as ~6× on stale
+  $0.80/$4.00 Haiku pricing).
+- **gaps/counting-enumeration.md**: Haiku 4.5 measured 13/13 on exact
+  word-count generation at N=10–14 under stacked constraints (Sonnet-low
+  missed twice); decisive factor is defining the unit of counting in the
+  prompt. Mitigations rescoped to large N and count-inside-long-output.
+- **gaps/multi-hop-reasoning.md**: split hop types — explicit chains
+  (lookups, state updates) measured 100% to 30 hops; the 2-3-hop caution
+  now scoped to latent inference chains, which remain unmeasured.
+
 ## [1.2.0] - 2026-05-26
 
 ### Added

--- a/down-skilling/SKILL.md
+++ b/down-skilling/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   a smaller model with high reliability.
 metadata:
   author: Oskar Austegard and Opus
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # Down-Skilling: Opus → Haiku Distillation
@@ -30,13 +30,14 @@ needs stated explicitly.
 
 ## Economics: Why Examples Are Free
 
-Opus input costs ~6× Haiku input. A task that costs $1.00 on Opus costs
-~$0.17 on Haiku — but only if Haiku gets it right on the first try.
-One retry wipes the savings; two retries makes Haiku more expensive.
+Opus 4.8 costs 5× Haiku 4.5 on both sides ($5/$25 vs $1/$5 per MTok;
+2026-07 pricing). A task that costs $1.00 on Opus costs ~$0.20 on Haiku —
+but only if Haiku gets it right on the first try. One retry halves the
+savings; a few retries makes Haiku more expensive.
 
 **The math that matters:**
-- Input tokens are cheap (Haiku: $0.80/MTok input vs $4.00/MTok output)
-- Adding 2,000 tokens of examples costs ~$0.0016 per call
+- Input tokens are cheap (Haiku 4.5: $1.00/MTok input vs $5.00/MTok output)
+- Adding 2,000 tokens of examples costs ~$0.002 per call
 - A single failed-then-retried call costs ~$0.008+ in wasted output
 - **Examples pay for themselves if they prevent even 1-in-5 retries**
 
@@ -51,6 +52,44 @@ One retry wipes the savings; two retries makes Haiku more expensive.
 **Bottom line:** Every example that prevents a Haiku misfire saves 5-25×
 its input cost in wasted output tokens. Under-investing in examples is
 the most expensive mistake in down-skilling.
+
+## Before Distilling: Check Whether the Task Needs It (2026-07 calibration)
+
+This skill's gap catalog was originally derived from model-card priors.
+A 2026-07-15 empirical calibration (300 measured Haiku 4.5 calls; data in
+the `agent-routing` skill's `references/calibration-2026-07-15.md`) found
+Haiku 4.5 substantially stronger than those priors on **mechanically
+checkable** work: 240/240 on nested modular arithmetic (16-leaf expression
+trees), 30-hop function chains, 25-operation state tracking, trap-laden
+word math, and 5-simultaneous-constraint sentence generation (exact word
+counts, required/forbidden tokens, a lipogram) — at `effort: low`, and in
+one control with chain-of-thought suppressed entirely. On the same battery
+Sonnet at low effort scored 17/20, missing exact-count constraints Haiku
+satisfied.
+
+**Triage before investing in a full distillation:**
+
+1. **Output mechanically checkable** (schema validates, tests run, counts
+   count, regex matches)? → A minimal prompt + a deterministic verifier +
+   retry-or-escalate-on-fail is cheaper and more reliable than an
+   example-heavy prompt with no verifier. Spend your effort writing the
+   checker, not the examples. Precision constraints ("exactly N words")
+   held reliably when the prompt defined the counting rule explicitly
+   ("a word = any run of letters or apostrophes") — definitional
+   precision, not scaffolding volume, did the work.
+2. **Output requires judgment** (tone, relevance, quality, ambiguity
+   resolution)? → This is what the rest of this skill is for. Distill
+   fully: procedures, rubrics, n-shot examples.
+3. **Mixed?** → Split the task. Route the checkable part per (1); distill
+   only the judgment part.
+
+**Iteration warning (measured, same calibration):** never ask Haiku to
+blindly re-improve its own output in a loop. On correct answers,
+re-application returned the identity (0 changes in 96 loop-pairs); on the
+one output that did change, quality *regressed* on the second pass and
+then froze on the degraded text for all remaining passes. If you iterate,
+score every iteration with an out-of-band checker or judge, keep
+`argmax`, and stop at the first regression.
 
 ## Activation
 

--- a/down-skilling/gaps/counting-enumeration.md
+++ b/down-skilling/gaps/counting-enumeration.md
@@ -3,10 +3,21 @@
 **Opus**: Counts items accurately. Generates exactly N items when asked.
 Tracks quantities across sections.
 
-**Haiku**: May produce N-1 or N+1 items when asked for exactly N.
-Counting errors increase with N > 5. May lose count in longer outputs.
+**Haiku**: Stronger than model-card priors suggested. Calibration
+(2026-07-15, Haiku 4.5): exact-word-count sentence generation hit the
+target 13/13 times at N = 10–14 — under up to four *additional*
+simultaneous constraints — while Sonnet at low effort missed twice on
+the same battery. The decisive factor was **definitional precision**:
+each prompt stated the counting rule explicitly ("a word = any run of
+letters or apostrophes"). Residual risk concentrates in large N (>15,
+unmeasured), counting inside long free-form outputs, and prompts that
+leave the unit of counting ambiguous.
 
-**Mitigation**: Structure output so counting is mechanical, not cognitive.
+**Mitigation**: Define the unit of counting exactly, in the prompt.
+Then, for larger N or count-inside-long-output tasks, structure output
+so counting is mechanical, not cognitive — and prefer a deterministic
+post-hoc checker (word counts are free to verify) over prompt
+scaffolding alone.
 
 For "generate exactly 5 items":
 ```

--- a/down-skilling/gaps/multi-hop-reasoning.md
+++ b/down-skilling/gaps/multi-hop-reasoning.md
@@ -3,10 +3,20 @@
 **Opus**: Chains 5+ reasoning steps naturally. Maintains coherence
 across long inference chains.
 
-**Haiku**: Reliable for 2-3 hops. Degrades at 4+. May skip intermediate
-steps or reach incorrect conclusions.
+**Haiku**: Split by hop type. **Explicit chains** — where each hop is a
+stated lookup or state update — measured far stronger than model-card
+priors: calibration (2026-07-15, Haiku 4.5) scored 100% on 30-hop
+function iteration, 25-operation box/state tracking, and 16-leaf nested
+arithmetic, even at low effort and in one control with written
+chain-of-thought suppressed. The 2-3-hop caution applies to **latent
+inference chains** — hops the model must construct itself from implicit
+relationships (cause→effect→consequence, unstated intermediate
+conclusions), which remain unmeasured and should be treated per the
+original prior.
 
-**Mitigation**: Decompose into sequential sub-tasks with explicit outputs.
+**Mitigation** (for latent chains): Decompose into sequential sub-tasks
+with explicit outputs — this converts a latent chain into the explicit
+kind Haiku is measured-good at.
 
 ```
 Step 1: Extract [A] from the input.
@@ -17,6 +27,8 @@ Step 3: Given [B], select [C] from [enumerated options].
 Or bound reasoning depth: "Think in exactly 3 steps, writing each step
 before the next."
 
-Never rely on Haiku to chain more than 3 inferences silently. If the
-task requires 4+ hops, split into separate prompts or make intermediate
-results explicit in the process steps.
+Never rely on Haiku to chain more than 3 *latent* inferences silently.
+If the task requires 4+ such hops, split into separate prompts or make
+intermediate results explicit in the process steps. Explicitly-stated
+chains (lookups, state updates) need no such split — measured reliable
+to 30 hops.


### PR DESCRIPTION
## What

Two related changes, both grounded in a 2026-07-15 empirical calibration (300 measured Haiku 4.5 subagent calls, deterministic scoring; evidence tables ship in `agent-routing/references/calibration-2026-07-15.md`).

### 1. New skill: `agent-routing` (v1.0.0)

Model + effort routing for subagent orchestration. Moved here from [claude-workspace-fuse#42](https://github.com/oaustegard/claude-workspace-fuse/pull/42) — a general skill belongs in claude-skills, not the hub. Frontmatter follows the [agentskills.io spec](https://agentskills.io/specification.md), with `compatibility` explicitly scoping it to Claude Code (it assumes Agent/Workflow subagent tools with per-call `model`/`effort`; not applicable to claude.ai chat).

Core content: a routing table keyed on task checkability; a Haiku-first **cascade** (Haiku + verifier, escalate on verify-failure — beats Sonnet-direct while Haiku's failure rate < ~2/3 at current pricing); loop discipline from a Looped-Mamba (arXiv 2607.10110) replication (blind self-loops are identity-or-drift; evaluator-as-selector; stop on first regression); judge rules; explicit known-unknowns.

Key measurements: Haiku 4.5 went **240/240** on closed-form work (16-leaf mod-23 trees, 30-hop chains, 25-op state tracking, trap math, 5-constraint generation incl. a lipogram) at `effort: low`, and **20/20 vs Sonnet-low's 17/20** on the calibration battery (Sonnet miscounted exact word lengths twice and broke a no-'e' constraint; hand-verified).

### 2. `down-skilling` 1.2.0 → 1.3.0

The skill was written from model-card priors; the calibration contradicts two of its gap files and its pricing:

- **New triage gate** ("Before Distilling: Check Whether the Task Needs It"): mechanically checkable outputs are better served by a minimal prompt + deterministic verifier + escalate-on-fail than by example-heavy distillation — reserve full distillation for judgment-shaped outputs. Plus an **iteration warning** (0/96 changes when re-improving correct answers; regression-then-freeze on the one output that did change).
- **Economics repriced**: Haiku 4.5 $1/$5, Opus 4.8 $5/$25 per MTok (5× both sides; previous text used stale $0.80/$4.00 Haiku pricing and "~6×").
- **`gaps/counting-enumeration.md`**: exact-count generation measured 13/13 at N=10–14 under stacked constraints (better than Sonnet-low); the decisive factor is defining the unit of counting in the prompt. Mitigations rescoped to large N / count-inside-long-output.
- **`gaps/multi-hop-reasoning.md`**: hop types split — *explicit* chains (lookups, state updates) measured 100% to 30 hops; the 2-3-hop caution is now scoped to *latent* inference chains, which remain unmeasured. The decomposition mitigation is reframed as converting latent chains into the explicit kind.

Unmeasured claims are labeled as priors throughout — nothing in the diff presents an assumption as a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sNZdwRJAfqdFq1Fkvataa

---
_Generated by [Claude Code](https://claude.ai/code/session_012sNZdwRJAfqdFq1Fkvataa)_