### PR TITLE
Subagent context-handoff guidance (exploring-codebases 2.4.0, agent-routing 1.2.0)

### DIFF
--- a/agent-routing/SKILL.md
+++ b/agent-routing/SKILL.md
@@ -4,7 +4,7 @@ description: Decide which model (Haiku/Sonnet/Opus) and effort level each subage
 compatibility: Designed for Claude Code / Claude Code on the Web — assumes an orchestrator with Agent/Workflow subagent tools exposing per-call model and effort options. Not applicable to claude.ai chat use.
 metadata:
   author: Oskar Austegard and Claude (Fable 5)
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Agent Routing — model + effort selection for subagents
@@ -24,6 +24,29 @@ reasoning depth demonstrably falls short.
 To turn a judgment-shaped task INTO a Haiku-executable one (explicit procedures,
 n-shot examples), use the sibling `down-skilling` skill. This skill decides the
 routing; that one engineers the prompt.
+
+## Context handoff — routing picks the tier; the prompt carries the context
+
+Subagents inherit nothing: not the conversation, not loaded skills, not the
+existence of artifacts already on disk. Every index, scan output, artifact
+path, or tool-invocation recipe the orchestrator relies on must be serialized
+into the subagent's prompt (or written to a file the prompt points at).
+Otherwise the agent falls back to blind rediscovery — and the tier premium is
+spent on crawling, not judgment. A Sonnet with no handoff wastes more than a
+Haiku with a good procedure.
+
+This is the context-side twin of down-skilling: that skill engineers the
+*procedure* into the prompt; this rule makes the *artifacts and tools* travel
+with it. Checklist per spawn: (1) artifact paths + how to query them, (2) tool
+commands verbatim (interpreter path included — subagents don't know your
+venv), (3) explicit anti-patterns ("no `ls`/glob discovery"), (4) an output
+spec. Skills that orchestrate fan-outs should embed this (see
+`exploring-codebases` for the worked exploration case).
+
+Evidence: 2026-07-16, four Sonnet Explore agents launched onto a 2,300-file
+repo without the handoff opened with `ls` crawls despite a full tree-sitter
+symbol index sitting on disk; relaunched with per-agent index slices + the
+verbatim tool command + anti-crawl rules, discovery cost dropped to ~zero.
 
 ## Routing table
 

--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   the divergent "what's here?" skill — for targeted "where is X?" queries,
   use searching-codebases instead.
 metadata:
-  version: 2.3.1
+  version: 2.4.0
 ---
 
 # Exploring Codebases
@@ -147,6 +147,42 @@ Two patterns that pair especially well:
 
 bm25 is corpus-agnostic — it'll also work on `project` knowledge stores
 or `uploads/` if your exploration spans docs, transcripts, or PDFs.
+
+## Delegating to subagents (large repos only, and only if subagents exist)
+
+**Gate first: does this environment expose a subagent tool** (Agent/Task in
+Claude Code and CCotw)? Claude.ai chat and bare-skill runs have none — run
+steps 2–4 inline and skip this section entirely. Never simulate fan-out by
+other means when the tool is absent.
+
+When the tool exists and the repo is large (>1000 files or several distinct
+subsystems), keep steps 2–3 inline — they're mechanical and cheap — and fan
+out only step 4's judgment work, one agent per subsystem.
+
+**Subagents inherit nothing.** Not your conversation, not this SKILL.md, not
+the knowledge that scan artifacts exist on disk. An agent prompted only with
+"explore `crates/foo`" will re-derive structure by `ls`/glob crawling at full
+tier cost. (Observed 2026-07-16: four Sonnet agents launched onto a
+2,300-file repo without the handoff spent their opening turns running `ls`,
+with the full symbol index already on disk.)
+
+Every subagent prompt must therefore carry:
+
+1. **Its structure slice, pre-computed.** Partition the gather output's
+   `## Public API` section by subsystem path prefix, write each slice to a
+   file, and point the agent at its file: "grep/Read this instead of listing
+   directories." Small slices (<50KB) can be pasted inline instead.
+2. **The treesit recipe verbatim** — the full command including the venv
+   python path, plus the batch rule (one invocation, many queries; each
+   invocation pays the scan, extra queries are free).
+3. **Anti-crawl instructions** — no `ls`/Glob for discovery; `Read` only to
+   confirm or expand a line range the slice or treesit already located.
+4. **An output spec** — what to report, a line budget, and "file paths +
+   line refs" so results are verifiable.
+
+Routing (see the `agent-routing` skill): multi-turn exploration is outside
+Haiku's calibrated zone — use `sonnet` for subsystem agents and keep the
+final cross-cluster synthesis in the orchestrator.
 
 ## Notes
 


### PR DESCRIPTION
## What

Two coordinated skill updates encoding a lesson from today's grok-build inventory session:

- **exploring-codebases → 2.4.0**: new *"Delegating to subagents (large repos only, and only if subagents exist)"* section. **Gated on the environment actually exposing a subagent tool** — claude.ai chat and bare-skill runs have none, so those stay inline. When the gate passes, prescribes: per-agent pre-computed gather slices (grep/Read a slice file instead of listing directories), the verbatim treesit command with batch rule, anti-crawl instructions, and an output spec. Routes subsystem agents to `sonnet` per agent-routing's multi-turn caveat.
- **agent-routing → 1.2.0**: new *"Context handoff — routing picks the tier; the prompt carries the context"* principle. Subagents inherit nothing; every artifact path and tool recipe the orchestrator relies on must be serialized into the spawn prompt or the tier premium is spent on rediscovery. Includes a 4-point per-spawn checklist and cross-links to `down-skilling` (procedure) and `exploring-codebases` (worked exploration case).

## Why

Observed 2026-07-16: four Sonnet Explore agents fanned onto xai-org/grok-build (2,300 files, 12.5k symbols) with prompts that named their crate clusters but omitted the treesit recipe and the already-on-disk gather scan. All four opened with `ls`/glob crawling, rediscovering structure that was pre-computed. Relaunched with per-agent index slices + verbatim tool commands + anti-crawl rules, discovery cost dropped to ~zero.

The defect was neither in routing (tier choice was correct) nor in tree-sitting (the tool worked) — it was the context handoff, which no skill covered. Primary fix lands in exploring-codebases (the orchestrating consumer); the generalized principle lands in agent-routing; tree-sitting stays clean since "paste my invocation block when delegating" is true of every script-backed skill and is now expressed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vzzwLCrZQgoddrdvqod1n

---
_Generated by [Claude Code](https://claude.ai/code/session_017vzzwLCrZQgoddrdvqod1n)_