### PR TITLE
feat(tree-sitting): persistent scan-cache (0.7.0)

### DIFF
--- a/tree-sitting/CHANGELOG.md
+++ b/tree-sitting/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `tree-sitting` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.7.0] - 2026-07-16
+
+### Added
+
+- Persistent filesystem scan-cache: scans are cached to disk, keyed on fileset fingerprint (mtime + size of all candidate files, combined with skip-set and cache format version). Auto-invalidates when files change, are added, or removed. Atomic writes prevent corrupt cache files. Cache hits return byte-identical results vs. fresh parse. New flags: `--no-cache` (disable cache), `--rebuild-cache` (force rewrite). New env var: `TREESIT_CACHE_DIR` to relocate cache from system temp.
+
+### Changed
+
+- Workflow guidance: batched multi-query drills are now the default approach for structural exploration. Users should combine `find:`, `source:`, and `refs:` queries in a single invocation instead of separate calls. Added explicit note NOT to fall back to grep/sed for symbol structure lookups.
+
 ## [0.6.0] - 2026-05-17
 
 ### Other

--- a/tree-sitting/SKILL.md
+++ b/tree-sitting/SKILL.md
@@ -2,7 +2,7 @@
 name: tree-sitting
 description: AST-powered code navigation via tree-sitter. Auto-scans codebases and provides progressive-disclosure tree views with symbol search, source retrieval, and reference finding. Each invocation is self-contained — no cross-process state. Use when exploring unfamiliar repos, navigating code, or needing fast symbol lookup. Triggers on "map this codebase", "explore repo", "find symbol", "navigate code", "tree-sitter", or when starting work on an unfamiliar repository.
 metadata:
-  version: 0.6.0
+  version: 0.7.0
 ---
 
 # tree-sitting
@@ -78,7 +78,33 @@ Append after the repo path. Multiple queries per call.
 | `imports:FILE` | `imports:src/api.py` | Import list for a file |
 | `dir:PATH` | `dir:src/core` | Directory overview (engine format) |
 
+### Caching
+
+Scans are cached to disk, keyed on a fileset fingerprint (mtime + size of all
+files under root, combined with skip-set and cache format version). Repeat drills
+in a session skip re-parsing — results are byte-identical whether served from
+cache or fresh parse.
+
+Cache auto-invalidates when files change, are added, or removed. Use `--no-cache`
+to skip cache entirely (always parse), or `--rebuild-cache` to ignore existing
+cache and rewrite it. Set `TREESIT_CACHE_DIR` environment variable to relocate
+cache from the system temp directory.
+
 ### Workflow
+
+For structural drills ("what does this expose", "where is X", "who calls X"),
+**batch multiple queries in a single call**:
+
+```bash
+# Batch drills (default for exploration)
+treesit.py /repo 'find:Parser*' 'source:parse_input' 'refs:ParseState'
+```
+
+One scan, all results. Do not fall back to `grep` or `sed` for symbol lookups —
+the AST queries (`find:`, `source:`, `refs:`) provide accurate, fast symbol-aware
+results that text search cannot match.
+
+For iterative exploration:
 
 ```
 1. treesit.py /repo                           → orient: what dirs, how big
@@ -89,7 +115,7 @@ Append after the repo path. Multiple queries per call.
 ```
 
 Each call is self-contained. No need to "scan first, query later" —
-scan happens automatically every time (~700ms).
+scan happens automatically, and results are cached for subsequent calls (~700ms first scan).
 
 ## Usage: Direct Python (single invocation)
 

--- a/tree-sitting/scripts/engine.py
+++ b/tree-sitting/scripts/engine.py
@@ -7,6 +7,9 @@ Designed to be held in a long-lived process (MCP server) for fast queries.
 
 import os
 import fnmatch
+import hashlib
+import json
+import tempfile
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional
@@ -101,6 +104,40 @@ DEFAULT_SKIP = {
     'vendor', 'coverage', '.eggs', '*.egg-info',
 }
 
+# Cache format version — bump this to invalidate all existing caches
+CACHE_FORMAT_VERSION = 1
+
+
+def cache_path_for(root: str) -> Path:
+    """Determine deterministic cache file path for a root directory.
+
+    Honors TREESIT_CACHE_DIR environment variable if set, otherwise uses
+    system temp directory. Filename derived from SHA256 of resolved abspath.
+
+    Args:
+        root: Source root path (may contain symlinks or be relative)
+
+    Returns:
+        pathlib.Path to cache file (may not exist)
+    """
+    # Resolve to absolute canonical path
+    root_resolved = str(Path(root).resolve())
+
+    # Determine cache directory
+    cache_dir_env = os.environ.get('TREESIT_CACHE_DIR')
+    if cache_dir_env:
+        cache_dir = Path(cache_dir_env)
+    else:
+        cache_dir = Path(tempfile.gettempdir()) / 'treesit-cache'
+
+    # Ensure cache directory exists
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Derive filename from SHA256 of resolved path
+    cache_hash = hashlib.sha256(root_resolved.encode()).hexdigest()
+
+    return cache_dir / f'{cache_hash}.json'
+
 
 @dataclass
 class Symbol:
@@ -128,6 +165,28 @@ class Symbol:
         if include_children and self.children:
             d['children'] = [c.to_dict(include_children=False) for c in self.children]
         return d
+
+    @staticmethod
+    def from_dict(d: dict) -> 'Symbol':
+        """Deserialize a Symbol from a dict (from cache JSON).
+
+        Reconstructs one level of children (to_dict stores one level).
+        """
+        children = []
+        if 'children' in d and d['children']:
+            for child_dict in d['children']:
+                children.append(Symbol.from_dict(child_dict))
+
+        return Symbol(
+            name=d['name'],
+            kind=d['kind'],
+            file=d['file'],
+            line=d['line'],
+            end_line=d['end_line'],
+            signature=d.get('signature'),
+            doc=d.get('doc'),
+            children=children,
+        )
 
     def format_oneline(self) -> str:
         """Format as a concise one-line string."""
@@ -1256,8 +1315,8 @@ def extract_imports(tree, source: bytes, lang: str) -> list[str]:
 class FileEntry:
     path: str       # relative path
     lang: str
-    source: bytes
-    tree: object    # tree-sitter Tree
+    source: Optional[bytes]  # Can be None for lazy loading from cache
+    tree: Optional[object]   # tree-sitter Tree; can be None for lazy loading
     symbols: list[Symbol]
     imports: list[str]
 
@@ -1274,43 +1333,124 @@ class CodeCache:
     def is_loaded(self) -> bool:
         return self.root is not None and len(self.files) > 0
 
-    def scan(self, root: str, skip: set[str] | None = None) -> dict:
-        """Parse all recognized files under root. Returns stats."""
+    def _fingerprint(self, root: str, skip: set[str] | None = None) -> str:
+        """Compute a stable fingerprint of the scanned tree.
+
+        Hash over sorted (relpath, size, mtime_ns) for all candidate files,
+        combined with CACHE_FORMAT_VERSION and sorted(skip).
+
+        Args:
+            root: Root directory path
+            skip: Set of directory names to skip (uses DEFAULT_SKIP if None)
+
+        Returns:
+            Hex string fingerprint
+        """
+        root_path = Path(root).resolve()
+        skip_dirs = skip if skip is not None else DEFAULT_SKIP
+
+        # Collect all candidate files: (relpath, size, mtime_ns)
+        file_stats = []
+
+        for dirpath, dirnames, filenames in os.walk(root_path):
+            # Prune directories to skip
+            dirnames[:] = [d for d in dirnames
+                          if d not in skip_dirs and not d.startswith('.')]
+
+            for fn in sorted(filenames):
+                fp = Path(dirpath) / fn
+                ext = fp.suffix.lower()
+                # Only consider files we can parse
+                if ext not in EXT_TO_LANG:
+                    continue
+
+                try:
+                    relpath = str(fp.relative_to(root_path))
+                    stat = fp.stat()
+                    file_stats.append((relpath, stat.st_size, stat.st_mtime_ns))
+                except OSError:
+                    # File disappeared or is unreadable; skip it
+                    continue
+
+        # Create hash input: sorted file stats + version + sorted skip
+        hash_parts = []
+        hash_parts.append(f'version:{CACHE_FORMAT_VERSION}')
+        hash_parts.extend(f'{relpath}:{size}:{mtime}' for relpath, size, mtime in sorted(file_stats))
+        hash_parts.extend(f'skip:{d}' for d in sorted(skip_dirs))
+
+        hash_input = '\n'.join(hash_parts).encode('utf-8')
+        return hashlib.sha256(hash_input).hexdigest()
+
+    def scan(self, root: str, skip: set[str] | None = None, use_cache: bool = True, rebuild_cache: bool = False) -> dict:
+        """Parse all recognized files under root, with optional persistent cache.
+
+        Args:
+            root: Root directory to scan
+            skip: Set of directory names to skip (uses DEFAULT_SKIP if None)
+            use_cache: If True, read from and write to persistent cache
+            rebuild_cache: If True, ignore cache and force fresh parse
+
+        Returns:
+            Stats dict including 'loaded_from_cache' bool
+        """
         self.root = Path(root).resolve()
         self.files.clear()
         self._symbol_index.clear()
-        skip_dirs = skip or DEFAULT_SKIP
+        skip_dirs = skip if skip is not None else DEFAULT_SKIP
         total_bytes = 0
         errors = 0
+        loaded_from_cache = False
 
-        for dirpath, dirnames, filenames in os.walk(self.root):
-            dirnames[:] = [d for d in dirnames
-                           if d not in skip_dirs and not d.startswith('.')]
-            for fn in sorted(filenames):
-                fp = Path(dirpath) / fn
-                lang = EXT_TO_LANG.get(fp.suffix.lower())
-                if not lang:
-                    continue
-                relpath = str(fp.relative_to(self.root))
+        # Determine cache path and fingerprint
+        cache_path = cache_path_for(str(self.root)) if use_cache else None
+        fingerprint = self._fingerprint(str(self.root), skip_dirs) if use_cache else None
+
+        # Try to load from cache
+        if use_cache and not rebuild_cache and cache_path and fingerprint:
+            try:
+                loaded_from_cache = self._try_load_cache(cache_path, fingerprint)
+            except Exception:
+                # Any error loading cache: silently fall back to parse
+                loaded_from_cache = False
+
+        # If no cache hit, parse fresh
+        if not loaded_from_cache:
+            for dirpath, dirnames, filenames in os.walk(self.root):
+                dirnames[:] = [d for d in dirnames
+                               if d not in skip_dirs and not d.startswith('.')]
+                for fn in sorted(filenames):
+                    fp = Path(dirpath) / fn
+                    lang = EXT_TO_LANG.get(fp.suffix.lower())
+                    if not lang:
+                        continue
+                    relpath = str(fp.relative_to(self.root))
+                    try:
+                        source = fp.read_bytes()
+                        total_bytes += len(source)
+                        parser = _get_parser(lang)
+                        if parser is None:
+                            continue  # Parser not available for this language
+                        tree = parser.parse(source)
+                        syms = extract_symbols(tree, source, relpath, lang)
+                        imps = extract_imports(tree, source, lang)
+                        self.files[relpath] = FileEntry(
+                            path=relpath, lang=lang, source=source,
+                            tree=tree, symbols=syms, imports=imps)
+                        # Index symbols
+                        for sym in syms:
+                            self._symbol_index.setdefault(sym.name, []).append(sym)
+                            for child in sym.children:
+                                self._symbol_index.setdefault(child.name, []).append(child)
+                    except Exception as e:
+                        errors += 1
+
+            # Write cache if caching is enabled
+            if use_cache and cache_path and fingerprint:
                 try:
-                    source = fp.read_bytes()
-                    total_bytes += len(source)
-                    parser = _get_parser(lang)
-                    if parser is None:
-                        continue  # Parser not available for this language
-                    tree = parser.parse(source)
-                    syms = extract_symbols(tree, source, relpath, lang)
-                    imps = extract_imports(tree, source, lang)
-                    self.files[relpath] = FileEntry(
-                        path=relpath, lang=lang, source=source,
-                        tree=tree, symbols=syms, imports=imps)
-                    # Index symbols
-                    for sym in syms:
-                        self._symbol_index.setdefault(sym.name, []).append(sym)
-                        for child in sym.children:
-                            self._symbol_index.setdefault(child.name, []).append(child)
-                except Exception as e:
-                    errors += 1
+                    self._write_cache(cache_path, fingerprint)
+                except Exception:
+                    # Silently ignore cache write failures
+                    pass
 
         return {
             'root': str(self.root),
@@ -1319,7 +1459,137 @@ class CodeCache:
             'bytes': total_bytes,
             'errors': errors,
             'languages': sorted(set(e.lang for e in self.files.values())),
+            'loaded_from_cache': loaded_from_cache,
         }
+
+    def _try_load_cache(self, cache_path: Path, fingerprint: str) -> bool:
+        """Try to load cache from disk.
+
+        Args:
+            cache_path: Path to cache file
+            fingerprint: Expected fingerprint
+
+        Returns:
+            True if cache was loaded successfully, False otherwise.
+            On any error, returns False and caller falls back to parse.
+        """
+        if not cache_path.exists():
+            return False
+
+        try:
+            with open(cache_path, 'r') as f:
+                cache_data = json.load(f)
+        except (json.JSONDecodeError, IOError, OSError):
+            # Bad JSON or unreadable file
+            return False
+
+        # Validate cache format
+        if not isinstance(cache_data, dict):
+            return False
+
+        # Check version
+        cache_version = cache_data.get('cache_format_version')
+        if cache_version != CACHE_FORMAT_VERSION:
+            return False
+
+        # Check fingerprint
+        cache_fingerprint = cache_data.get('fingerprint')
+        if cache_fingerprint != fingerprint:
+            return False
+
+        # Load files from cache
+        files_data = cache_data.get('files', {})
+        if not isinstance(files_data, dict):
+            return False
+
+        try:
+            for relpath, file_data in files_data.items():
+                lang = file_data.get('lang')
+                imports = file_data.get('imports', [])
+                symbols_data = file_data.get('symbols', [])
+
+                # Deserialize symbols
+                symbols = []
+                for sym_dict in symbols_data:
+                    try:
+                        sym = Symbol.from_dict(sym_dict)
+                        symbols.append(sym)
+                    except (KeyError, TypeError):
+                        # Bad symbol data; fail cache load
+                        return False
+
+                # Create FileEntry with tree=None and source=None (lazy load)
+                self.files[relpath] = FileEntry(
+                    path=relpath,
+                    lang=lang,
+                    source=None,
+                    tree=None,
+                    symbols=symbols,
+                    imports=imports,
+                )
+
+                # Index symbols
+                for sym in symbols:
+                    self._symbol_index.setdefault(sym.name, []).append(sym)
+                    for child in sym.children:
+                        self._symbol_index.setdefault(child.name, []).append(child)
+
+            return True
+        except Exception:
+            return False
+
+    def _write_cache(self, cache_path: Path, fingerprint: str) -> None:
+        """Write cache to disk atomically.
+
+        Args:
+            cache_path: Path to write cache file to
+            fingerprint: Fingerprint of scanned tree
+        """
+        # Build cache data structure
+        cache_data = {
+            'cache_format_version': CACHE_FORMAT_VERSION,
+            'fingerprint': fingerprint,
+            'files': {},
+        }
+
+        # Serialize files
+        for relpath, entry in self.files.items():
+            cache_data['files'][relpath] = {
+                'lang': entry.lang,
+                'symbols': [s.to_dict(include_children=True) for s in entry.symbols],
+                'imports': entry.imports,
+            }
+
+        # Write atomically: write to temp file, then replace
+        tmp_path = None
+        try:
+            # Use same directory as target file for atomic rename
+            cache_dir = cache_path.parent
+            cache_dir.mkdir(parents=True, exist_ok=True)
+
+            # Create temp file in the same directory for atomic rename
+            fd, tmp_file_path = tempfile.mkstemp(
+                prefix='.treesit-',
+                suffix='.tmp.json',
+                dir=cache_dir,
+            )
+            tmp_path = Path(tmp_file_path)
+            os.close(fd)  # Close the file descriptor; we'll reopen with json.dump
+
+            with open(tmp_path, 'w') as f:
+                json.dump(cache_data, f)
+
+            # Atomic replace
+            os.replace(tmp_path, cache_path)
+        except Exception:
+            # Clean up temp file if it exists
+            if tmp_path is not None:
+                try:
+                    if tmp_path.exists():
+                        tmp_path.unlink()
+                except Exception:
+                    pass
+            raise
 
     def find_symbol(self, query: str, kind: str | None = None,
                     limit: int = 20) -> list[Symbol]:
@@ -1407,7 +1677,10 @@ class CodeCache:
         return '\n'.join(lines)
 
     def get_source_range(self, filepath: str, start_line: int, end_line: int) -> str:
-        """Get source code for a line range."""
+        """Get source code for a line range.
+
+        Supports lazy source loading: if entry.source is None, reads from disk.
+        """
         entry = self.files.get(filepath)
         if not entry:
             for rp, e in self.files.items():
@@ -1416,18 +1689,46 @@ class CodeCache:
                     break
         if not entry:
             return f"File not found: {filepath}"
-        lines = entry.source.decode('utf-8', errors='replace').split('\n')
+
+        # Lazy load source if needed
+        source = entry.source
+        if source is None:
+            try:
+                if self.root:
+                    src_path = self.root / entry.path
+                    source = src_path.read_bytes()
+                else:
+                    return f"Cannot load source: no root context"
+            except OSError:
+                return f"Cannot read source file: {entry.path}"
+
+        lines = source.decode('utf-8', errors='replace').split('\n')
         selected = lines[start_line-1:end_line]
         return '\n'.join(f"{start_line+i:4d} | {line}" for i, line in enumerate(selected))
 
     def references(self, symbol_name: str, limit: int = 20) -> list[dict]:
-        """Find text references to a symbol across the codebase."""
+        """Find text references to a symbol across the codebase.
+
+        Supports lazy source loading: if entry.source is None, reads from disk.
+        """
         results = []
         name_bytes = symbol_name.encode()
         for relpath, entry in self.files.items():
-            if name_bytes not in entry.source:
+            # Lazy load source if needed
+            source = entry.source
+            if source is None:
+                try:
+                    if self.root:
+                        src_path = self.root / entry.path
+                        source = src_path.read_bytes()
+                    else:
+                        continue
+                except OSError:
+                    continue
+
+            if name_bytes not in source:
                 continue
-            lines = entry.source.decode('utf-8', errors='replace').split('\n')
+            lines = source.decode('utf-8', errors='replace').split('\n')
             for i, line in enumerate(lines):
                 if symbol_name in line:
                     results.append({

--- a/tree-sitting/scripts/treesit.py
+++ b/tree-sitting/scripts/treesit.py
@@ -320,6 +320,10 @@ def main():
                         help='Suppress tree overview, show only query results')
     parser.add_argument('--stats', action='store_true',
                         help='Show scan statistics')
+    parser.add_argument('--no-cache', action='store_true',
+                        help='Disable persistent cache (never read or write)')
+    parser.add_argument('--rebuild-cache', action='store_true',
+                        help='Ignore existing cache, re-parse, and overwrite cache')
 
     args, extra = parser.parse_known_args()
     # Extra args are queries (argparse struggles with nargs='*' after options)
@@ -337,11 +341,14 @@ def main():
     cache = CodeCache()
     skip = set(args.skip.split(',')) if args.skip else None
     t0 = time.perf_counter()
-    stats = cache.scan(args.repo, skip=skip)
+    use_cache = not args.no_cache
+    rebuild_cache = args.rebuild_cache
+    stats = cache.scan(args.repo, skip=skip, use_cache=use_cache, rebuild_cache=rebuild_cache)
     elapsed = (time.perf_counter() - t0) * 1000
 
     if args.stats:
-        print(f"Scanned {stats['files']} files ({stats['bytes']//1024} KB) in {elapsed:.0f}ms")
+        cached_marker = " (cached)" if stats.get('loaded_from_cache', False) else ""
+        print(f"Scanned {stats['files']} files ({stats['bytes']//1024} KB) in {elapsed:.0f}ms{cached_marker}")
         print(f"Symbols: {stats['symbols']} | Languages: {', '.join(stats['languages'])}")
         if stats['errors']:
             print(f"Errors: {stats['errors']}")

--- a/tree-sitting/tests/test_cache_fingerprint.py
+++ b/tree-sitting/tests/test_cache_fingerprint.py
@@ -1,0 +1,331 @@
+"""Tests for tree-sitting cache fingerprinting and cache path resolution.
+
+This test suite covers the persistent scan-cache contract (v1, cheap tier):
+- _fingerprint stability and invalidation
+- cache_path_for determinism and env override behavior
+
+Run: python -m pytest tests/test_cache_fingerprint.py -v
+"""
+
+import sys
+import os
+import tempfile
+import time
+from pathlib import Path
+
+# Bootstrap parsers before importing engine
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+
+from engine import CodeCache
+# cache_path_for will be imported from engine after implementation
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+def create_test_repo(tmp_path: Path) -> Path:
+    """Create a minimal test repository with real source files."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+
+    # Create a Python source file
+    py_file = repo / "example.py"
+    py_file.write_bytes(b'''
+def greet(name: str) -> str:
+    """Greet someone."""
+    return f"Hello, {name}!"
+
+class Service:
+    def start(self) -> None:
+        pass
+''')
+
+    # Create a Rust source file
+    rs_file = repo / "lib.rs"
+    rs_file.write_bytes(b'''
+pub struct Config {
+    pub name: String,
+}
+
+pub fn create() -> Config {
+    Config { name: String::new() }
+}
+
+impl Config {
+    pub fn new(name: &str) -> Self {
+        Config { name: name.to_string() }
+    }
+}
+''')
+
+    return repo
+
+
+# ── Fingerprint: Stability ──────────────────────────────────────────────
+
+def test_fingerprint_is_stable_unchanged_tree(tmp_path: Path):
+    """Fingerprint is STABLE: two calls on an unchanged tree return the same value."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # First fingerprint
+    fp1 = cache._fingerprint(str(repo), skip=None)
+    assert isinstance(fp1, str), "Fingerprint should return a string"
+    assert len(fp1) > 0, "Fingerprint should not be empty"
+
+    # Second fingerprint on unchanged tree
+    fp2 = cache._fingerprint(str(repo), skip=None)
+    assert fp2 == fp1, "Fingerprint should be stable across rescans of unchanged tree"
+
+
+# ── Fingerprint: Content Changes ────────────────────────────────────────
+
+def test_fingerprint_changes_on_file_content_modify(tmp_path: Path):
+    """Fingerprint CHANGES when a file's content is modified (mtime/size changes)."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint before modification
+    fp_before = cache._fingerprint(str(repo), skip=None)
+
+    # Modify file content (use os.utime to force distinct mtime_ns)
+    py_file = repo / "example.py"
+    py_file.write_bytes(b'''
+def greet(name: str) -> str:
+    """Greet someone."""
+    return f"Hello, {name}!"
+
+class Service:
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+''')
+    # Force mtime to be distinct
+    mtime_ns = (time.time_ns() + 1000000000)
+    os.utime(py_file, ns=(mtime_ns, mtime_ns))
+
+    # Get fingerprint after modification
+    fp_after = cache._fingerprint(str(repo), skip=None)
+
+    assert fp_after != fp_before, "Fingerprint should change when file content is modified"
+
+
+def test_fingerprint_changes_on_file_size_change(tmp_path: Path):
+    """Fingerprint CHANGES when file size changes."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint before size change
+    fp_before = cache._fingerprint(str(repo), skip=None)
+
+    # Modify file size (truncate to make size noticeably different)
+    py_file = repo / "example.py"
+    original_size = py_file.stat().st_size
+    py_file.write_bytes(b'# Much shorter file\n')
+    assert py_file.stat().st_size != original_size
+
+    # Get fingerprint after size change
+    fp_after = cache._fingerprint(str(repo), skip=None)
+
+    assert fp_after != fp_before, "Fingerprint should change when file size changes"
+
+
+# ── Fingerprint: File Operations ────────────────────────────────────────
+
+def test_fingerprint_changes_on_file_added(tmp_path: Path):
+    """Fingerprint CHANGES when a file is added."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint before adding file
+    fp_before = cache._fingerprint(str(repo), skip=None)
+
+    # Add a new Python file
+    new_file = repo / "new_module.py"
+    new_file.write_bytes(b'def new_function():\n    pass\n')
+
+    # Get fingerprint after adding file
+    fp_after = cache._fingerprint(str(repo), skip=None)
+
+    assert fp_after != fp_before, "Fingerprint should change when a file is added"
+
+
+def test_fingerprint_changes_on_file_removed(tmp_path: Path):
+    """Fingerprint CHANGES when a file is removed."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint before removing file
+    fp_before = cache._fingerprint(str(repo), skip=None)
+
+    # Remove a file
+    py_file = repo / "example.py"
+    py_file.unlink()
+
+    # Get fingerprint after removing file
+    fp_after = cache._fingerprint(str(repo), skip=None)
+
+    assert fp_after != fp_before, "Fingerprint should change when a file is removed"
+
+
+# ── Fingerprint: Skip-set Changes ───────────────────────────────────────
+
+def test_fingerprint_changes_on_skip_set_change(tmp_path: Path):
+    """Fingerprint CHANGES when the skip-set changes."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint with no skip set
+    fp_no_skip = cache._fingerprint(str(repo), skip=None)
+
+    # Get fingerprint with a skip set (even if it doesn't exclude anything)
+    fp_with_skip = cache._fingerprint(str(repo), skip={'nonexistent_dir'})
+
+    # The fingerprints should differ because skip-set is part of the hash
+    assert fp_with_skip != fp_no_skip, "Fingerprint should change when skip-set changes"
+
+
+def test_fingerprint_changes_with_different_skip_sets(tmp_path: Path):
+    """Fingerprint differs for different skip-sets (included in hash)."""
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint with skip set A
+    fp_skip_a = cache._fingerprint(str(repo), skip={'dir_a'})
+
+    # Get fingerprint with skip set B
+    fp_skip_b = cache._fingerprint(str(repo), skip={'dir_b'})
+
+    assert fp_skip_a != fp_skip_b, "Fingerprint should differ for different skip-sets"
+
+
+# ── Fingerprint: Cache Format Version ───────────────────────────────────
+
+def test_fingerprint_changes_on_cache_format_version_bump(tmp_path: Path, monkeypatch):
+    """Fingerprint CHANGES when engine.CACHE_FORMAT_VERSION changes."""
+    import engine
+
+    repo = create_test_repo(tmp_path)
+    cache = CodeCache()
+
+    # Get fingerprint with current version
+    original_version = engine.CACHE_FORMAT_VERSION
+    fp_v1 = cache._fingerprint(str(repo), skip=None)
+
+    # Bump the cache format version
+    monkeypatch.setattr(engine, 'CACHE_FORMAT_VERSION', original_version + 1)
+
+    # Get fingerprint with new version
+    fp_v2 = cache._fingerprint(str(repo), skip=None)
+
+    # Restore original version
+    monkeypatch.setattr(engine, 'CACHE_FORMAT_VERSION', original_version)
+
+    assert fp_v2 != fp_v1, "Fingerprint should change when CACHE_FORMAT_VERSION is bumped"
+
+
+# ── cache_path_for: Determinism ────────────────────────────────────────
+
+def test_cache_path_for_is_deterministic(tmp_path: Path):
+    """cache_path_for(root) is deterministic for the same resolved abspath."""
+    import engine
+    repo = create_test_repo(tmp_path)
+    repo_path = str(repo)
+
+    # Call cache_path_for twice with the same path
+    path1 = engine.cache_path_for(repo_path)
+    path2 = engine.cache_path_for(repo_path)
+
+    assert path1 == path2, "cache_path_for should be deterministic for the same root"
+
+
+def test_cache_path_for_resolves_symlinks(tmp_path: Path):
+    """cache_path_for resolves symlinks to canonical path."""
+    import engine
+    repo = create_test_repo(tmp_path)
+
+    # Create a symlink to the repo
+    symlink = tmp_path / "link_to_repo"
+    symlink.symlink_to(repo)
+
+    # Get cache paths for both the real and symlinked paths
+    path_real = engine.cache_path_for(str(repo))
+    path_symlink = engine.cache_path_for(str(symlink))
+
+    # They should be the same (both resolve to the real path)
+    assert path_real == path_symlink, "cache_path_for should resolve symlinks to the same canonical path"
+
+
+def test_cache_path_for_differs_for_different_roots(tmp_path: Path):
+    """cache_path_for differs for different roots."""
+    import engine
+    repo1 = create_test_repo(tmp_path)
+    repo2 = create_test_repo(tmp_path)  # Creates another repo in tmp_path
+
+    path1 = engine.cache_path_for(str(repo1))
+    path2 = engine.cache_path_for(str(repo2))
+
+    assert path1 != path2, "cache_path_for should return different paths for different roots"
+
+
+# ── cache_path_for: Environment Override ────────────────────────────────
+
+def test_cache_path_for_honors_treesit_cache_dir_env(tmp_path: Path, monkeypatch):
+    """cache_path_for honors TREESIT_CACHE_DIR environment variable."""
+    import engine
+    repo = create_test_repo(tmp_path)
+    cache_dir = tmp_path / "my_cache"
+    cache_dir.mkdir()
+
+    # Set TREESIT_CACHE_DIR env var
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    # Get cache path
+    cache_path = engine.cache_path_for(str(repo))
+
+    # Verify the cache path is under the specified cache dir
+    assert cache_path.parent == cache_dir, (
+        f"cache_path_for should use TREESIT_CACHE_DIR; "
+        f"got {cache_path.parent}, expected {cache_dir}"
+    )
+
+
+def test_cache_path_for_uses_temp_dir_when_no_env(tmp_path: Path, monkeypatch):
+    """cache_path_for uses system temp dir when TREESIT_CACHE_DIR is not set."""
+    import engine
+    repo = create_test_repo(tmp_path)
+
+    # Ensure TREESIT_CACHE_DIR is not set
+    monkeypatch.delenv('TREESIT_CACHE_DIR', raising=False)
+
+    # Get cache path
+    cache_path = engine.cache_path_for(str(repo))
+
+    # Verify it's a Path
+    assert isinstance(cache_path, Path), "cache_path_for should return a Path object"
+
+    # Verify parent directory exists (temp dir)
+    assert cache_path.parent.exists(), "cache_path_for should use an existing directory (temp)"
+
+    # Verify parent is writable
+    assert os.access(cache_path.parent, os.W_OK), "cache path parent should be writable"
+
+
+def test_cache_path_for_filename_derived_from_abspath(tmp_path: Path):
+    """cache_path_for filename is deterministically derived from resolved abspath."""
+    import engine
+    repo1 = create_test_repo(tmp_path / "subdir1")
+    repo2 = create_test_repo(tmp_path / "subdir2")
+
+    path1 = engine.cache_path_for(str(repo1))
+    path2 = engine.cache_path_for(str(repo2))
+
+    # Filenames should be different (based on different paths)
+    assert path1.name != path2.name, (
+        "cache filenames should differ for different root paths"
+    )
+
+    # Both filenames should look like SHA256 hashes or similar deterministic names
+    # (exact format depends on implementation, but should be hex/base64-ish)
+    assert len(path1.name) > 8, "cache filename should be long enough to be unique"
+    assert len(path2.name) > 8, "cache filename should be long enough to be unique"

--- a/tree-sitting/tests/test_cache_fingerprint.py
+++ b/tree-sitting/tests/test_cache_fingerprint.py
@@ -24,7 +24,7 @@ from engine import CodeCache
 def create_test_repo(tmp_path: Path) -> Path:
     """Create a minimal test repository with real source files."""
     repo = tmp_path / "test_repo"
-    repo.mkdir()
+    repo.mkdir(parents=True, exist_ok=True)
 
     # Create a Python source file
     py_file = repo / "example.py"
@@ -259,8 +259,8 @@ def test_cache_path_for_resolves_symlinks(tmp_path: Path):
 def test_cache_path_for_differs_for_different_roots(tmp_path: Path):
     """cache_path_for differs for different roots."""
     import engine
-    repo1 = create_test_repo(tmp_path)
-    repo2 = create_test_repo(tmp_path)  # Creates another repo in tmp_path
+    repo1 = create_test_repo(tmp_path / "root_a")
+    repo2 = create_test_repo(tmp_path / "root_b")  # a genuinely distinct root
 
     path1 = engine.cache_path_for(str(repo1))
     path2 = engine.cache_path_for(str(repo2))

--- a/tree-sitting/tests/test_cache_lazy_source.py
+++ b/tree-sitting/tests/test_cache_lazy_source.py
@@ -1,0 +1,281 @@
+"""Tests for lazy source correctness on cache hits — T4.
+
+This module tests that FileEntry objects loaded from the persistent cache
+have source=None and tree=None, and that code paths requiring source bytes
+(get_source_range, references) lazily read from disk and return identical
+results to a fresh parse.
+
+Run: python -m pytest tests/test_cache_lazy_source.py -v
+"""
+
+import sys
+import os
+import json
+import tempfile
+import shutil
+from pathlib import Path
+
+# Bootstrap parsers before importing engine
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+
+from engine import CodeCache, FileEntry
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _cache_dir_for_root(root: str) -> Path:
+    """Return the cache file path for a root, using TREESIT_CACHE_DIR if set."""
+    # This mirrors the engine.cache_path_for() logic that will be implemented
+    cache_dir = os.environ.get('TREESIT_CACHE_DIR')
+    if cache_dir:
+        return Path(cache_dir)
+    # Fallback: use system temp
+    return Path(tempfile.gettempdir()) / 'treesit-cache'
+
+
+def _read_cache_json(root: str) -> dict:
+    """Read raw cache JSON from disk (for inspection)."""
+    import hashlib
+    root_resolved = str(Path(root).resolve())
+    cache_hash = hashlib.sha256(root_resolved.encode()).hexdigest()
+    cache_dir = _cache_dir_for_root(root)
+    cache_file = cache_dir / f'{cache_hash}.json'
+    if not cache_file.exists():
+        return {}
+    return json.loads(cache_file.read_text())
+
+
+# ── T4.1: Cache hit, get_source_range returns same as fresh parse ───────
+
+def test_cache_hit_get_source_range_matches_fresh():
+    """After cache-hit scan, get_source_range returns same text as fresh parse."""
+    tmpdir = tempfile.mkdtemp()
+    cache_dir = tempfile.mkdtemp()
+    try:
+        os.environ['TREESIT_CACHE_DIR'] = cache_dir
+
+        # Create a test file with recognizable content
+        test_file = Path(tmpdir) / 'module.py'
+        test_file.write_text(
+            'def alpha():\n'
+            '    """Line 2 docstring."""\n'
+            '    return 42\n'
+            'def beta():\n'
+            '    pass\n'
+        )
+
+        # Scan fresh (populates cache)
+        cache_fresh = CodeCache()
+        cache_fresh.scan(tmpdir)
+        src_fresh = cache_fresh.get_source_range('module.py', 2, 4)
+
+        # Clear in-memory cache, scan from disk cache (cache hit)
+        cache_hit = CodeCache()
+        hit_stats = cache_hit.scan(tmpdir)  # must be a cache hit
+        assert hit_stats.get('loaded_from_cache') is True, \
+            "second scan must load from cache, else this test is vacuous"
+        src_hit = cache_hit.get_source_range('module.py', 2, 4)
+
+        # Results must be identical
+        assert src_fresh == src_hit, \
+            f"Fresh: {src_fresh!r} != Hit: {src_hit!r}"
+        assert 'Line 2 docstring' in src_hit
+
+    finally:
+        if 'TREESIT_CACHE_DIR' in os.environ:
+            del os.environ['TREESIT_CACHE_DIR']
+        shutil.rmtree(tmpdir)
+        shutil.rmtree(cache_dir)
+
+
+# ── T4.2: Cache hit, references returns same as fresh parse ────────────
+
+def test_cache_hit_references_matches_fresh():
+    """After cache-hit scan, references() returns same results as fresh parse."""
+    tmpdir = tempfile.mkdtemp()
+    cache_dir = tempfile.mkdtemp()
+    try:
+        os.environ['TREESIT_CACHE_DIR'] = cache_dir
+
+        # Create test files with a symbol used in multiple places
+        Path(tmpdir, 'def.py').write_text(
+            'class UserConfig:\n'
+            '    """Holds user settings."""\n'
+            '    def __init__(self):\n'
+            '        pass\n'
+        )
+        Path(tmpdir, 'use.py').write_text(
+            'from def import UserConfig\n'
+            'cfg = UserConfig()\n'
+            'settings = UserConfig()\n'
+        )
+
+        # Scan fresh
+        cache_fresh = CodeCache()
+        cache_fresh.scan(tmpdir)
+        refs_fresh = cache_fresh.references('UserConfig', limit=10)
+
+        # Scan from cache hit
+        cache_hit = CodeCache()
+        hit_stats = cache_hit.scan(tmpdir)
+        assert hit_stats.get('loaded_from_cache') is True, \
+            "second scan must load from cache, else this test is vacuous"
+        refs_hit = cache_hit.references('UserConfig', limit=10)
+
+        # Results must be identical: same files, same line numbers, same text
+        assert len(refs_fresh) == len(refs_hit), \
+            f"Fresh found {len(refs_fresh)} refs, hit found {len(refs_hit)}"
+
+        for ref_f, ref_h in zip(refs_fresh, refs_hit):
+            assert ref_f == ref_h, \
+                f"Fresh: {ref_f} != Hit: {ref_h}"
+
+        # Verify we found references in both files
+        files = [r['file'] for r in refs_hit]
+        assert any('def.py' in f for f in files)
+        assert any('use.py' in f for f in files)
+
+    finally:
+        if 'TREESIT_CACHE_DIR' in os.environ:
+            del os.environ['TREESIT_CACHE_DIR']
+        shutil.rmtree(tmpdir)
+        shutil.rmtree(cache_dir)
+
+
+# ── T4.3: Cache file does NOT contain raw source text ───────────────────
+
+def test_cache_file_omits_raw_source():
+    """Cache JSON does not contain the raw source bytes of fixture files."""
+    tmpdir = tempfile.mkdtemp()
+    cache_dir = tempfile.mkdtemp()
+    try:
+        os.environ['TREESIT_CACHE_DIR'] = cache_dir
+
+        # Create test file with a distinctive marker comment
+        marker = '### DISTINCTIVE_CACHE_TEST_MARKER_12345 ###'
+        test_file = Path(tmpdir) / 'sample.py'
+        test_file.write_text(
+            f'# {marker}\n'
+            'def function():\n'
+            '    return "value"\n'
+        )
+
+        # Scan to write cache
+        cache = CodeCache()
+        cache.scan(tmpdir)
+
+        # Read raw cache JSON from disk — it must actually exist, else the
+        # marker-absence check below is vacuously true.
+        cache_json = _read_cache_json(tmpdir)
+        assert cache_json, "cache file must exist and be non-empty"
+        cache_text = json.dumps(cache_json)
+
+        # Verify the distinctive marker is NOT in the cache JSON
+        assert marker not in cache_text, \
+            f"Marker found in cache JSON: {cache_text[:500]}"
+        assert 'function' not in cache_text or 'function' in str(cache_json.get('files', [])), \
+            "Source code should not be in cache (only symbol names)"
+
+    finally:
+        if 'TREESIT_CACHE_DIR' in os.environ:
+            del os.environ['TREESIT_CACHE_DIR']
+        shutil.rmtree(tmpdir)
+        shutil.rmtree(cache_dir)
+
+
+# ── T4.4: Graceful degradation when source file deleted ────────────────
+
+def test_cache_hit_missing_file_degrades_gracefully():
+    """After cache written, delete source file, cache-hit scan with get_source_range
+    and references must degrade gracefully (no crash, empty/skipped result)."""
+    tmpdir = tempfile.mkdtemp()
+    cache_dir = tempfile.mkdtemp()
+    try:
+        os.environ['TREESIT_CACHE_DIR'] = cache_dir
+
+        # Create and scan test files
+        Path(tmpdir, 'exists.py').write_text('def keep_me(): pass\n')
+        Path(tmpdir, 'delete_me.py').write_text(
+            'def symbol_in_deleted():\n'
+            '    return 42\n'
+        )
+
+        cache = CodeCache()
+        cache.scan(tmpdir)  # writes cache
+        initial_refs = cache.references('symbol_in_deleted', limit=5)
+        assert len(initial_refs) > 0, "Should find symbol before deletion"
+
+        # Load from cache (entry.source lazily None), THEN delete the file so the
+        # lazy source read must cope with a now-missing file on a cached entry.
+        cache2 = CodeCache()
+        hit_stats = cache2.scan(tmpdir)
+        assert hit_stats.get('loaded_from_cache') is True, \
+            "must be a cache hit so the lazy-read path is exercised"
+        (Path(tmpdir) / 'delete_me.py').unlink()
+
+        # get_source_range on deleted file should not crash
+        result = cache2.get_source_range('delete_me.py', 1, 2)
+        # Should either be empty, or return a "not found" message, not crash
+        assert isinstance(result, str)
+
+        # references should not crash even if file is missing
+        refs = cache2.references('symbol_in_deleted', limit=5)
+        # Should either be empty list or skip the missing file gracefully
+        assert isinstance(refs, list)
+
+    finally:
+        if 'TREESIT_CACHE_DIR' in os.environ:
+            del os.environ['TREESIT_CACHE_DIR']
+        shutil.rmtree(tmpdir)
+        shutil.rmtree(cache_dir)
+
+
+# ── T4.5: FileEntry from cache has source=None, tree=None immediately ───
+
+def test_file_entry_lazy_fields_null_after_cache_hit():
+    """FileEntry objects loaded from cache have source=None and tree=None
+    immediately after scan (before any lazy read)."""
+    tmpdir = tempfile.mkdtemp()
+    cache_dir = tempfile.mkdtemp()
+    try:
+        os.environ['TREESIT_CACHE_DIR'] = cache_dir
+
+        # Create and scan test file
+        Path(tmpdir, 'lazy.py').write_text(
+            'def lazy_function():\n'
+            '    pass\n'
+        )
+
+        # First scan: writes cache
+        cache1 = CodeCache()
+        cache1.scan(tmpdir)
+        entry1 = cache1.files.get('lazy.py')
+        assert entry1 is not None
+        # First scan may have source loaded (depends on implementation)
+        # Just verify the structure exists
+        assert isinstance(entry1, FileEntry)
+
+        # Second scan: should hit cache
+        cache2 = CodeCache()
+        cache2.scan(tmpdir)
+
+        # Check FileEntry from cache hit
+        entry2 = cache2.files.get('lazy.py')
+        assert entry2 is not None, "FileEntry should be populated from cache"
+
+        # CRITICAL: source and tree must be None on cache hit
+        # to force lazy loading behavior
+        assert entry2.source is None, \
+            "FileEntry.source must be None on cache hit (lazy loading required)"
+        assert entry2.tree is None, \
+            "FileEntry.tree must be None on cache hit (lazy loading required)"
+
+        # But symbols should be populated from cache
+        assert entry2.symbols is not None
+        assert len(entry2.symbols) > 0, "Symbols should be loaded from cache"
+
+    finally:
+        if 'TREESIT_CACHE_DIR' in os.environ:
+            del os.environ['TREESIT_CACHE_DIR']
+        shutil.rmtree(tmpdir)
+        shutil.rmtree(cache_dir)

--- a/tree-sitting/tests/test_cache_lifecycle.py
+++ b/tree-sitting/tests/test_cache_lifecycle.py
@@ -1,0 +1,898 @@
+"""Tests for tree-sitting cache lifecycle (T3: cache lifecycle, flags, atomicity, robustness).
+
+Run: python -m pytest tests/test_cache_lifecycle.py -v
+Or:  python tests/test_cache_lifecycle.py
+
+These tests are for NOT-YET-IMPLEMENTED cache features. TDD red phase.
+All tests WILL FAIL until the cache implementation is complete.
+"""
+
+import sys
+import os
+import json
+import time
+import tempfile
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Bootstrap parsers before importing engine
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+
+import engine
+from engine import CodeCache, Symbol
+# Not-yet-implemented names: resolve lazily so the module COLLECTS (red-fails per
+# test) instead of erroring at import during TDD red phase.
+cache_path_for = getattr(engine, "cache_path_for", None)
+CACHE_FORMAT_VERSION = getattr(engine, "CACHE_FORMAT_VERSION", None)
+
+
+# ── Fixtures and helpers ─────────────────────────────────────────────────────
+
+def create_test_tree(tmpdir, files_dict: dict[str, str]) -> Path:
+    """Create a test directory tree with given files.
+
+    Args:
+        tmpdir: Path to create files in
+        files_dict: dict of relpath -> content (as string)
+
+    Returns:
+        Path to tmpdir
+    """
+    root = Path(tmpdir)
+    for relpath, content in files_dict.items():
+        filepath = root / relpath
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(content)
+    return root
+
+
+def read_cache_json(cache_path: Path) -> dict:
+    """Read cache JSON file safely."""
+    if not cache_path.exists():
+        raise FileNotFoundError(f"Cache file not found: {cache_path}")
+    with open(cache_path, 'r') as f:
+        return json.load(f)
+
+
+def find_temp_files_in_dir(dirpath: Path, pattern: str = '.tmp') -> list[Path]:
+    """Find temporary files matching pattern in directory."""
+    return list(dirpath.glob(f'*{pattern}*'))
+
+
+# ── T3.1: First scan(use_cache=True) creates cache, loaded_from_cache=False ──
+
+def test_first_scan_creates_cache(tmp_path, monkeypatch):
+    """First scan(use_cache=True) CREATES the cache file at cache_path_for(root).
+
+    Assertions:
+    - Cache file exists after scan
+    - loaded_from_cache is False (no prior cache)
+    - Cache contains JSON with CACHE_FORMAT_VERSION header
+    """
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    # Create test tree
+    root = create_test_tree(tmp_path / 'project', {
+        'main.py': 'def hello(): pass\n',
+        'lib.py': 'class Foo:\n    def bar(self): pass\n',
+    })
+
+    # First scan
+    cache = CodeCache()
+    stats = cache.scan(str(root), use_cache=True)
+
+    # Assert cache was created
+    expected_cache_path = cache_path_for(str(root))
+    assert expected_cache_path.exists(), f"Cache file not created at {expected_cache_path}"
+
+    # Assert loaded_from_cache is False
+    assert 'loaded_from_cache' in stats, "loaded_from_cache key missing from stats"
+    assert stats['loaded_from_cache'] is False, "First scan should have loaded_from_cache=False"
+
+    # Assert cache contains valid JSON with version header
+    cache_data = read_cache_json(expected_cache_path)
+    assert 'cache_format_version' in cache_data, "Cache missing cache_format_version"
+    assert cache_data['cache_format_version'] == CACHE_FORMAT_VERSION
+
+
+def test_first_scan_cache_has_fingerprint(tmp_path, monkeypatch):
+    """Cache file includes fingerprint of scanned tree."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    cache = CodeCache()
+    cache.scan(str(root), use_cache=True)
+
+    cache_path = cache_path_for(str(root))
+    cache_data = read_cache_json(cache_path)
+
+    assert 'fingerprint' in cache_data, "Cache missing fingerprint field"
+    assert isinstance(cache_data['fingerprint'], str), "Fingerprint should be a string"
+    assert len(cache_data['fingerprint']) > 0, "Fingerprint should not be empty"
+
+
+def test_first_scan_cache_stores_symbols(tmp_path, monkeypatch):
+    """Cache file stores symbols with required fields from Symbol.to_dict()."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def process(x): """Process x."""\n    pass\n',
+    })
+
+    cache = CodeCache()
+    cache.scan(str(root), use_cache=True)
+
+    cache_path = cache_path_for(str(root))
+    cache_data = read_cache_json(cache_path)
+
+    assert 'files' in cache_data, "Cache missing files field"
+    assert isinstance(cache_data['files'], dict), "files should be a dict"
+
+    # Check that at least one file is stored with required fields
+    for relpath, file_data in cache_data['files'].items():
+        assert 'lang' in file_data, f"File {relpath} missing lang"
+        assert 'symbols' in file_data, f"File {relpath} missing symbols"
+
+        # Symbols should have fields from Symbol.to_dict()
+        for sym in file_data['symbols']:
+            assert 'name' in sym, "Symbol missing name"
+            assert 'kind' in sym, "Symbol missing kind"
+            assert 'file' in sym, "Symbol missing file"
+            assert 'line' in sym, "Symbol missing line"
+            assert 'end_line' in sym, "Symbol missing end_line"
+
+
+# ── T3.2: Second scan(use_cache=True) loads cache, loaded_from_cache=True ──
+
+def test_second_scan_loads_cache(tmp_path, monkeypatch):
+    """Second scan(use_cache=True) on unchanged tree loads it: loaded_from_cache=True."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'main.py': 'def hello(): pass\n',
+    })
+
+    # First scan
+    cache1 = CodeCache()
+    stats1 = cache1.scan(str(root), use_cache=True)
+    assert stats1['loaded_from_cache'] is False
+    files_count_1 = stats1['files']
+    symbols_count_1 = stats1['symbols']
+
+    # Second scan (should load from cache)
+    cache2 = CodeCache()
+    stats2 = cache2.scan(str(root), use_cache=True)
+
+    # Assert cache was loaded
+    assert 'loaded_from_cache' in stats2, "loaded_from_cache key missing"
+    assert stats2['loaded_from_cache'] is True, "Second scan should have loaded_from_cache=True"
+
+    # Assert stats match (same content)
+    assert stats2['files'] == files_count_1, "File count should match"
+    assert stats2['symbols'] == symbols_count_1, "Symbol count should match"
+
+
+def test_cache_load_reconstructs_symbol_index(tmp_path, monkeypatch):
+    """Loaded cache reconstructs symbol index correctly."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'lib.py': 'def helper(): pass\nclass Service:\n    def process(self): pass\n',
+    })
+
+    # First scan
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    results_1 = cache1.find_symbol('helper')
+    assert len(results_1) > 0, "First scan should find 'helper'"
+
+    # Second scan (loads cache)
+    cache2 = CodeCache()
+    cache2.scan(str(root), use_cache=True)
+    results_2 = cache2.find_symbol('helper')
+
+    # Assert symbol index is rebuilt
+    assert len(results_2) > 0, "Loaded cache should find 'helper' via symbol index"
+    assert results_2[0].name == 'helper', "Symbol name should match"
+
+
+def test_cache_load_no_parse(tmp_path, monkeypatch):
+    """When cache is loaded, no parsing happens (tree=None in entries)."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    # First scan
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+
+    # Second scan (loads from cache)
+    cache2 = CodeCache()
+    cache2.scan(str(root), use_cache=True)
+
+    # Check that loaded entries have tree=None and source=None
+    for entry in cache2.files.values():
+        assert entry.tree is None, "Loaded cache entry should have tree=None"
+        assert entry.source is None, "Loaded cache entry should have source=None"
+
+
+# ── T3.3: use_cache=False neither reads nor writes cache ──
+
+def test_use_cache_false_skips_read(tmp_path, monkeypatch):
+    """use_cache=False: existing cache is NOT consulted, always parses."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    # Create cache first with use_cache=True
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+    assert cache_path.exists(), "Cache should be created"
+
+    # Now scan with use_cache=False
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=False)
+
+    # Assert cache was not used
+    assert stats['loaded_from_cache'] is False, "use_cache=False should never load from cache"
+
+    # Assert entries have source and tree (parsed fresh)
+    for entry in cache2.files.values():
+        assert entry.source is not None, "use_cache=False should parse and populate source"
+        assert entry.tree is not None, "use_cache=False should parse and populate tree"
+
+
+def test_use_cache_false_does_not_write_cache(tmp_path, monkeypatch):
+    """use_cache=False: cache is NOT written even if it doesn't exist."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def bar(): pass\n',
+    })
+
+    # Ensure no cache exists
+    cache_path = cache_path_for(str(root))
+    assert not cache_path.exists(), "Cache should not exist initially"
+
+    # Scan with use_cache=False
+    cache = CodeCache()
+    cache.scan(str(root), use_cache=False)
+
+    # Assert cache was not created
+    assert not cache_path.exists(), "use_cache=False should not create cache"
+
+
+def test_use_cache_false_delete_existing_cache(tmp_path, monkeypatch):
+    """Verify that use_cache=False doesn't consult pre-existing cache."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def original(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Delete the source file
+    (root / 'code.py').unlink()
+
+    # Create new tree with different content
+    create_test_tree(root, {
+        'code.py': 'def updated(): pass\n',
+    })
+
+    # Scan with use_cache=False should parse the updated file
+    cache2 = CodeCache()
+    cache2.scan(str(root), use_cache=False)
+
+    # Should find 'updated', not 'original'
+    results = cache2.find_symbol('updated')
+    assert len(results) > 0, "Should find updated function"
+
+
+# ── T3.4: rebuild_cache=True overwrites cache, loaded_from_cache=False ──
+
+def test_rebuild_cache_overwrites_existing(tmp_path, monkeypatch):
+    """rebuild_cache=True: parse fresh and overwrite cache."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def original(): pass\n',
+    })
+
+    # First scan to create cache
+    cache1 = CodeCache()
+    stats1 = cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+    cache_mtime_1 = cache_path.stat().st_mtime
+
+    # Wait a bit to ensure mtime will differ
+    time.sleep(0.01)
+
+    # Scan with rebuild_cache=True
+    cache2 = CodeCache()
+    stats2 = cache2.scan(str(root), rebuild_cache=True)
+
+    # Assert full parse happened
+    assert stats2['loaded_from_cache'] is False, "rebuild_cache=True should have loaded_from_cache=False"
+
+    # Assert cache was overwritten (mtime advanced)
+    cache_mtime_2 = cache_path.stat().st_mtime
+    assert cache_mtime_2 >= cache_mtime_1, "Cache file should be updated/rewritten"
+
+    # Assert entries have source and tree (parsed)
+    for entry in cache2.files.values():
+        assert entry.source is not None, "rebuild_cache=True should parse fresh"
+        assert entry.tree is not None, "rebuild_cache=True should parse fresh"
+
+
+def test_rebuild_cache_true_ignores_existing_cache(tmp_path, monkeypatch):
+    """rebuild_cache=True ignores any existing valid cache."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+
+    # Scan again with rebuild_cache=True (should not load, should parse fresh)
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), rebuild_cache=True)
+
+    assert stats['loaded_from_cache'] is False, "rebuild_cache=True should parse fresh, not load"
+
+    # Entries should have tree and source
+    for entry in cache2.files.values():
+        assert entry.tree is not None
+        assert entry.source is not None
+
+
+# ── T3.5: Robust — corrupt cache falls back to parse, no crash ──
+
+def test_corrupt_cache_json_fallback(tmp_path, monkeypatch):
+    """Corrupt JSON in cache -> falls back to full parse, loaded_from_cache=False."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def process(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Corrupt the cache file
+    cache_path.write_text('{ INVALID JSON HERE }')
+
+    # Scan should NOT crash and should fall back to parse
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    # Assert full parse happened (no crash, correct fallback)
+    assert stats['loaded_from_cache'] is False, "Corrupt cache should fall back to parse"
+    assert stats['files'] > 0, "Should still parse the tree"
+    assert stats['errors'] == 0, "Should complete successfully"
+
+
+def test_corrupt_cache_unreadable_fallback(tmp_path, monkeypatch):
+    """Unreadable cache file -> falls back to parse, produces correct results."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def helper(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Write garbage bytes
+    cache_path.write_bytes(b'\x00\x01\x02\x03 garbage')
+
+    # Scan should not crash
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    # Verify fallback succeeded
+    assert stats['loaded_from_cache'] is False
+    assert stats['files'] == 1
+    results = cache2.find_symbol('helper')
+    assert len(results) > 0, "Should find symbol despite cache corruption"
+
+
+def test_corrupt_cache_missing_fields_fallback(tmp_path, monkeypatch):
+    """Cache with missing required fields -> falls back to parse."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def func(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Write incomplete cache (missing 'files' field)
+    invalid_cache = {
+        'cache_format_version': CACHE_FORMAT_VERSION,
+        'fingerprint': 'some_fp',
+        # Missing 'files' field
+    }
+    cache_path.write_text(json.dumps(invalid_cache))
+
+    # Should not crash and should parse fresh
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    assert stats['loaded_from_cache'] is False
+    assert stats['files'] > 0
+
+
+# ── T3.6: Robustness — version mismatch cache -> full parse, no crash ──
+
+def test_version_mismatch_fallback(tmp_path, monkeypatch):
+    """Cache with stale CACHE_FORMAT_VERSION -> full parse, no crash."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def legacy(): pass\n',
+    })
+
+    # Create cache with current version
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Manually change version in cache file
+    cache_data = read_cache_json(cache_path)
+    cache_data['cache_format_version'] = CACHE_FORMAT_VERSION - 1  # Stale version
+    cache_path.write_text(json.dumps(cache_data))
+
+    # Scan with use_cache=True should detect version mismatch and parse fresh
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    # Assert full parse happened
+    assert stats['loaded_from_cache'] is False, "Version mismatch should fall back to parse"
+    assert stats['files'] > 0, "Should successfully parse"
+
+    # Verify correct results
+    results = cache2.find_symbol('legacy')
+    assert len(results) > 0, "Should find symbols despite version mismatch"
+
+
+def test_version_mismatch_updates_cache(tmp_path, monkeypatch):
+    """Version mismatch cache is rewritten with new version."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def func(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Change version to simulate staleness
+    cache_data = read_cache_json(cache_path)
+    old_version = CACHE_FORMAT_VERSION - 1
+    cache_data['cache_format_version'] = old_version
+    cache_path.write_text(json.dumps(cache_data))
+
+    # Scan should rewrite with new version
+    cache2 = CodeCache()
+    cache2.scan(str(root), use_cache=True)
+
+    # Check that cache was updated
+    updated_cache_data = read_cache_json(cache_path)
+    assert updated_cache_data['cache_format_version'] == CACHE_FORMAT_VERSION
+
+
+# ── T3.7: Robustness — fingerprint mismatch -> full parse, cache refreshed ──
+
+def test_fingerprint_mismatch_fallback(tmp_path, monkeypatch):
+    """Valid cache exists, file modified -> fingerprint mismatch -> full parse."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def original(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+    cache_data_1 = read_cache_json(cache_path)
+    orig_fingerprint = cache_data_1['fingerprint']
+
+    # Modify source file
+    (root / 'code.py').write_text('def modified(): pass\n')
+
+    # Scan with use_cache=True
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    # Assert full parse happened (fingerprint changed)
+    assert stats['loaded_from_cache'] is False, "Fingerprint mismatch should trigger full parse"
+
+    # Assert new fingerprint in cache
+    cache_data_2 = read_cache_json(cache_path)
+    assert cache_data_2['fingerprint'] != orig_fingerprint, "Cache should have new fingerprint"
+
+    # Verify new content is in cache
+    results = cache2.find_symbol('modified')
+    assert len(results) > 0, "Cache should contain updated symbol"
+
+
+def test_fingerprint_mismatch_detects_file_size_change(tmp_path, monkeypatch):
+    """Fingerprint includes file size; size change -> cache miss."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def func(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+
+    # Modify file (add content, changing size)
+    (root / 'code.py').write_text('def func(): pass\n\n# comment\n')
+
+    # Scan should detect size change
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    assert stats['loaded_from_cache'] is False, "File size change should invalidate cache"
+
+
+def test_fingerprint_mismatch_detects_mtime_change(tmp_path, monkeypatch):
+    """Fingerprint includes mtime_ns; mtime change -> cache miss."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+
+    # Touch file to change mtime
+    time.sleep(0.01)  # Ensure mtime differs
+    (root / 'code.py').touch()
+
+    # Scan should detect mtime change
+    cache2 = CodeCache()
+    stats = cache2.scan(str(root), use_cache=True)
+
+    assert stats['loaded_from_cache'] is False, "mtime change should invalidate cache"
+
+
+# ── T3.8: Atomic write via temp file + os.replace ──
+
+def test_atomic_write_uses_temp_file(tmp_path, monkeypatch):
+    """Cache write uses temp file + os.replace, no leftover temp files."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    # Scan to create cache
+    cache = CodeCache()
+    cache.scan(str(root), use_cache=True)
+
+    # Assert no temp files left in cache dir
+    temp_files = find_temp_files_in_dir(cache_dir, '.tmp')
+    assert len(temp_files) == 0, f"Should not have leftover temp files, found: {temp_files}"
+
+
+def test_atomic_write_replaces_atomically(tmp_path, monkeypatch):
+    """Verify cache write uses os.replace for atomic replacement."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def bar(): pass\n',
+    })
+
+    # Create cache
+    cache1 = CodeCache()
+    cache1.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Patch os.replace to verify it's called
+    original_replace = os.replace
+    replace_called = []
+
+    def tracked_replace(src, dst):
+        replace_called.append((src, dst))
+        return original_replace(src, dst)
+
+    with patch('os.replace', side_effect=tracked_replace):
+        # Create new cache instance and scan (should write)
+        cache2 = CodeCache()
+        cache2.scan(str(root), rebuild_cache=True)
+
+    # Assert os.replace was called with appropriate args
+    assert len(replace_called) > 0, "os.replace should be called for atomic write"
+    # Verify destination is the cache file
+    _, dest_file = replace_called[0]
+    assert Path(dest_file) == cache_path, "Replace destination should be cache_path"
+
+
+def test_atomic_write_no_half_written_cache(tmp_path, monkeypatch):
+    """On successful scan, cache file is complete (not half-written)."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def func(): pass\n',
+        'lib.py': 'class Service: pass\n',
+    })
+
+    # Scan
+    cache = CodeCache()
+    cache.scan(str(root), use_cache=True)
+    cache_path = cache_path_for(str(root))
+
+    # Verify cache file is valid JSON (not truncated/half-written)
+    try:
+        cache_data = read_cache_json(cache_path)
+        assert 'cache_format_version' in cache_data
+        assert 'fingerprint' in cache_data
+        assert 'files' in cache_data
+    except json.JSONDecodeError:
+        raise AssertionError("Cache file is not valid JSON (half-written?)")
+
+
+# ── Backward compatibility ──────────────────────────────────────────────────
+
+def test_scan_backward_compat_no_params(tmp_path, monkeypatch):
+    """scan(root) with no extra params maintains backward compatibility."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def hello(): pass\n',
+    })
+
+    # Call scan with no use_cache or rebuild_cache params
+    cache = CodeCache()
+    stats = cache.scan(str(root))
+
+    # Should work without errors, defaults to use_cache=True
+    assert 'files' in stats
+    assert 'symbols' in stats
+    assert 'loaded_from_cache' in stats
+
+
+def test_scan_backward_compat_skip_param(tmp_path, monkeypatch):
+    """scan(root, skip=...) maintains backward compatibility."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+        'node_modules/pkg/lib.js': 'function bar() {}',
+    })
+
+    # Call scan with skip parameter
+    cache = CodeCache()
+    skip_set = {'node_modules'}
+    stats = cache.scan(str(root), skip=skip_set)
+
+    # Should work and respect skip
+    assert 'files' in stats
+    assert stats['files'] == 1  # Only code.py, node_modules skipped
+
+
+# ── Cache path generation ──────────────────────────────────────────────────
+
+def test_cache_path_for_deterministic(tmp_path):
+    """cache_path_for() is deterministic: same root -> same path."""
+    root = str((tmp_path / 'project').resolve())
+
+    path1 = cache_path_for(root)
+    path2 = cache_path_for(root)
+
+    assert path1 == path2, "cache_path_for should be deterministic"
+
+
+def test_cache_path_for_honors_env(tmp_path, monkeypatch):
+    """cache_path_for() honors TREESIT_CACHE_DIR env var."""
+    cache_dir = tmp_path / 'custom_cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = str((tmp_path / 'project').resolve())
+    cache_path = cache_path_for(root)
+
+    # Cache should be under custom dir
+    assert str(cache_path).startswith(str(cache_dir)), \
+        f"Cache path {cache_path} should be under {cache_dir}"
+
+
+def test_cache_path_for_derives_from_root_hash(tmp_path, monkeypatch):
+    """cache_path_for() filename derived from sha256 of root."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root1 = str((tmp_path / 'project1').resolve())
+    root2 = str((tmp_path / 'project2').resolve())
+
+    path1 = cache_path_for(root1)
+    path2 = cache_path_for(root2)
+
+    # Paths should be different (derived from different roots)
+    assert path1 != path2, "Different roots should have different cache paths"
+    assert path1.parent == path2.parent, "Should be in same cache dir"
+
+
+# ── Fingerprint generation ──────────────────────────────────────────────────
+
+def test_fingerprint_changes_on_file_add(tmp_path, monkeypatch):
+    """CodeCache._fingerprint() changes when file is added."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    cache = CodeCache()
+
+    # First fingerprint
+    fp1 = cache._fingerprint(str(root), None)
+
+    # Add a file
+    (root / 'new.py').write_text('def bar(): pass\n')
+
+    # Second fingerprint should differ
+    fp2 = cache._fingerprint(str(root), None)
+
+    assert fp1 != fp2, "Fingerprint should change when file is added"
+
+
+def test_fingerprint_changes_on_skip_change(tmp_path, monkeypatch):
+    """_fingerprint() changes when skip set changes."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+        'test.py': 'def test_foo(): pass\n',
+    })
+
+    cache = CodeCache()
+
+    # Fingerprint with no skip
+    fp1 = cache._fingerprint(str(root), None)
+
+    # Fingerprint with skip={'test.py'}
+    fp2 = cache._fingerprint(str(root), {'test.py'})
+
+    assert fp1 != fp2, "Fingerprint should change when skip set changes"
+
+
+def test_fingerprint_stable_on_unchanged_tree(tmp_path, monkeypatch):
+    """_fingerprint() is stable across re-scans of unchanged tree."""
+    cache_dir = tmp_path / 'cache'
+    cache_dir.mkdir()
+    monkeypatch.setenv('TREESIT_CACHE_DIR', str(cache_dir))
+
+    root = create_test_tree(tmp_path / 'project', {
+        'code.py': 'def foo(): pass\n',
+    })
+
+    cache = CodeCache()
+
+    # Get fingerprints at different times
+    fp1 = cache._fingerprint(str(root), None)
+    time.sleep(0.01)
+    fp2 = cache._fingerprint(str(root), None)
+
+    assert fp1 == fp2, "Fingerprint should be stable for unchanged tree"
+
+
+# ── Standalone runner ───────────────────────────────────────────────────────
+
+if __name__ == '__main__':
+    import traceback
+
+    # Collect tests
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith('test_') and callable(v)]
+
+    # Run with fixtures support (simplified: just tmp_path via tempfile)
+    passed = failed = 0
+    for test in tests:
+        # Create tmp_path for each test
+        tmp_path = Path(tempfile.mkdtemp())
+        try:
+            # Create monkeypatch mock
+            class Monkeypatch:
+                def setenv(self, key, val):
+                    os.environ[key] = val
+
+            monkeypatch = Monkeypatch()
+
+            # Run test
+            test(tmp_path, monkeypatch)
+            passed += 1
+            print(f"  ✓ {test.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"  ✗ {test.__name__}: {e}")
+            traceback.print_exc()
+        finally:
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/tree-sitting/tests/test_cache_roundtrip.py
+++ b/tree-sitting/tests/test_cache_roundtrip.py
@@ -1,0 +1,601 @@
+"""Tests for cache roundtrip equivalence: fresh parse vs cache hit.
+
+This tests the core cache invariant: query results must be byte-identical
+whether served from a fresh parse or a cache hit.
+
+Run: python -m pytest tests/test_cache_roundtrip.py -v
+Or:  python tests/test_cache_roundtrip.py  (standalone)
+"""
+
+import sys
+import os
+import tempfile
+import shutil
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Bootstrap parsers before importing engine
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+
+from engine import (
+    CodeCache, Symbol, FileEntry, _get_parser,
+)
+
+# These are not yet implemented; tests will fail trying to use them.
+# They're listed here for reference of what contract they must fulfill.
+try:
+    from engine import CACHE_FORMAT_VERSION, cache_path_for
+except ImportError:
+    CACHE_FORMAT_VERSION = None
+    cache_path_for = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def create_fixture_repo(tmpdir: str) -> str:
+    """Create a multi-language fixture repo for testing.
+
+    Returns the root path.
+    """
+    root = Path(tmpdir)
+
+    # Python files
+    (root / 'py_module.py').write_text('''
+class UserManager:
+    """Manages users."""
+    def find_by_id(self, user_id: int):
+        """Find a user by ID."""
+        return None
+    def create_user(self, name: str):
+        pass
+
+def process_data(items):
+    """Process data items."""
+    return []
+''')
+
+    (root / 'utils.py').write_text('''
+import os
+import sys
+from pathlib import Path
+
+def read_config():
+    return {}
+
+class Config:
+    def __init__(self):
+        self.debug = False
+''')
+
+    # JavaScript/TypeScript files
+    (root / 'app.js').write_text('''
+/** Main application. */
+class App {
+    /** Initialize the app. */
+    init(config) {
+        this.config = config;
+    }
+
+    /** Start the server. */
+    start() {
+        console.log('Starting...');
+    }
+}
+
+function createApp(name) {
+    return new App();
+}
+
+const shutdown = async () => {};
+''')
+
+    (root / 'types.ts').write_text('''
+interface User {
+    id: number;
+    name: string;
+}
+
+interface Config {
+    debug: boolean;
+    port: number;
+}
+
+function createUser(name: string): User {
+    return { id: 1, name };
+}
+
+export const DEFAULT_CONFIG: Config = {
+    debug: false,
+    port: 3000,
+};
+''')
+
+    # C file
+    (root / 'utils.c').write_text('''
+#include <stdio.h>
+
+int add(int a, int b) {
+    return a + b;
+}
+
+typedef struct {
+    int x;
+    int y;
+} Point;
+
+enum Color { RED, GREEN, BLUE };
+''')
+
+    # Create a subdirectory with more files
+    sub = root / 'src'
+    sub.mkdir()
+
+    (sub / 'core.py').write_text('''
+class Engine:
+    def __init__(self):
+        self.state = None
+
+    def run(self):
+        """Run the engine."""
+        pass
+
+    def stop(self):
+        pass
+''')
+
+    # Markdown file
+    (root / 'README.md').write_text('''
+# My Project
+
+## Overview
+
+This is a test project.
+
+### Features
+
+- Feature 1
+- Feature 2
+
+## Usage
+
+See below.
+''')
+
+    return str(root)
+
+
+# ── Test: Cache Roundtrip Equivalence ────────────────────────────────────
+
+def test_cache_roundtrip_fresh_then_hit():
+    """Verify cache hit returns identical results to fresh parse.
+
+    1. Scan fresh repo with use_cache=True (writes cache)
+    2. Create new CodeCache, scan same repo (should hit cache)
+    3. Assert all query outputs are identical
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        # ── Fresh scan (writes cache) ──
+        cache_fresh = CodeCache()
+        stats_fresh = cache_fresh.scan(repo_root, use_cache=True)
+
+        assert 'loaded_from_cache' in stats_fresh, \
+            "scan() must return 'loaded_from_cache' key"
+        assert stats_fresh['loaded_from_cache'] is False, \
+            "First scan should not load from cache"
+        assert stats_fresh['files'] > 0, "Fixture should have files"
+
+        # Capture fresh results from all query functions
+        fresh_results = {
+            'tree_overview': cache_fresh.tree_overview(),
+            'dir_overview': cache_fresh.dir_overview(''),
+            'find_symbol_create': cache_fresh.find_symbol('create*'),
+            'find_symbol_exact': cache_fresh.find_symbol('UserManager'),
+            'file_symbols_py': cache_fresh.file_symbols('py_module.py'),
+            'file_imports_utils': cache_fresh.file_imports('utils.py'),
+            'references_Config': cache_fresh.references('Config'),
+            'get_source_range': cache_fresh.get_source_range('utils.py', 6, 8),
+        }
+
+        # Verify fresh results are non-empty/valid
+        assert fresh_results['tree_overview'], "tree_overview should return content"
+        assert fresh_results['dir_overview'], "dir_overview should return content"
+        assert len(fresh_results['find_symbol_create']) > 0, \
+            "Should find symbols matching 'create*'"
+        assert len(fresh_results['find_symbol_exact']) > 0, \
+            "Should find exact symbol 'UserManager'"
+
+        # ── Cache hit scan ──
+        cache_hit = CodeCache()
+        stats_hit = cache_hit.scan(repo_root, use_cache=True)
+
+        assert stats_hit['loaded_from_cache'] is True, \
+            "Second scan should load from cache"
+
+        # Capture results from cache hit
+        hit_results = {
+            'tree_overview': cache_hit.tree_overview(),
+            'dir_overview': cache_hit.dir_overview(''),
+            'find_symbol_create': cache_hit.find_symbol('create*'),
+            'find_symbol_exact': cache_hit.find_symbol('UserManager'),
+            'file_symbols_py': cache_hit.file_symbols('py_module.py'),
+            'file_imports_utils': cache_hit.file_imports('utils.py'),
+            'references_Config': cache_hit.references('Config'),
+            'get_source_range': cache_hit.get_source_range('utils.py', 6, 8),
+        }
+
+        # ── Equivalence: all results must be identical ──
+        assert fresh_results['tree_overview'] == hit_results['tree_overview'], \
+            "tree_overview must return identical results"
+        assert fresh_results['dir_overview'] == hit_results['dir_overview'], \
+            "dir_overview must return identical results"
+
+        # find_symbol results: compare by symbol names and properties
+        fresh_names = {s.name for s in fresh_results['find_symbol_create']}
+        hit_names = {s.name for s in hit_results['find_symbol_create']}
+        assert fresh_names == hit_names, \
+            "find_symbol('create*') must return same symbol names"
+
+        fresh_exact = fresh_results['find_symbol_exact']
+        hit_exact = hit_results['find_symbol_exact']
+        assert len(fresh_exact) == len(hit_exact), \
+            "find_symbol exact match must return same count"
+        if fresh_exact:
+            s_fresh = fresh_exact[0]
+            s_hit = hit_exact[0]
+            assert s_fresh.name == s_hit.name, "Symbol names must match"
+            assert s_fresh.kind == s_hit.kind, "Symbol kinds must match"
+            assert s_fresh.file == s_hit.file, "Symbol files must match"
+            assert s_fresh.line == s_hit.line, "Symbol lines must match"
+
+        # file_symbols comparison
+        fresh_file_syms = fresh_results['file_symbols_py']
+        hit_file_syms = hit_results['file_symbols_py']
+        assert len(fresh_file_syms) == len(hit_file_syms), \
+            "file_symbols must return same count"
+        for fs, hs in zip(fresh_file_syms, hit_file_syms):
+            assert fs.name == hs.name, "file_symbols names must match"
+            assert fs.kind == hs.kind, "file_symbols kinds must match"
+
+        # file_imports comparison
+        fresh_imps = fresh_results['file_imports_utils']
+        hit_imps = hit_results['file_imports_utils']
+        assert fresh_imps == hit_imps, \
+            "file_imports must return identical list"
+
+        # references comparison
+        fresh_refs = fresh_results['references_Config']
+        hit_refs = hit_results['references_Config']
+        assert len(fresh_refs) == len(hit_refs), \
+            "references must return same count"
+        assert fresh_refs == hit_refs, \
+            "references must return identical results"
+
+        # get_source_range comparison
+        assert fresh_results['get_source_range'] == hit_results['get_source_range'], \
+            "get_source_range must return identical source"
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cache_no_parsing_on_hit():
+    """Verify parser factory is NOT called on cache hit.
+
+    Monkeypatch _get_parser to track calls:
+    - Fresh scan: _get_parser MUST be called
+    - Cache hit scan: _get_parser MUST NOT be called
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        # ── Fresh scan with spy ──
+        parse_call_count_fresh = 0
+        original_get_parser = None
+
+        def spy_get_parser(lang):
+            nonlocal parse_call_count_fresh
+            parse_call_count_fresh += 1
+            return original_get_parser(lang)
+
+        # Fresh scan
+        original_get_parser = _get_parser.__wrapped__ if hasattr(_get_parser, '__wrapped__') else _get_parser
+        with patch('engine._get_parser', side_effect=spy_get_parser) as mock_parser:
+            cache_fresh = CodeCache()
+            stats_fresh = cache_fresh.scan(repo_root, use_cache=True)
+            fresh_parse_calls = mock_parser.call_count
+
+        assert stats_fresh['loaded_from_cache'] is False
+        assert fresh_parse_calls > 0, \
+            "Fresh scan should call _get_parser for language detection"
+
+        # ── Cache hit with spy ──
+        parse_call_count_hit = 0
+
+        def spy_get_parser_hit(lang):
+            nonlocal parse_call_count_hit
+            parse_call_count_hit += 1
+            return original_get_parser(lang)
+
+        with patch('engine._get_parser', side_effect=spy_get_parser_hit) as mock_parser_hit:
+            cache_hit = CodeCache()
+            stats_hit = cache_hit.scan(repo_root, use_cache=True)
+            hit_parse_calls = mock_parser_hit.call_count
+
+        assert stats_hit['loaded_from_cache'] is True, \
+            "Second scan should load from cache"
+
+        # On cache hit, _get_parser should NOT be called at all
+        # (the cache contains already-extracted symbols, no parsing needed)
+        assert hit_parse_calls == 0, \
+            f"Cache hit should not call _get_parser, but got {hit_parse_calls} calls"
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cache_use_cache_false():
+    """Verify use_cache=False never reads or writes cache.
+
+    Scan with use_cache=False twice:
+    - Both scans return loaded_from_cache=False
+    - Results still correct
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        # First scan with use_cache=False
+        cache1 = CodeCache()
+        stats1 = cache1.scan(repo_root, use_cache=False)
+
+        assert stats1['loaded_from_cache'] is False, \
+            "use_cache=False should never load from cache"
+        assert stats1['files'] > 0, "Should parse files"
+
+        results1 = {
+            'tree_overview': cache1.tree_overview(),
+            'symbols': cache1.find_symbol('create*'),
+        }
+
+        # Second scan with use_cache=False
+        cache2 = CodeCache()
+        stats2 = cache2.scan(repo_root, use_cache=False)
+
+        assert stats2['loaded_from_cache'] is False, \
+            "use_cache=False should never load from cache"
+
+        results2 = {
+            'tree_overview': cache2.tree_overview(),
+            'symbols': cache2.find_symbol('create*'),
+        }
+
+        # Results should still be identical
+        assert results1['tree_overview'] == results2['tree_overview']
+        assert len(results1['symbols']) == len(results2['symbols'])
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cache_rebuild_cache_flag():
+    """Verify rebuild_cache=True forces fresh parse and overwrites cache.
+
+    Scan with rebuild_cache=True should:
+    - Return loaded_from_cache=False
+    - Parse fresh
+    - Overwrite the cache file
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        # Initial scan
+        cache1 = CodeCache()
+        stats1 = cache1.scan(repo_root, use_cache=True)
+        assert stats1['loaded_from_cache'] is False
+
+        results1 = cache1.find_symbol('UserManager')
+
+        # Rebuild cache
+        cache2 = CodeCache()
+        stats2 = cache2.scan(repo_root, use_cache=True, rebuild_cache=True)
+
+        assert stats2['loaded_from_cache'] is False, \
+            "rebuild_cache=True should parse fresh, not load"
+
+        results2 = cache2.find_symbol('UserManager')
+
+        # Results should match
+        assert len(results1) == len(results2), \
+            "rebuild_cache should produce same results as original parse"
+        if results1:
+            assert results1[0].name == results2[0].name
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cache_format_version_defined():
+    """Verify CACHE_FORMAT_VERSION constant exists and is an int."""
+    assert hasattr(__import__('engine'), 'CACHE_FORMAT_VERSION'), \
+        "engine.CACHE_FORMAT_VERSION must be defined"
+    version = __import__('engine').CACHE_FORMAT_VERSION
+    assert isinstance(version, int), \
+        f"CACHE_FORMAT_VERSION must be int, got {type(version)}"
+
+
+def test_cache_path_for_function():
+    """Verify cache_path_for() function exists and returns Path.
+
+    Should:
+    - Return a pathlib.Path
+    - Be deterministic (same root -> same path)
+    - Honor TREESIT_CACHE_DIR env var if set
+    """
+    assert hasattr(__import__('engine'), 'cache_path_for'), \
+        "engine.cache_path_for must be defined"
+
+    # Test determinism
+    root = '/some/project/root'
+    path1 = cache_path_for(root)
+    path2 = cache_path_for(root)
+
+    assert isinstance(path1, Path), "cache_path_for must return pathlib.Path"
+    assert path1 == path2, "cache_path_for must be deterministic"
+
+
+def test_cache_fingerprint_method():
+    """Verify CodeCache._fingerprint() method exists and works.
+
+    Should:
+    - Return a string
+    - Be stable across rescans of unchanged tree
+    - Change on file add/remove/modify
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        cache = CodeCache()
+
+        assert hasattr(cache, '_fingerprint'), \
+            "CodeCache must have _fingerprint method"
+
+        # Get fingerprint before any changes
+        fp1 = cache._fingerprint(repo_root, skip=None)
+        assert isinstance(fp1, str), "_fingerprint must return string"
+        assert len(fp1) > 0, "_fingerprint must return non-empty string"
+
+        # Get fingerprint again (should be identical)
+        fp2 = cache._fingerprint(repo_root, skip=None)
+        assert fp1 == fp2, "_fingerprint must be stable for unchanged tree"
+
+        # Modify a file
+        mod_file = Path(repo_root) / 'utils.py'
+        mod_file.write_text(mod_file.read_text() + '\n# comment')
+
+        # Fingerprint should change
+        fp3 = cache._fingerprint(repo_root, skip=None)
+        assert fp3 != fp1, "_fingerprint must change when file is modified"
+
+        # Add a file
+        new_file = Path(repo_root) / 'new.py'
+        new_file.write_text('# new file')
+
+        fp4 = cache._fingerprint(repo_root, skip=None)
+        assert fp4 != fp3, "_fingerprint must change when file is added"
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cache_file_entry_lazy_source():
+    """Verify lazy source loading: tree=None and source=None on cache hit.
+
+    After cache hit, FileEntry should have:
+    - tree: None (not loaded)
+    - source: None (not loaded)
+    - symbols: populated from cache
+    - But get_source_range() still works by lazily reading disk
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        # Fresh scan
+        cache_fresh = CodeCache()
+        cache_fresh.scan(repo_root, use_cache=True)
+
+        fresh_entry = cache_fresh.files.get('utils.py')
+        assert fresh_entry is not None
+        assert fresh_entry.source is not None, "Fresh parse should have source"
+        assert fresh_entry.tree is not None, "Fresh parse should have tree"
+
+        # Cache hit
+        cache_hit = CodeCache()
+        cache_hit.scan(repo_root, use_cache=True)
+
+        hit_entry = cache_hit.files.get('utils.py')
+        assert hit_entry is not None
+
+        # On cache hit, tree and source should be None (lazy loaded)
+        if cache_hit.root:  # Only check if cache was actually loaded
+            assert hit_entry.tree is None, \
+                "Cache hit should not load tree (lazy loading)"
+            assert hit_entry.source is None, \
+                "Cache hit should not load source (lazy loading)"
+
+            # But symbols should be populated
+            assert len(hit_entry.symbols) > 0, \
+                "Cache hit should populate symbols"
+
+            # And get_source_range() should still work (lazy loading)
+            source = cache_hit.get_source_range('utils.py', 6, 8)
+            assert 'read_config' in source or 'return {}' in source, \
+                "get_source_range should work with lazy source loading"
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cache_symbol_children_roundtrip():
+    """Verify Symbol.to_dict(include_children=True) roundtrips correctly.
+
+    Cache stores symbols via to_dict(), must deserialize children properly.
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        repo_root = create_fixture_repo(tmpdir)
+
+        # Fresh scan
+        cache_fresh = CodeCache()
+        cache_fresh.scan(repo_root, use_cache=True)
+
+        # Find a symbol with children (class)
+        user_mgr = cache_fresh.find_symbol('UserManager')
+        assert len(user_mgr) > 0
+
+        fresh_sym = user_mgr[0]
+        assert fresh_sym.kind == 'class'
+        fresh_children_names = {c.name for c in fresh_sym.children}
+
+        # Cache hit
+        cache_hit = CodeCache()
+        cache_hit.scan(repo_root, use_cache=True)
+
+        user_mgr_hit = cache_hit.find_symbol('UserManager')
+        assert len(user_mgr_hit) > 0
+
+        hit_sym = user_mgr_hit[0]
+        hit_children_names = {c.name for c in hit_sym.children}
+
+        # Children must match
+        assert fresh_children_names == hit_children_names, \
+            "Symbol children must roundtrip correctly through cache"
+
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+# ── Standalone runner ────────────────────────────────────────────────────
+
+if __name__ == '__main__':
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_') and callable(v)]
+    passed = failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+            print(f"  ✓ {test.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"  ✗ {test.__name__}: {e}")
+            traceback.print_exc()
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/tree-sitting/tests/test_cli_cache.py
+++ b/tree-sitting/tests/test_cli_cache.py
@@ -1,0 +1,394 @@
+"""Tests for tree-sitting CLI cache integration.
+
+Tests the --no-cache and --rebuild-cache flags, cache file creation/loading,
+and the "(cached)" marker in stats output.
+
+Run: python -m pytest tests/test_cli_cache.py -v
+Or:  cd /home/user/claude-skills/tree-sitting && python -m pytest tests/test_cli_cache.py -v
+"""
+
+import sys
+import os
+import subprocess
+import tempfile
+import shutil
+from pathlib import Path
+
+
+class TestCLICacheIntegration:
+    """CLI invocations with caching behavior."""
+
+    @staticmethod
+    def _fixture_repo(tmp_path: Path) -> Path:
+        """Create a minimal test repository with Python and Rust files."""
+        repo = tmp_path / "fixture_repo"
+        repo.mkdir()
+
+        # Python file with named symbols
+        py_file = repo / "example.py"
+        py_file.write_text("""\
+def greet(name: str) -> str:
+    \"\"\"Greet someone.\"\"\"
+    return f"Hello, {name}!"
+
+
+class UserService:
+    \"\"\"Manages users.\"\"\"
+
+    def find_by_id(self, user_id: int):
+        \"\"\"Find a user by ID.\"\"\"
+        return None
+
+    def create(self, name: str):
+        \"\"\"Create a new user.\"\"\"
+        return {"name": name}
+
+
+def utility_function():
+    pass
+""")
+
+        # Rust file with named symbols
+        rs_file = repo / "lib.rs"
+        rs_file.write_text("""\
+pub struct Config {
+    pub name: String,
+}
+
+pub trait Handler {
+    fn handle(&self);
+}
+
+pub fn create_config(name: &str) -> Config {
+    Config {
+        name: name.to_string(),
+    }
+}
+
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+impl Config {
+    pub fn new(name: String) -> Self {
+        Config { name }
+    }
+}
+""")
+
+        return repo
+
+    @staticmethod
+    def _run_cli(repo_path: str, cache_dir: str, queries: list = None, flags: list = None) -> tuple[str, str, int]:
+        """Run treesit.py CLI and return (stdout, stderr, returncode).
+
+        repo_path: absolute path to repo to scan
+        cache_dir: absolute path to cache directory (set as TREESIT_CACHE_DIR env)
+        queries: list of query strings (e.g., ['find:greet', 'find:Config'])
+        flags: list of flag strings (e.g., ['--no-cache', '--stats'])
+        """
+        python = "/home/claude/.venv/bin/python"
+        treesit_py = "/home/user/claude-skills/tree-sitting/scripts/treesit.py"
+
+        cmd = [python, treesit_py, repo_path]
+        if flags:
+            cmd.extend(flags)
+        if queries:
+            cmd.extend(queries)
+
+        env = os.environ.copy()
+        env["TREESIT_CACHE_DIR"] = cache_dir
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd="/home/user/claude-skills/tree-sitting"
+        )
+
+        return result.stdout, result.stderr, result.returncode
+
+    def test_first_invocation_creates_cache_no_marker(self, tmp_path: Path):
+        """First CLI invocation parses and creates cache; no '(cached)' in stats."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation: should parse (no cache yet)
+        stdout, stderr, rc = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[],
+            flags=["--stats"]
+        )
+
+        assert rc == 0, f"CLI failed: {stderr}"
+        assert "(cached)" not in stdout, "First run should NOT show '(cached)' marker"
+        assert "Scanned" in stdout, "Stats output should be present"
+
+        # Cache file should now exist
+        cache_files = list(cache_dir.glob("*"))
+        assert len(cache_files) > 0, "Cache file should be created after first invocation"
+
+    def test_second_invocation_serves_from_cache(self, tmp_path: Path):
+        """Second identical invocation served from cache; stats show '(cached)'."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation
+        self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+
+        # Second invocation: should hit cache
+        stdout, stderr, rc = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[],
+            flags=["--stats"]
+        )
+
+        assert rc == 0, f"CLI failed: {stderr}"
+        assert "(cached)" in stdout, "Second run should show '(cached)' marker in stats"
+
+    def test_no_cache_flag_disables_cache(self, tmp_path: Path):
+        """--no-cache flag: never read/write cache; no '(cached)' even on repeat."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation with --no-cache
+        stdout1, stderr1, rc1 = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[],
+            flags=["--no-cache", "--stats"]
+        )
+        assert rc1 == 0, f"First --no-cache run failed: {stderr1}"
+        assert "(cached)" not in stdout1, "First --no-cache run should NOT have '(cached)'"
+
+        # Verify no cache file created
+        cache_files = list(cache_dir.glob("*"))
+        assert len(cache_files) == 0, "Cache file should NOT be created with --no-cache"
+
+        # Second invocation with --no-cache (identical to first)
+        stdout2, stderr2, rc2 = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[],
+            flags=["--no-cache", "--stats"]
+        )
+        assert rc2 == 0, f"Second --no-cache run failed: {stderr2}"
+        assert "(cached)" not in stdout2, "Repeat --no-cache run should NOT have '(cached)'"
+
+        # Still no cache file
+        cache_files = list(cache_dir.glob("*"))
+        assert len(cache_files) == 0, "Cache file should still NOT exist after second --no-cache run"
+
+        # Positive control: prove caching is real, so the negatives above aren't
+        # vacuously green. A normal run creates a cache; a normal repeat is a hit.
+        self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        pc_out, _, pc_rc = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert pc_rc == 0
+        assert list(cache_dir.glob("*")), "positive control: a cache-enabled run must create a cache file"
+        assert "(cached)" in pc_out, "positive control: a cache-enabled repeat must show '(cached)'"
+
+    def test_rebuild_cache_flag_refreshes_cache(self, tmp_path: Path):
+        """--rebuild-cache: ignore existing cache, re-parse, and overwrite cache."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation: normal (creates cache)
+        self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+
+        # Positive control: a normal repeat must be a cache hit, so the
+        # "not (cached)" assertion below is meaningful rather than vacuous.
+        pc_out, _, pc_rc = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert pc_rc == 0
+        assert "(cached)" in pc_out, "positive control: normal repeat must be a cache hit"
+
+        # Second invocation with --rebuild-cache
+        stdout, stderr, rc = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[],
+            flags=["--rebuild-cache", "--stats"]
+        )
+
+        assert rc == 0, f"--rebuild-cache run failed: {stderr}"
+        assert "(cached)" not in stdout, "--rebuild-cache should NOT show '(cached)' marker"
+        assert "Scanned" in stdout, "Stats should be present (fresh parse)"
+
+    def test_multi_query_with_cache(self, tmp_path: Path):
+        """Batched multi-query invocation with caching: scans once, runs all queries."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Multi-query invocation with find and source
+        stdout, stderr, rc = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=["find:greet", "find:Config", "source:UserService"],
+            flags=["--stats"]
+        )
+
+        assert rc == 0, f"Multi-query run failed: {stderr}"
+        assert "Scanned" in stdout, "Stats should be present"
+
+        # All three queries should appear in output
+        # Note: the exact output depends on implementation, but should include results
+        assert stdout, "Query results should be in output"
+
+        # A second identical batched run must be a cache hit and return the same
+        # results (proving the cache path serves batched queries correctly).
+        stdout2, stderr2, rc2 = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=["find:greet", "find:Config", "source:UserService"],
+            flags=["--stats"],
+        )
+        assert rc2 == 0, f"Second multi-query run failed: {stderr2}"
+        assert "(cached)" in stdout2, "batched multi-query repeat must be a cache hit"
+
+    def test_cache_hit_and_no_cache_identical_output(self, tmp_path: Path):
+        """Cache-hit and --no-cache runs produce identical query output (except stats)."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        query = "find:greet"
+        flags_normal = ["--stats"]
+        flags_no_cache = ["--no-cache", "--stats"]
+
+        # First: populate cache
+        self._run_cli(str(repo), str(cache_dir), queries=[query], flags=flags_normal)
+
+        # Second: hit cache
+        stdout_cached, stderr_cached, rc_cached = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[query],
+            flags=flags_normal
+        )
+        assert rc_cached == 0
+
+        # Third: no-cache (equivalent of re-parsing)
+        stdout_no_cache, stderr_no_cache, rc_no_cache = self._run_cli(
+            str(repo),
+            str(cache_dir),
+            queries=[query],
+            flags=flags_no_cache
+        )
+        assert rc_no_cache == 0
+
+        # Strip the stats lines (they'll differ due to "(cached)" marker and timing)
+        # and compare the rest
+        def extract_query_output(output: str) -> str:
+            """Extract query results, stripping stats and timing info."""
+            lines = output.split('\n')
+            # Skip lines with "Scanned", "Symbols:", "Errors:", "(cached)", timing
+            filtered = [
+                line for line in lines
+                if line and not any(x in line for x in ["Scanned", "Symbols:", "Errors:", "(cached)"])
+            ]
+            return '\n'.join(filtered)
+
+        query_out_cached = extract_query_output(stdout_cached)
+        query_out_no_cache = extract_query_output(stdout_no_cache)
+
+        assert query_out_cached, "Cache hit should produce query output"
+        assert query_out_no_cache, "No-cache run should produce query output"
+        # The essential query results should be identical
+        assert query_out_cached == query_out_no_cache, \
+            f"Query output differs between cache-hit and no-cache.\nCached:\n{query_out_cached}\n\nNo-cache:\n{query_out_no_cache}"
+
+    def test_cache_survives_tree_unchanged(self, tmp_path: Path):
+        """Cache is reused across invocations when files are unchanged."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation
+        stdout1, _, rc1 = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert rc1 == 0
+        assert "(cached)" not in stdout1
+
+        # Second invocation (same repo, same files)
+        stdout2, _, rc2 = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert rc2 == 0
+        assert "(cached)" in stdout2, "Cache should be reused when files unchanged"
+
+    def test_cache_invalidated_on_file_change(self, tmp_path: Path):
+        """Cache is invalidated when files are modified."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation
+        self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+
+        # Positive control: unchanged repeat must be a cache hit before we can
+        # meaningfully assert that a modification invalidates it.
+        pc_out, _, _ = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert "(cached)" in pc_out, "cache must engage on an unchanged repeat first"
+
+        # Modify a file
+        py_file = repo / "example.py"
+        py_file.write_text(py_file.read_text() + "\n\ndef new_function():\n    pass\n")
+
+        # Third invocation: should detect change and re-parse (no "(cached)")
+        stdout3, _, rc3 = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert rc3 == 0
+        assert "(cached)" not in stdout3, "Cache should be invalidated after file modification"
+
+    def test_cache_invalidated_on_file_add(self, tmp_path: Path):
+        """Cache is invalidated when new files are added."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation
+        self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+
+        # Positive control: unchanged repeat must be a cache hit first.
+        pc_out, _, _ = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert "(cached)" in pc_out, "cache must engage on an unchanged repeat first"
+
+        # Add a new file
+        new_file = repo / "new_module.py"
+        new_file.write_text("def new_func():\n    pass\n")
+
+        # Third invocation: should detect change and re-parse
+        stdout3, _, rc3 = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert rc3 == 0
+        assert "(cached)" not in stdout3, "Cache should be invalidated after adding file"
+
+    def test_cache_invalidated_on_file_delete(self, tmp_path: Path):
+        """Cache is invalidated when files are deleted."""
+        repo = self._fixture_repo(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # First invocation
+        self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+
+        # Positive control: unchanged repeat must be a cache hit first.
+        pc_out, _, _ = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert "(cached)" in pc_out, "cache must engage on an unchanged repeat first"
+
+        # Delete a file
+        py_file = repo / "example.py"
+        py_file.unlink()
+
+        # Third invocation: should detect change and re-parse
+        stdout3, _, rc3 = self._run_cli(str(repo), str(cache_dir), queries=[], flags=["--stats"])
+        assert rc3 == 0
+        assert "(cached)" not in stdout3, "Cache should be invalidated after deleting file"
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## What & why

The `tree-sitting` engine re-parsed the whole tree on **every** CLI invocation (~700 ms for a mid-size repo), so at the micro-decision "just show me this enum" `grep`/`sed` reflexively won — the AST tooling lost the ergonomics contest exactly where it should dominate. This adds a **persistent, filesystem-backed scan cache** so repeated drills in a session skip re-parsing, closing that gap.

This is the "cheap tier" of a larger plan; scope-graph reference resolution, an interner/mmap store, and `refs`-precision are explicitly **out of scope** here (deferred to a follow-up).

## How it works

- **Fingerprint-keyed cache.** `CodeCache._fingerprint()` hashes the sorted `(relpath, size, mtime_ns)` of the scanned fileset plus `CACHE_FORMAT_VERSION`. Any file add/remove/modify (or a version bump) invalidates it.
- **Derived index only.** The cache stores per file: `relpath`, `lang`, `symbols` (`Symbol.to_dict`), `imports` — **not** the tree-sitter `tree` or raw `source` (those aren't serializable / would bloat it). `Symbol.from_dict` reconstructs one level of children.
- **Lazy source.** On a cache hit, `FileEntry.source`/`tree` are `None`; `get_source_range()`/`references()` read the file from disk on demand and degrade gracefully if it's gone.
- **Robustness.** Atomic write (temp file + `os.replace`); corrupt / version-mismatch / fingerprint-mismatch caches silently fall back to a full parse — a bad cache never raises to the caller.
- **CLI.** `scan()` gains `use_cache`/`rebuild_cache`; stats carry `loaded_from_cache`. New flags `--no-cache` and `--rebuild-cache`, and a `(cached)` marker on the stats line.
- **Guidance.** SKILL.md documents the cache and makes batched `find:`/`source:`/`refs:` the default drill, with an explicit note not to fall back to `grep`/`sed` for symbol structure.

## Testing

TDD: ~90 tests written first (fingerprint/invalidation, fresh-vs-cache-hit equivalence with a no-parse spy, lifecycle/flags/atomicity/corruption fallback, lazy-source, CLI integration), then implemented to green.

- **Full suite: 96 passed** (28 pre-existing + new), 0 skipped.
- **End-to-end on a real tree:** cold parse **200 ms → cached 2 ms** (`(cached)` shown), `--no-cache` re-parses (no marker), `find:` still resolves against the cached index.

## Notes

- Cache location defaults to a temp dir; override with `TREESIT_CACHE_DIR`.
- Backward compatible: `scan(root)` / `scan(root, skip=...)` unchanged.
- SKILL.md `metadata.version` bumped `0.6.0 → 0.7.0` (feature) to trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gY6z3pMjtuzFnsNS9L5Kx

---
_Generated by [Claude Code](https://claude.ai/code/session_015gY6z3pMjtuzFnsNS9L5Kx)_