### PR TITLE
Add README.md to agent-routing and down-skilling

### DIFF
--- a/agent-routing/README.md
+++ b/agent-routing/README.md
@@ -1,0 +1,23 @@
+# agent-routing
+
+Decides which model (Haiku / Sonnet / Opus) and effort level a subagent
+should get, when to cascade cheap-first behind a verifier instead of
+picking one tier, and how to run improvement loops without them silently
+regressing. Use when spawning subagents via the Agent or Workflow tools —
+especially fan-outs of more than a handful — or when asked which model or
+effort a task should route to.
+
+Claude Code only — the `compatibility` field says so, and the skill's
+advice (per-call `model`/`effort`, Agent/Workflow subagents) doesn't apply
+to claude.ai chat.
+
+The headline finding: Haiku 4.5 went 240/240 on mechanically checkable
+work (nested arithmetic, multi-hop lookups, state tracking, trap math,
+constraint-stacked generation) at `effort: low`, while Sonnet at low
+effort missed 3/20 on the same battery. That inverts the usual default —
+route *down* first, escalate on verifier failure, not the reverse.
+
+Full routing table, cascade cost math, and loop discipline (evaluator as
+exit gate — never trust the last iteration blindly) live in
+**[SKILL.md](./SKILL.md)**. Raw evidence and re-run instructions in
+**[references/calibration-2026-07-15.md](./references/calibration-2026-07-15.md)**.

--- a/down-skilling/README.md
+++ b/down-skilling/README.md
@@ -1,0 +1,22 @@
+# down-skilling
+
+Distills Opus-level reasoning into explicit, procedural prompts with
+n-shot examples so Haiku (or Sonnet) can execute a task reliably. Use
+when the user says "down-skill", "distill for Haiku", or wants to
+delegate a task to a smaller model with high reliability.
+
+Before distilling anything, the skill now triages: if the task's output
+is mechanically checkable (schema validates, tests pass, a count is a
+count), a minimal prompt plus a deterministic verifier beats a
+heavy example-laden distillation — save the n-shot investment for
+outputs that genuinely need judgment. That triage step, the per-gap
+mitigations, and the pricing in the Economics section were all recalibrated
+against measured Haiku 4.5 data on 2026-07-15 (see `agent-routing`'s
+[calibration reference](../agent-routing/references/calibration-2026-07-15.md)) —
+several model-card-era priors turned out to understate Haiku, most notably
+on counting/enumeration and multi-hop reasoning over *explicit* chains.
+
+Full prompt architecture, the gap catalog (`gaps/`), worked
+before/after examples (`examples/`), and the self-check checklist live in
+**[SKILL.md](./SKILL.md)**. Version history in
+**[CHANGELOG.md](./CHANGELOG.md)**.


### PR DESCRIPTION
## What

Follow-up to #728 (merged), which landed both skills without READMEs. Adds `README.md` to `agent-routing/` and `down-skilling/`, matching the repo's existing convention (short pointer to `SKILL.md`/`CHANGELOG.md` rather than duplicating content — see e.g. `converting-files/README.md`, `creating-bookmarklets/README.md`).

Rebased onto current `main` since #728's branch was deleted on merge before this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sNZdwRJAfqdFq1Fkvataa

---
_Generated by [Claude Code](https://claude.ai/code/session_012sNZdwRJAfqdFq1Fkvataa)_