### PR TITLE
Add creating-video skill; extend parsing-video for editing review

### DIFF
--- a/creating-video/SKILL.md
+++ b/creating-video/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: creating-video
+description: "Create video from prompts by overseeing multi-clip AI generation end to end: write a shot list, generate each scene with Google Veo (via the Cloudflare AI Gateway), review the results, and assemble them into a finished cut. Use when the user asks to make/generate a video, a short film, an animatic, or a multi-scene clip from a script or idea; when they mention Veo, text-to-video, or image-to-video; or when acting as the editing/director agent over generated footage. Triggers on 'make a video', 'generate a clip', 'short film', 'video from this script', 'turn this into a video', 'veo', 'text to video', 'storyboard to video'. For transcoding/trimming/merging/GIF/subtitles use processing-video; for reading or summarizing existing video content use parsing-video."
+metadata:
+  version: 0.1.0
+---
+
+# Creating Video
+
+Claude cannot render video itself, but it can direct a generator. This skill drives
+a multi-clip pipeline — **script → per-scene Veo generation → review → assembly** —
+with Claude as the editing agent overseeing continuity and cut.
+
+Requires `ffmpeg`/`ffprobe` and Cloudflare AI Gateway creds (`/mnt/project/proxy.env`).
+
+## The five stages
+
+1. **Shot list** — break the story into beats, ~5–8 s each, one prompt per shot.
+2. **Generate** — `scripts/veo_generate.py`, run detached.
+3. **Review** — `parsing-video` on each clip **and** on the assembled cut.
+4. **Assemble** — `scripts/assemble.py`, run detached.
+5. **Iterate** — re-review, regenerate only the failing scenes.
+
+## Stage 2 — Generation (Veo via Cloudflare AI Gateway)
+
+Auth is CF AI Gateway BYOK: `proxy.env` supplies `CF_ACCOUNT_ID`, `CF_GATEWAY_ID`,
+`CF_API_TOKEN`; the Google key lives *inside* the gateway, so both the generate
+call and the file download route through it.
+
+**Enumerate models — never hardcode.** Strings change.
+```bash
+python3 scripts/veo_generate.py --list
+# 2026-07-18: veo-3.1-generate-preview / -fast-generate-preview / -lite-generate-preview
+```
+
+**Run detached.** Veo takes 1–3 min per clip; `bash_tool` caps at ~50 s. Launch and
+adaptive-wait on the `DONE` sentinel:
+```bash
+# prompts.json = {"1": "...", "2": "...", ...}
+set -a; . /mnt/project/proxy.env; set +a
+(setsid python3 scripts/veo_generate.py prompts.json --out veo/ \
+    --negative "large paper, on-screen text, watermark" &)
+# then, in a separate call:
+timeout 45 sh -c 'while [ ! -f veo/DONE ]; do sleep 4; done'; cat veo/generate.log
+```
+
+**Gotchas (all diagnosed 2026-07-18 — the script already handles them):**
+- `personGeneration:"allow_adult"` → HTTP 400. Omit it.
+- ~5 concurrent operations max; the 6th returns 429. The script fires in waves and
+  refills slots as ops finish.
+- The egress proxy 503s on cold start → retry with backoff.
+- Output is an 8 s 1280×720 mp4 with native Veo audio.
+
+## Stage 3 — Review (use the parsing-video skill)
+
+Contact-sheet **each clip and the assembled cut**. Per-clip sheets miss cross-clip
+continuity; the full-cut sheet is where character drift, prop jumps, and logic
+breaks show up in one read (Oskar, 2026-07-18: review the whole assembly, not just
+scenes). Scan every sheet against the **continuity checklist**:
+
+- **Character** — same face/hair/wardrobe across every shot they appear in.
+- **Prop** — same identity, size, color, and attachment point shot to shot.
+- **Physical logic** — is the world coherent (a window must be open before a bird
+  lands on the sill)?
+- **Action completeness** — is the key action actually *shown*, not cut around?
+
+## Stage 4 — Assembly (`scripts/assemble.py`)
+
+Trims each 8 s clip to its beat, crossfades, drops audio by default, burns the
+payoff word, and holds the final frame so the ending lands.
+```bash
+(setsid python3 scripts/assemble.py veo/scene_1.mp4 ... veo/scene_6.mp4 \
+    --out film.mp4 --overlay-last "COMING HOME" --tail-hold 1.3 &)
+```
+Run detached too — six trims plus a 30 s stitch exceed the bash ceiling on the
+single-core container. Diagnosed: abrupt ending → `--tail-hold`; jarring cuts
+between six independent Veo ambiences → audio dropped by default (`--keep-audio`
+to `acrossfade` instead).
+
+## Prompt craft — continuity is the hard part
+
+Every failure mode below came from real crits on 2026-07-18. Write against them on
+the first pass; they are expensive to fix by regeneration.
+
+- **Lock a character sheet.** One verbatim appearance/wardrobe block, reused in
+  every shot with that character. Independent per-shot prompts produced three
+  different women and, once, a man's hands where the woman's were required.
+- **Lock the setting.** One room/location description across co-located scenes.
+- **Name the actor in every shot** ("the same woman's hands") — never leave it to
+  the model to infer who is on screen.
+- **Prop continuity is the weakest link and is not fully solvable by text.** Name
+  the prop's size, color, and attachment point in *every* shot, plus a
+  `negativePrompt` against its failure modes. Residual limitation: Veo still drifts
+  a prop across independent generations (a leg-scroll migrated between talons and
+  tail across shots even with locks). The hard fix is **image-to-video seeding** —
+  generate one canonical still of the prop/subject and pass it as the first-frame
+  image so the prop is pinned. Reach for it when text locks aren't enough.
+- **Spell out scene logic** — physical coherence (open vs closed window), the
+  correct order of beats (surprise at the *arrival*, not at the message), and
+  *show* the payoff action rather than cutting away from it.
+- **Thematic coherence.** Title, on-screen payoff, and story beat should cohere.
+  A drifting title/word resolves cleanly when the physical prop *is* the title.
+- **On-screen text.** Veo renders words unreliably. Keep "no on-screen text" in the
+  prompt and burn the payoff word in assembly (`assemble.py --overlay-last`).
+
+## Scope
+
+- Transcode / trim / merge / GIF / subtitles → **processing-video**.
+- Reading, summarizing, or QA of existing video content → **parsing-video** (also
+  the review step here).

--- a/creating-video/scripts/assemble.py
+++ b/creating-video/scripts/assemble.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+assemble.py — cut raw Veo clips into a finished short via ffmpeg.
+
+Encodes the editing facts learned 2026-07-18:
+  - Veo returns ~8s clips; trim each to its beat (~5s) picking a window past
+    the initial settle (default --ss 0.4).
+  - Drop audio by default (-an): crossfading 6 independent Veo ambiences is
+    jarring. Pass --keep-audio to acrossfade instead.
+  - xfade chain offset for equal clips of duration D with transition T:
+    offset_k = (k+1)*(D-T). Get this wrong and clips stack or gap.
+  - Veo renders on-screen WORDS unreliably, so keep "no on-screen text" in the
+    generation prompt and burn the payoff word here with drawtext.
+  - Abrupt endings: hold the final frame (--tail-hold) before the fade-out so
+    the last beat lands instead of being cut. (Oskar note, 2026-07-18.)
+  - Single-core container: encodes serialize; keep each ffmpeg invocation short.
+
+Usage:
+  python3 assemble.py c1.mp4 c2.mp4 ... c6.mp4 --out film.mp4 \
+      [--beat 5.42] [--xfade 0.5] [--keep-audio] \
+      [--overlay-last "COMING HOME"] [--overlay-at 3.2] \
+      [--tail-hold 1.2] [--font /path/to/Bold.ttf]
+"""
+import os, sys, json, argparse, subprocess, tempfile
+from pathlib import Path
+
+
+def _run(cmd):
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return p.returncode, p.stdout.decode(errors="replace")
+
+
+def _font():
+    for c in ("/usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf",
+              "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"):
+        if Path(c).exists():
+            return c
+    return None
+
+
+def assemble(clips, out, beat=5.42, xfade=0.5, keep_audio=False,
+             overlay_last=None, overlay_at=3.2, tail_hold=0.0,
+             size="1280:720", fps=25, font=None):
+    tmp = Path(tempfile.mkdtemp())
+    font = font or _font()
+    vf_base = (f"scale={size}:force_original_aspect_ratio=increase,"
+               f"crop={size},fps={fps}")
+    trimmed = []
+    n = len(clips)
+    for i, src in enumerate(clips):
+        vf = vf_base
+        last = (i == n - 1)
+        # hold last frame on the final clip by extending it via tpad
+        beat_i = beat + (tail_hold if last else 0.0)
+        if last and overlay_last and font:
+            dt = (f",drawtext=fontfile='{font}':text='{overlay_last}':"
+                  f"fontcolor=white:fontsize=72:x=(w-text_w)/2:y=h*0.82:"
+                  f"alpha='if(lt(t,{overlay_at}),0,min((t-{overlay_at})/1.5,0.94))':"
+                  f"shadowcolor=black:shadowx=3:shadowy=3")
+            vf += dt
+        if last and tail_hold > 0:
+            vf += f",tpad=stop_mode=clone:stop_duration={tail_hold}"
+        vf += ",format=yuv420p"
+        dst = tmp / f"t{i}.mp4"
+        audio = [] if not keep_audio else []
+        cmd = ["ffmpeg", "-y", "-ss", "0.4", "-t", f"{beat}", "-i", str(src),
+               "-vf", vf, "-r", str(fps)]
+        if not keep_audio:
+            cmd += ["-an"]
+        cmd += ["-c:v", "libx264", "-preset", "veryfast", "-crf", "20", str(dst)]
+        rc, log = _run(cmd)
+        if rc != 0 or not dst.exists():
+            raise RuntimeError(f"trim failed for {src}:\n{log[-400:]}")
+        trimmed.append(dst)
+
+    # xfade chain
+    inputs = []
+    for t in trimmed:
+        inputs += ["-i", str(t)]
+    D = beat  # clip duration for offset math (tail_hold handled inside last clip)
+    T = xfade
+    fc = ""
+    prev = "0"
+    total = D + tail_hold  # final clip is longer by tail_hold
+    for k in range(1, n):
+        off = k * (D - T)
+        lbl = "v" if k == n - 1 else f"x{k}"
+        fc += f"[{prev}][{k}]xfade=transition=fade:duration={T}:offset={off:.3f}[{lbl}];"
+        prev = lbl
+    full_len = (n * D) - ((n - 1) * T) + tail_hold
+    fc += (f"[v]fade=t=in:st=0:d=0.6,"
+           f"fade=t=out:st={full_len-1.0:.2f}:d=1.0,format=yuv420p[vv]")
+    cmd = ["ffmpeg", "-y"] + inputs + ["-filter_complex", fc, "-map", "[vv]",
+           "-r", str(fps), "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+           "-movflags", "+faststart", str(out)]
+    rc, log = _run(cmd)
+    if rc != 0 or not Path(out).exists():
+        raise RuntimeError(f"stitch failed:\n{log[-500:]}")
+    return out
+
+
+def _main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("clips", nargs="+")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--beat", type=float, default=5.42)
+    ap.add_argument("--xfade", type=float, default=0.5)
+    ap.add_argument("--keep-audio", action="store_true")
+    ap.add_argument("--overlay-last", default=None)
+    ap.add_argument("--overlay-at", type=float, default=3.2)
+    ap.add_argument("--tail-hold", type=float, default=0.0)
+    ap.add_argument("--font", default=None)
+    a = ap.parse_args()
+    out = assemble(a.clips, a.out, beat=a.beat, xfade=a.xfade,
+                   keep_audio=a.keep_audio, overlay_last=a.overlay_last,
+                   overlay_at=a.overlay_at, tail_hold=a.tail_hold, font=a.font)
+    rc, info = _run(["ffprobe", "-v", "error", "-show_entries",
+                     "format=duration", "-of", "csv=p=0", out])
+    print(f"wrote {out} ({info.strip()}s)")
+
+
+if __name__ == "__main__":
+    _main()

--- a/creating-video/scripts/veo_generate.py
+++ b/creating-video/scripts/veo_generate.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+veo_generate.py — generate video clips with Google Veo via the Cloudflare AI Gateway.
+
+Encodes the hard-won facts (all diagnosed 2026-07-18):
+  - Model strings are NOT stable. ENUMERATE, never hardcode: --list.
+  - Auth is CF AI Gateway BYOK (proxy.env); the Google key lives inside the
+    gateway, so both the generate call AND the file download route through it.
+  - Veo is predictLongRunning: fire -> poll operation -> download file URI.
+  - personGeneration:"allow_adult" -> HTTP 400 (unsupported). Omit it.
+  - ~5 concurrent operations max; the 6th returns 429. Fire in waves, refill
+    slots as ops complete.
+  - The egress proxy 503s on cold start; retry with backoff.
+  - bash_tool has a ~50s wall-clock ceiling. Veo takes 1-3 min/clip. RUN THIS
+    SCRIPT DETACHED (setsid ... &) and adaptive-wait on its DONE sentinel;
+    do not block a single bash call on generation.
+
+Usage:
+  python3 veo_generate.py --list                       # enumerate video models
+  python3 veo_generate.py prompts.json --out veo/ \
+      [--model veo-3.1-fast-generate-preview] \
+      [--aspect 16:9] [--negative "large paper, on-screen text"] \
+      [--max-concurrent 5]
+
+prompts.json: {"1": "prompt text", "2": "prompt text", ...}
+Writes veo/scene_<n>.mp4 for each, plus veo/DONE and veo/results.json on finish.
+"""
+import os, sys, json, time, argparse
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    os.system(f"{sys.executable} -m pip install requests --break-system-packages -q")
+    import requests
+
+BASE = "https://gateway.ai.cloudflare.com/v1"
+_PROXY_PATHS = [Path("/mnt/project/proxy.env"), Path("proxy.env"),
+                Path.home() / "proxy.env"]
+
+
+def gateway():
+    """Load CF AI Gateway creds and return (base_url, headers)."""
+    creds = {}
+    for p in _PROXY_PATHS:
+        if p.exists():
+            for line in p.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, _, v = line.partition("=")
+                    creds[k.strip()] = v.strip().strip('"').strip("'")
+            break
+    for k in ("CF_ACCOUNT_ID", "CF_GATEWAY_ID", "CF_API_TOKEN"):
+        creds.setdefault(k, os.environ.get(k, ""))
+    missing = [k for k in ("CF_ACCOUNT_ID", "CF_GATEWAY_ID", "CF_API_TOKEN") if not creds.get(k)]
+    if missing:
+        raise SystemExit(f"Missing gateway creds: {missing}. Provide proxy.env.")
+    g = f"{BASE}/{creds['CF_ACCOUNT_ID']}/{creds['CF_GATEWAY_ID']}/google-ai-studio/v1beta"
+    hdr = {"Content-Type": "application/json",
+           "cf-aig-authorization": f"Bearer {creds['CF_API_TOKEN']}"}
+    return g, hdr
+
+
+def _req(method, url, hdr, tries=4, **kw):
+    """HTTP with backoff on proxy 503 / 429 / non-JSON cold-start noise."""
+    delay = 0.5
+    for i in range(tries):
+        try:
+            r = requests.request(method, url, headers=hdr, timeout=kw.pop("timeout", 120), **kw)
+            if r.status_code >= 500 or r.status_code == 429:
+                raise RuntimeError(f"HTTP {r.status_code}: {(r.text or '')[:120]}")
+            return r
+        except Exception as e:
+            if i == tries - 1:
+                raise
+            time.sleep(delay); delay *= 2
+
+
+def list_video_models():
+    g, hdr = gateway()
+    r = _req("GET", f"{g}/models?pageSize=1000", hdr)
+    out = []
+    for m in r.json().get("models", []):
+        name = m.get("name", "")
+        methods = m.get("supportedGenerationMethods", [])
+        if "predictLongRunning" in methods or any(t in name.lower() for t in ("veo", "video")):
+            out.append((name, ",".join(methods)))
+    return out
+
+
+def _fire(g, hdr, model, prompt, aspect, negative):
+    body = {"instances": [{"prompt": prompt}], "parameters": {"aspectRatio": aspect}}
+    if negative:
+        body["parameters"]["negativePrompt"] = negative
+    # NOTE: do NOT add personGeneration:"allow_adult" -> 400.
+    r = _req("POST", f"{g}/models/{model}:predictLongRunning", hdr, json=body, timeout=90)
+    if r.status_code == 200:
+        return r.json().get("name")
+    if r.status_code == 429:
+        return "__RATELIMIT__"
+    raise RuntimeError(f"fire failed {r.status_code}: {r.text[:160]}")
+
+
+def _poll(g, hdr, op):
+    return _req("GET", f"{g}/{op}", hdr, timeout=60).json()
+
+
+def _download(g, hdr, uri, path):
+    fid = "files/" + uri.split("/files/")[1].split(":")[0]
+    r = _req("GET", f"{g}/{fid}:download?alt=media", hdr, timeout=180)
+    if r.status_code == 200 and len(r.content) > 1000:
+        Path(path).write_bytes(r.content)
+        return True
+    return False
+
+
+def generate(prompts, out_dir, model=None, aspect="16:9", negative=None,
+             max_concurrent=5, poll_interval=12, budget_s=780, log=print):
+    """
+    prompts: dict {scene_id: prompt}. Fires with a concurrency cap, refilling
+    slots as ops finish, polling until all done or budget exhausted.
+    Returns {scene_id: path|None}.
+    """
+    g, hdr = gateway()
+    if not model:
+        vids = [n for n, _ in list_video_models()]
+        model = next((n.split("/")[-1] for n in vids if "fast" in n),
+                     vids[0].split("/")[-1] if vids else None)
+        if not model:
+            raise SystemExit("No video model available on this key.")
+        log(f"model: {model}")
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+
+    pending = list(prompts.items())          # not yet fired
+    live = {}                                # scene_id -> op
+    done = {}                                # scene_id -> path|None
+    deadline = time.time() + budget_s
+    while (pending or live) and time.time() < deadline:
+        # refill concurrency slots
+        while pending and len(live) < max_concurrent:
+            sid, prompt = pending[0]
+            op = _fire(g, hdr, model, prompt, aspect, negative)
+            if op == "__RATELIMIT__":
+                break                         # slots full at provider; wait
+            pending.pop(0)
+            live[sid] = op
+            log(f"fired {sid} -> {op}")
+        # poll live ops
+        for sid in list(live):
+            try:
+                d = _poll(g, hdr, live[sid])
+            except Exception as e:
+                log(f"poll {sid} err {e}"); continue
+            if d.get("done"):
+                try:
+                    uri = d["response"]["generateVideoResponse"]["generatedSamples"][0]["video"]["uri"]
+                    path = f"{out_dir}/scene_{sid}.mp4"
+                    done[sid] = path if _download(g, hdr, uri, path) else None
+                    log(f"{sid} {'DONE '+path if done[sid] else 'DOWNLOAD FAILED'}")
+                except Exception as e:
+                    done[sid] = None
+                    log(f"{sid} done but no video: {json.dumps(d)[:160]} ({e})")
+                del live[sid]
+        if pending or live:
+            time.sleep(poll_interval)
+
+    for sid, _ in prompts.items():
+        done.setdefault(sid, None)
+    Path(out_dir, "results.json").write_text(json.dumps(done, indent=2))
+    Path(out_dir, "DONE").write_text("ok")
+    return done
+
+
+def _main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("prompts", nargs="?", help="JSON file: {scene_id: prompt}")
+    ap.add_argument("--out", default="veo")
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--aspect", default="16:9")
+    ap.add_argument("--negative", default=None)
+    ap.add_argument("--max-concurrent", type=int, default=5)
+    ap.add_argument("--list", action="store_true")
+    a = ap.parse_args()
+    if a.list:
+        for n, m in list_video_models():
+            print(f"{n}  |  {m}")
+        return
+    if not a.prompts:
+        ap.error("provide a prompts JSON file or --list")
+    prompts = json.loads(Path(a.prompts).read_text())
+    logf = open(Path(a.out) / "generate.log", "a") if Path(a.out).exists() or True else None
+    Path(a.out).mkdir(parents=True, exist_ok=True)
+    logf = open(Path(a.out) / "generate.log", "a")
+
+    def log(m):
+        print(m); logf.write(str(m) + "\n"); logf.flush()
+
+    res = generate(prompts, a.out, model=a.model, aspect=a.aspect,
+                   negative=a.negative, max_concurrent=a.max_concurrent, log=log)
+    log(f"FINISHED: {sorted(k for k,v in res.items() if v)} "
+        f"(failed: {sorted(k for k,v in res.items() if not v)})")
+
+
+if __name__ == "__main__":
+    _main()

--- a/parsing-video/SKILL.md
+++ b/parsing-video/SKILL.md
@@ -2,7 +2,7 @@
 name: parsing-video
 description: "Interpret video content visually by sampling frames into timestamped contact sheets that can be read as images. Use when: user asks what happens in a video; asks to summarize, describe, review, or QA video content or footage; asks about scenes, actions, people, or objects in a video; needs a storyboard-style overview of a clip; asks to find where something occurs in a video. Triggers on 'watch this video', 'what's in this video', 'summarize the video', 'describe the footage', 'contact sheet', 'storyboard', 'review this clip', 'find the scene where', 'scene detection', 'shot boundaries', 'detect cuts', 'dwell points'. For converting, trimming, or transcoding video, use processing-video instead."
 metadata:
-  version: 0.3.0
+  version: 0.4.0
 ---
 
 # Parsing Video
@@ -96,6 +96,37 @@ Caveats:
 - The threshold is relative, so on **constant-motion footage** (one unbroken pan) it degrades to picking the least-motion moments — harmless but arbitrary; prefer uniform sampling there. It exits non-zero when no hold lasts `--min-dwell`.
 - **Subject motion during a held shot** (a person gesturing in a static frame) raises the valley floor but rarely fills it; if a busy-but-held shot is missed, lower `--percentile`.
 - Dwells say where the camera settled, not what changed — combine with uniform coverage for anything time-critical.
+
+## Overseeing a multi-clip edit
+
+When acting as the editing agent over a generated or assembled cut (see the
+**creating-video** skill), review at two levels:
+
+1. **The whole assembly.** Contact-sheet the *final stitched cut*, not just the
+   individual clips. Per-clip sheets each look fine in isolation; character drift,
+   prop jumps, and logic breaks only appear when the shots sit in sequence. One
+   4×4 sheet over a 30 s cut gives ~2–3 tiles per scene — enough to catch them.
+
+2. **The seams.** A cut hides continuity errors at the boundary — the outgoing
+   clip's last frame vs the incoming clip's first frame. `scripts/seams.py` pairs
+   them, one row per cut, for a one-look check:
+
+   ```bash
+   python3 scripts/seams.py clip1.mp4 clip2.mp4 ... clipN.mp4 --out seams.png
+   ```
+
+Read every sheet against the **continuity checklist** for generated video:
+
+- **Character** — same face/hair/wardrobe across every shot they appear in.
+- **Prop** — same identity, size, color, and attachment point shot to shot
+  (the classic failure: a small object that changes size or moves between shots).
+- **Physical logic** — is the world coherent across the cut (a window open before
+  something enters through it; an action's result matching its setup)?
+- **Action completeness** — is the key beat actually *shown*, not cut around?
+
+Report which scene or seam fails and what the fix is (tighten the prompt, or
+regenerate just that shot) — that verdict is the deliverable the editing agent
+acts on.
 
 ## Interpreting honestly
 

--- a/parsing-video/scripts/seams.py
+++ b/parsing-video/scripts/seams.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+seams.py — seam-continuity sheet for an editing agent overseeing a multi-clip cut.
+
+A whole-film contact sheet shows overall flow; this shows the CUTS. For each
+boundary it pairs the last frame of the outgoing clip with the first frame of the
+incoming clip, side by side, one row per seam — so character/prop/logic continuity
+across a cut is checkable in a single Read.
+
+Usage:
+  python3 seams.py clip1.mp4 clip2.mp4 clip3.mp4 [--out seams.png] [--tile-width 480]
+
+Reads left-to-right, top-to-bottom: row k = [end of clip k | start of clip k+1].
+"""
+import sys, subprocess, tempfile, argparse
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    subprocess.run([sys.executable, "-m", "pip", "install", "pillow",
+                    "--break-system-packages", "-q"])
+    from PIL import Image, ImageDraw, ImageFont
+
+
+def _dur(path):
+    r = subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                        "-of", "csv=p=0", str(path)], stdout=subprocess.PIPE)
+    try:
+        return float(r.stdout.decode().strip())
+    except ValueError:
+        return 0.0
+
+
+def _frame(path, t, out):
+    subprocess.run(["ffmpeg", "-y", "-ss", f"{max(t,0):.2f}", "-i", str(path),
+                    "-frames:v", "1", str(out)],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return Path(out).exists()
+
+
+def _label(img, text):
+    d = ImageDraw.Draw(img)
+    try:
+        f = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 22)
+    except Exception:
+        f = ImageFont.load_default()
+    d.rectangle([0, img.height - 30, len(text) * 13 + 12, img.height], fill=(0, 0, 0))
+    d.text((6, img.height - 28), text, fill=(255, 255, 255), font=f)
+    return img
+
+
+def build(clips, out="seams.png", tile_w=480):
+    tmp = Path(tempfile.mkdtemp())
+    tiles = []  # (label, path)
+    for i, c in enumerate(clips):
+        d = _dur(c)
+        fin = tmp / f"{i}_in.png"; fout = tmp / f"{i}_out.png"
+        _frame(c, 0.1, fin)
+        _frame(c, max(d - 0.15, 0.1), fout)
+        tiles.append((f"clip{i+1} OUT", fout, f"clip{i+2} IN"))
+    rows = []
+    for k in range(len(clips) - 1):
+        out_lbl, out_path, _ = tiles[k]
+        in_path = tmp / f"{k+1}_in.png"
+        rows.append((f"seam {k+1}\u2192{k+2}: {out_lbl}", out_path,
+                     f"clip{k+2} IN", in_path))
+    if not rows:
+        raise SystemExit("Need at least 2 clips for a seam sheet.")
+
+    # size each tile to tile_w preserving aspect
+    def load(p, lbl):
+        im = Image.open(p).convert("RGB")
+        h = int(im.height * tile_w / im.width)
+        im = im.resize((tile_w, h))
+        return _label(im, lbl)
+
+    row_imgs = []
+    for lo, op, li, ip in rows:
+        left = load(op, lo); right = load(ip, li)
+        h = max(left.height, right.height)
+        row = Image.new("RGB", (tile_w * 2 + 8, h), (18, 18, 18))
+        row.paste(left, (0, 0)); row.paste(right, (tile_w + 8, 0))
+        row_imgs.append(row)
+    W = row_imgs[0].width
+    H = sum(r.height for r in row_imgs) + 8 * (len(row_imgs) - 1)
+    sheet = Image.new("RGB", (W, H), (18, 18, 18))
+    y = 0
+    for r in row_imgs:
+        sheet.paste(r, (0, y)); y += r.height + 8
+    sheet.save(out)
+    print(f"{out}  ({len(rows)} seams, {len(clips)} clips)")
+    print("Each row: [end of outgoing clip | start of incoming clip]. "
+          "Read for character/prop/logic continuity across the cut.")
+    return out
+
+
+def _main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("clips", nargs="+")
+    ap.add_argument("--out", default="seams.png")
+    ap.add_argument("--tile-width", type=int, default=480)
+    a = ap.parse_args()
+    build(a.clips, a.out, a.tile_width)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Adds **creating-video** and extends **parsing-video** for editing-agent review.

## creating-video (new)
End-to-end multi-clip AI video: script -> per-scene Veo generation (Google Veo via the Cloudflare AI Gateway) -> review -> ffmpeg assembly, with Claude as the editing agent.
- `veo_generate.py`: enumerate-don't-hardcode models, fire/poll/download via the gateway (BYOK), concurrency-cap (5) + 429 refill, proxy-503 backoff. Run detached (bash ~50s ceiling).
- `assemble.py`: trim to beats, xfade chain (offset=(k+1)(D-T)), audio dropped by default, payoff-word overlay, `--tail-hold` to fix abrupt endings.
- SKILL.md documents the continuity craft learned from real crits: lock character sheet + setting, name the actor per shot, prop-continuity is the weakest link (text locks + negativePrompt help but Veo still drifts a prop across shots -> image-to-video seeding is the hard fix), spell out scene logic, keep on-screen text out of the prompt and overlay it in assembly.

## parsing-video (v0.3.0 -> v0.4.0)
New 'Overseeing a multi-clip edit' section: sheet the whole assembly (not just clips), a continuity checklist, and `seams.py` (pairs each cut's outgoing/incoming frame for one-look seam review).

## Verification (in-session)
- `veo_generate.py --list` enumerated veo-3.1 {generate,fast,lite}-preview.
- `assemble.py` produced a 31.4s cut; `seams.py` a 5-seam sheet.
- `skill_lint.validate_skill` clean on both SKILL.md (require_version=True).

Diagnosed gotchas encoded: personGeneration allow_adult -> 400; 5-concurrent cap -> 429; download routes through the gateway; single-core -> run generate AND assemble detached.