### PR TITLE
creating-video: default to Gemini Omni Flash

### DIFF
--- a/creating-video/SKILL.md
+++ b/creating-video/SKILL.md
@@ -1,55 +1,69 @@
 ---
 name: creating-video
-description: "Create video from prompts by overseeing multi-clip AI generation end to end: write a shot list, generate each scene with Google Veo (via the Cloudflare AI Gateway), review the results, and assemble them into a finished cut. Use when the user asks to make/generate a video, a short film, an animatic, or a multi-scene clip from a script or idea; when they mention Veo, text-to-video, or image-to-video; or when acting as the editing/director agent over generated footage. Triggers on 'make a video', 'generate a clip', 'short film', 'video from this script', 'turn this into a video', 'veo', 'text to video', 'storyboard to video'. For transcoding/trimming/merging/GIF/subtitles use processing-video; for reading or summarizing existing video content use parsing-video."
+description: "Create video from prompts by overseeing multi-clip AI generation end to end: write a shot list, generate each scene with Gemini Omni Flash (via the Cloudflare AI Gateway), review the results, and assemble them into a finished cut. Use when the user asks to make/generate a video, a short film, an animatic, or a multi-scene clip from a script or idea; when they mention Omni, Veo, text-to-video, or image-to-video; or when acting as the editing/director agent over generated footage. Triggers on 'make a video', 'generate a clip', 'short film', 'video from this script', 'turn this into a video', 'omni', 'veo', 'text to video', 'storyboard to video'. For transcoding/trimming/merging/GIF/subtitles use processing-video; for reading or summarizing existing video content use parsing-video."
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # Creating Video
 
 Claude cannot render video itself, but it can direct a generator. This skill drives
-a multi-clip pipeline — **script → per-scene Veo generation → review → assembly** —
+a multi-clip pipeline — **script → per-scene generation → review → assembly** —
 with Claude as the editing agent overseeing continuity and cut.
 
 Requires `ffmpeg`/`ffprobe` and Cloudflare AI Gateway creds (`/mnt/project/proxy.env`).
 
+**Default model: Gemini Omni Flash** (`gemini-omni-flash-preview`, Interactions
+API) — Google's own guidance as of 2026-07. It beats Veo on character
+consistency, reference-image control, text rendering, and conversational
+editing, and generates faster (~30–90 s/clip vs 1–3 min). Fall back to **Veo
+3.1** (`scripts/veo_generate.py`, kept intact) only for scene extension,
+first+last-frame interpolation, or legacy pipelines — Omni supports neither.
+
 ## The five stages
 
-1. **Shot list** — break the story into beats, ~5–8 s each, one prompt per shot.
-2. **Generate** — `scripts/veo_generate.py`, run detached.
+1. **Shot list** — break the story into beats, up to 10 s each, one prompt per shot.
+2. **Generate** — `scripts/omni_generate.py`, run detached.
 3. **Review** — `parsing-video` on each clip **and** on the assembled cut.
 4. **Assemble** — `scripts/assemble.py`, run detached.
-5. **Iterate** — re-review, regenerate only the failing scenes.
+5. **Iterate** — re-review, then **edit** failing scenes conversationally
+   (cheaper and more stable than regenerating from scratch).
 
-## Stage 2 — Generation (Veo via Cloudflare AI Gateway)
+## Stage 2 — Generation (Omni via Cloudflare AI Gateway)
 
 Auth is CF AI Gateway BYOK: `proxy.env` supplies `CF_ACCOUNT_ID`, `CF_GATEWAY_ID`,
-`CF_API_TOKEN`; the Google key lives *inside* the gateway, so both the generate
-call and the file download route through it.
+`CF_API_TOKEN`; the Google key lives *inside* the gateway. Both the interactions
+call and the `files/{id}:download` retrieval route through it (verified 2026-07-20).
 
-**Enumerate models — never hardcode.** Strings change.
+**Run detached.** The Interactions API is *synchronous* — the HTTP call holds
+open for the whole generation (~30–90 s/clip). `bash_tool` caps at ~50 s. Launch
+and adaptive-wait on the `DONE` sentinel:
 ```bash
-python3 scripts/veo_generate.py --list
-# 2026-07-18: veo-3.1-generate-preview / -fast-generate-preview / -lite-generate-preview
-```
-
-**Run detached.** Veo takes 1–3 min per clip; `bash_tool` caps at ~50 s. Launch and
-adaptive-wait on the `DONE` sentinel:
-```bash
-# prompts.json = {"1": "...", "2": "...", ...}
+# prompts.json = {"1": "...", "2": {"text": "...", "images": ["ref0.png"]}, ...}
 set -a; . /mnt/project/proxy.env; set +a
-(setsid python3 scripts/veo_generate.py prompts.json --out veo/ \
-    --negative "large paper, on-screen text, watermark" &)
+(setsid python3 scripts/omni_generate.py prompts.json --out omni/ \
+    --negative "on-screen watermark" &)
 # then, in a separate call:
-timeout 45 sh -c 'while [ ! -f veo/DONE ]; do sleep 4; done'; cat veo/generate.log
+timeout 45 sh -c 'while [ ! -f omni/DONE ]; do sleep 3; done'; cat omni/generate.log
 ```
 
-**Gotchas (all diagnosed 2026-07-18 — the script already handles them):**
-- `personGeneration:"allow_adult"` → HTTP 400. Omit it.
-- ~5 concurrent operations max; the 6th returns 429. The script fires in waves and
-  refills slots as ops finish.
+**Gotchas (all verified 2026-07-20 — the script already handles them):**
+- **No dry run exists.** Even `input:""` returns 200 and bills a full
+  generation (~58k video output tokens). Every request costs money; never
+  "validate" with a throwaway call.
+- No `negativePrompt` parameter (Veo had one; Omni 400s on unsupported
+  params). `--negative` folds into the prompt as "Do not include: X."
+- Videos >4MB need `delivery:"uri"` → poll `files/{id}` to ACTIVE → download
+  via the gateway. The script always uses uri delivery, inline base64 as
+  fallback.
+- Output is up to 10 s 1280×720 mp4 with synchronized audio + SynthID
+  watermark. No video extension, no first↔last-frame interpolation, no
+  multi-video referencing — those are Veo territory.
 - The egress proxy 503s on cold start → retry with backoff.
-- Output is an 8 s 1280×720 mp4 with native Veo audio.
+
+**Omni defaults to multi-shot.** Left alone it invents its own cuts inside a
+clip, which fights a shot-list pipeline. Every per-scene prompt should say
+"single continuous shot" / "no scene cuts" unless the beat wants internal cuts.
 
 ## Stage 3 — Review (use the parsing-video skill)
 
@@ -66,45 +80,61 @@ scenes). Scan every sheet against the **continuity checklist**:
 
 ## Stage 4 — Assembly (`scripts/assemble.py`)
 
-Trims each 8 s clip to its beat, crossfades, drops audio by default, burns the
-payoff word, and holds the final frame so the ending lands.
+Trims each clip to its beat, crossfades, drops audio by default, optionally burns
+an overlay word, and holds the final frame so the ending lands.
 ```bash
-(setsid python3 scripts/assemble.py veo/scene_1.mp4 ... veo/scene_6.mp4 \
-    --out film.mp4 --overlay-last "COMING HOME" --tail-hold 1.3 &)
+(setsid python3 scripts/assemble.py omni/scene_1.mp4 ... omni/scene_6.mp4 \
+    --out film.mp4 --tail-hold 1.3 &)
 ```
 Run detached too — six trims plus a 30 s stitch exceed the bash ceiling on the
 single-core container. Diagnosed: abrupt ending → `--tail-hold`; jarring cuts
-between six independent Veo ambiences → audio dropped by default (`--keep-audio`
-to `acrossfade` instead).
+between independently generated ambiences → audio dropped by default
+(`--keep-audio` to `acrossfade` instead).
+
+## Stage 5 — Iterate by editing, not regenerating
+
+`results.json` stores each scene's `interaction_id`. A failed detail (wrong
+color, unwanted object, lighting) is a one-line conversational edit that
+preserves everything else:
+```bash
+python3 scripts/omni_generate.py --edit <interaction_id> \
+    "Make the scarf red. Keep everything else the same." --out omni/scene_3_v2.mp4
+```
+Simple edit prompts work best; append "Keep everything else the same." Reserve
+full regeneration for scenes whose composition or action is wrong. (Editing
+requires `store=true`, the script's default.)
 
 ## Prompt craft — continuity is the hard part
 
-Every failure mode below came from real crits on 2026-07-18. Write against them on
-the first pass; they are expensive to fix by regeneration.
+The failure modes below came from real crits on 2026-07-18 (Veo era). Omni
+narrows several of them but the disciplines still pay on the first pass.
 
-- **Lock a character sheet.** One verbatim appearance/wardrobe block, reused in
-  every shot with that character. Independent per-shot prompts produced three
-  different women and, once, a man's hands where the woman's were required.
+- **Pin characters and props with reference images** — the first-class fix for
+  the drift that text locks never fully solved under Veo. Generate one
+  canonical still per character/prop, put it in the scene's `images` list, and
+  bind it in the prompt: `the woman <IMAGE_REF_0> is holding <IMAGE_REF_1>`
+  (refs start at 0; `<FIRST_FRAME>` pins a starting frame instead).
+- **Still lock a character sheet in text.** One verbatim appearance/wardrobe
+  block, reused in every shot with that character — references constrain, text
+  directs.
 - **Lock the setting.** One room/location description across co-located scenes.
 - **Name the actor in every shot** ("the same woman's hands") — never leave it to
   the model to infer who is on screen.
-- **Prop continuity is the weakest link and is not fully solvable by text.** Name
-  the prop's size, color, and attachment point in *every* shot, plus a
-  `negativePrompt` against its failure modes. Residual limitation: Veo still drifts
-  a prop across independent generations (a leg-scroll migrated between talons and
-  tail across shots even with locks). The hard fix is **image-to-video seeding** —
-  generate one canonical still of the prop/subject and pass it as the first-frame
-  image so the prop is pinned. Reach for it when text locks aren't enough.
-- **Spell out scene logic** — physical coherence (open vs closed window), the
-  correct order of beats (surprise at the *arrival*, not at the message), and
-  *show* the payoff action rather than cutting away from it.
-- **Thematic coherence.** Title, on-screen payoff, and story beat should cohere.
-  A drifting title/word resolves cleanly when the physical prop *is* the title.
-- **On-screen text.** Veo renders words unreliably. Keep "no on-screen text" in the
-  prompt and burn the payoff word in assembly (`assemble.py --overlay-last`).
+- **Spell out scene logic** — physical coherence, the correct order of beats,
+  and *show* the payoff action rather than cutting away from it.
+- **Timing is promptable.** `[0-3s] ... [3-6s] ...` timecode syntax or natural
+  language ("after 3 seconds, ...") controls beats inside a clip.
+- **On-screen text now renders reliably** — spell out exactly what any visible
+  text should say (signs, labels, title cards). Burning text in assembly
+  (`assemble.py --overlay-last`) remains an option for cross-clip title cards.
+- **Audio is promptable.** Describe the track ("no dialogue", "calm background
+  music") or Omni invents one per clip — which still won't match across clips;
+  assembly drops audio by default for that reason.
 
 ## Scope
 
 - Transcode / trim / merge / GIF / subtitles → **processing-video**.
 - Reading, summarizing, or QA of existing video content → **parsing-video** (also
   the review step here).
+- Scene extension / first+last-frame control → the retained Veo path
+  (`scripts/veo_generate.py --list` to enumerate models; strings drift).

--- a/creating-video/scripts/omni_generate.py
+++ b/creating-video/scripts/omni_generate.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+omni_generate.py — generate video clips with Gemini Omni Flash via the
+Cloudflare AI Gateway (Interactions API).
+
+Facts this script encodes (verified 2026-07-20):
+  - Endpoint: POST {gateway}/google-ai-studio/v1beta/interactions — the CF AI
+    Gateway BYOK path proxies it; both the call and file downloads route
+    through the gateway.
+  - Model: gemini-omni-flash-preview (preview; re-check the docs when it 404s).
+  - The call is SYNCHRONOUS — no operation polling. A clip takes ~30s-3min of
+    held-open HTTP. bash_tool caps at ~50s, so RUN THIS SCRIPT DETACHED
+    (setsid ... &) and adaptive-wait on the DONE sentinel.
+  - THERE IS NO DRY RUN. Even input:"" returns 200 and bills a full
+    generation (~58k video output tokens). Every request costs money.
+  - No negativePrompt parameter (unsupported, unlike Veo). Fold negatives
+    into the prompt text: "Do not include: X".
+  - Videos >4MB need response_format delivery:"uri" -> poll files/{id} until
+    ACTIVE -> download via {gateway}/.../files/{id}:download?alt=media.
+    This script always uses uri delivery; inline base64 is the fallback.
+  - Stateful editing: pass previous_interaction_id + an instruction to edit a
+    prior generation in place. results.json stores each scene's interaction
+    id for exactly this purpose (requires store=true, the default).
+  - Reference images go inline in the input list; bind roles in the prompt
+    with <FIRST_FRAME> / <IMAGE_REF_N> tags (refs start at 0).
+  - Egress proxy 503s on cold start; retry with backoff.
+
+Usage:
+  python3 omni_generate.py prompts.json --out omni/ \
+      [--model gemini-omni-flash-preview] [--aspect 16:9] \
+      [--negative "on-screen text, watermark"] [--max-concurrent 3]
+  python3 omni_generate.py --edit <interaction_id> "Make the hat red. Keep everything else the same." --out omni/scene_2_v2.mp4
+
+prompts.json: {"1": "prompt text", ...} or
+              {"1": {"text": "...", "images": ["ref0.png", "first.png"]}, ...}
+Writes <out>/scene_<n>.mp4 per scene, plus <out>/results.json
+({scene: {path, interaction_id}}) and <out>/DONE.
+"""
+import os, sys, json, time, base64, argparse, mimetypes
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+try:
+    import requests
+except ImportError:
+    os.system(f"{sys.executable} -m pip install requests --break-system-packages -q")
+    import requests
+
+BASE = "https://gateway.ai.cloudflare.com/v1"
+DEFAULT_MODEL = "gemini-omni-flash-preview"
+_PROXY_PATHS = [Path("/mnt/project/proxy.env"), Path("proxy.env"),
+                Path.home() / "proxy.env"]
+
+
+def gateway():
+    """Load CF AI Gateway creds and return (base_url, headers)."""
+    creds = {}
+    for p in _PROXY_PATHS:
+        if p.exists():
+            for line in p.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, _, v = line.partition("=")
+                    creds[k.strip()] = v.strip().strip('"').strip("'")
+            break
+    for k in ("CF_ACCOUNT_ID", "CF_GATEWAY_ID", "CF_API_TOKEN"):
+        creds.setdefault(k, os.environ.get(k, ""))
+    missing = [k for k in ("CF_ACCOUNT_ID", "CF_GATEWAY_ID", "CF_API_TOKEN") if not creds.get(k)]
+    if missing:
+        raise SystemExit(f"Missing gateway creds: {missing}. Provide proxy.env.")
+    g = f"{BASE}/{creds['CF_ACCOUNT_ID']}/{creds['CF_GATEWAY_ID']}/google-ai-studio/v1beta"
+    hdr = {"Content-Type": "application/json",
+           "cf-aig-authorization": f"Bearer {creds['CF_API_TOKEN']}"}
+    return g, hdr
+
+
+def _req(method, url, hdr, tries=4, **kw):
+    """HTTP with backoff on proxy 503 / 429 / cold-start noise."""
+    delay = 1.0
+    for i in range(tries):
+        try:
+            r = requests.request(method, url, headers=hdr, timeout=kw.pop("timeout", 300), **kw)
+            if r.status_code >= 500 or r.status_code == 429:
+                raise RuntimeError(f"HTTP {r.status_code}: {(r.text or '')[:120]}")
+            return r
+        except Exception:
+            if i == tries - 1:
+                raise
+            time.sleep(delay); delay *= 2
+
+
+def _build_input(spec, negative):
+    """spec: str or {"text":..., "images":[paths]}. Returns Interactions input."""
+    if isinstance(spec, str):
+        text, images = spec, []
+    else:
+        text, images = spec["text"], spec.get("images", [])
+    if negative:
+        text = f"{text} Do not include: {negative}."
+    if not images:
+        return text
+    parts = []
+    for p in images:
+        mime = mimetypes.guess_type(p)[0] or "image/png"
+        parts.append({"type": "image", "mime_type": mime,
+                      "data": base64.b64encode(Path(p).read_bytes()).decode()})
+    parts.append({"type": "text", "text": text})
+    return parts
+
+
+def _extract_video(j):
+    """Return (uri, b64_data) from a completed interaction JSON (either may be None)."""
+    ov = j.get("output_video") or {}
+    uri, data = ov.get("uri"), ov.get("data")
+    if not (uri or data):
+        for step in j.get("steps", []):
+            if step.get("type") == "model_output":
+                for c in step.get("content", []):
+                    if c.get("type") == "video":
+                        uri, data = c.get("uri"), c.get("data")
+    return uri, data
+
+
+def _download_uri(g, hdr, uri, path, log, poll_interval=5, budget_s=300):
+    """Poll files/{id} until ACTIVE, then download via the gateway."""
+    fid = uri.split("/files/")[1].split(":")[0].split("?")[0]
+    deadline = time.time() + budget_s
+    while time.time() < deadline:
+        st = _req("GET", f"{g}/files/{fid}", hdr, timeout=30).json().get("state", "")
+        if st == "ACTIVE":
+            break
+        if st == "FAILED":
+            log(f"file {fid} FAILED"); return False
+        time.sleep(poll_interval)
+    r = _req("GET", f"{g}/files/{fid}:download?alt=media", hdr, timeout=300)
+    if r.status_code == 200 and len(r.content) > 1000:
+        Path(path).write_bytes(r.content)
+        return True
+    return False
+
+
+def _generate_one(g, hdr, model, sid, spec, aspect, negative, out_dir, log,
+                  previous_id=None):
+    body = {"model": model,
+            "input": spec if previous_id else _build_input(spec, negative),
+            "response_format": {"type": "video", "aspect_ratio": aspect,
+                                "delivery": "uri"}}
+    if previous_id:
+        body["previous_interaction_id"] = previous_id
+    r = _req("POST", f"{g}/interactions", hdr, json=body, timeout=600)
+    if r.status_code != 200:
+        log(f"{sid} failed {r.status_code}: {r.text[:160]}")
+        return sid, None, None
+    j = r.json()
+    iid = j.get("id")
+    uri, data = _extract_video(j)
+    path = str(Path(out_dir) / f"scene_{sid}.mp4")
+    ok = False
+    if uri:
+        ok = _download_uri(g, hdr, uri, path, log)
+    if not ok and data:
+        Path(path).write_bytes(base64.b64decode(data)); ok = True
+    log(f"{sid} {'DONE ' + path if ok else 'NO VIDEO'} (interaction {iid})")
+    return sid, path if ok else None, iid
+
+
+def generate(prompts, out_dir, model=DEFAULT_MODEL, aspect="16:9",
+             negative=None, max_concurrent=3, log=print):
+    """prompts: {scene_id: str|dict}. Returns {scene_id: {path, interaction_id}}."""
+    g, hdr = gateway()
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    done = {}
+    with ThreadPoolExecutor(max_workers=max_concurrent) as ex:
+        futs = {ex.submit(_generate_one, g, hdr, model, sid, spec, aspect,
+                          negative, out_dir, log): sid
+                for sid, spec in prompts.items()}
+        for f in as_completed(futs):
+            sid, path, iid = f.result()
+            done[sid] = {"path": path, "interaction_id": iid}
+    Path(out_dir, "results.json").write_text(json.dumps(done, indent=2))
+    Path(out_dir, "DONE").write_text("ok")
+    return done
+
+
+def edit(previous_id, instruction, out_path, model=DEFAULT_MODEL, log=print):
+    """One conversational edit turn on a stored interaction."""
+    g, hdr = gateway()
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    sid = Path(out_path).stem
+    _, path, iid = _generate_one(g, hdr, model, sid, instruction, "16:9", None,
+                                 Path(out_path).parent, log, previous_id=previous_id)
+    if path and path != str(out_path):
+        Path(path).rename(out_path)
+    return str(out_path) if path else None, iid
+
+
+def _main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("prompts", nargs="?", help="JSON file: {scene_id: prompt|{text,images}}")
+    ap.add_argument("--out", default="omni")
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--aspect", default="16:9", choices=["16:9", "9:16"])
+    ap.add_argument("--negative", default=None,
+                    help="folded into prompt text; Omni has no negativePrompt param")
+    ap.add_argument("--max-concurrent", type=int, default=3)
+    ap.add_argument("--edit", nargs=2, metavar=("INTERACTION_ID", "INSTRUCTION"))
+    a = ap.parse_args()
+
+    if a.edit:
+        pid, instr = a.edit
+        out = a.out if a.out.endswith(".mp4") else f"{a.out}/edit.mp4"
+        path, iid = edit(pid, instr, out)
+        print(f"{'DONE ' + path if path else 'FAILED'} (interaction {iid})")
+        return
+
+    if not a.prompts:
+        ap.error("provide a prompts JSON file or --edit")
+    prompts = json.loads(Path(a.prompts).read_text())
+    Path(a.out).mkdir(parents=True, exist_ok=True)
+    logf = open(Path(a.out) / "generate.log", "a")
+
+    def log(m):
+        print(m); logf.write(str(m) + "\n"); logf.flush()
+
+    res = generate(prompts, a.out, model=a.model, aspect=a.aspect,
+                   negative=a.negative, max_concurrent=a.max_concurrent, log=log)
+    ok = sorted(k for k, v in res.items() if v["path"])
+    log(f"FINISHED: {ok} (failed: {sorted(k for k in res if k not in ok)})")
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Switches the default generator from Veo 3.1 to Gemini Omni Flash (`gemini-omni-flash-preview`) per Google's own guidance; Veo path retained for scene extension / first+last-frame control.

New `scripts/omni_generate.py` (veo_generate.py untouched):
- Interactions API via the CF AI Gateway BYOK path — route verified end-to-end 2026-07-20
- Synchronous API, still run detached (30-90s/clip holds the HTTP call open)
- uri delivery + gateway file download; inline base64 fallback
- `--edit <interaction_id> "instruction"` conversational editing; results.json stores per-scene interaction ids
- `--negative` folds into prompt text (no negativePrompt param on Omni)

Smoke-tested in-session: one text-to-video generation (10s 720p h264+aac via uri delivery) and one edit turn — both produced valid mp4s.

Gotcha documented: there is NO dry run — even empty input returns 200 and bills a full generation (~58k video output tokens).

SKILL.md updates: reference-image pinning (`<IMAGE_REF_N>`/`<FIRST_FRAME>`) as the first-class continuity fix, "single continuous shot" required per scene (Omni defaults to multi-shot), edit-not-regenerate iterate stage, 10s clip cap, on-screen text now reliable.

Not verified in-session: multi-scene concurrent generation (max-concurrent thread pool) — ran single-scene only. Gate command: `python3 scripts/omni_generate.py prompts.json --out omni/` with a 2-3 scene prompts.json.