### PR TITLE
composing-html: remove default "Composed with composing-html" footer

### DIFF
--- a/composing-html/SKILL.md
+++ b/composing-html/SKILL.md
@@ -116,7 +116,8 @@ Semantic aliases: `--ok`, `--warn`, `--err`, `--info`.
 - `.stack`, `.row` — vertical / horizontal flex.
 - `.card`, `.card--soft`, `.card--elev` — content containers.
 - `.rule` — `<hr>` underline below `<h2>`.
-- `.colophon` — footer strip (auto-added by composer).
+- `.colophon` — optional footer strip; pass `colophon="text"` to `page()` to
+  show it (off by default).
 
 ### Components
 

--- a/composing-html/references/palette.md
+++ b/composing-html/references/palette.md
@@ -41,7 +41,8 @@ Semantic aliases: `--ok`, `--warn`, `--err`, `--info`.
 - `.stack`, `.row` — vertical / horizontal flex.
 - `.card`, `.card--soft`, `.card--elev` — content containers.
 - `.rule` — `<hr>` underline below `<h2>`.
-- `.colophon` — footer strip (auto-added by composer).
+- `.colophon` — optional footer strip; pass `colophon="text"` to `page()` to
+  show it (off by default).
 
 ## Components
 

--- a/composing-html/scripts/composer.py
+++ b/composing-html/scripts/composer.py
@@ -4,7 +4,7 @@ Page shell + primitive helpers shared by every template module.
 
 Templates receive a structured spec (a dict) and return a single HTML string
 that goes into <body>. The composer wraps it with <head>, inlines base.css /
-base.js, and adds the colophon footer. Templates never write <html>, <head>,
+base.js. If a caller passes `colophon=`, adds a colophon footer. Templates never write <html>, <head>,
 <style>, <script>, or <link>.
 
 Helpers provided here are deliberately small. Each takes plain Python data
@@ -199,7 +199,7 @@ def page(*, title: str, body: str,
          extra_css: str = "",
          extra_js: str = "",
          show_masthead: bool = True,
-         colophon: str | None = "Composed with composing-html") -> str:
+         colophon: str | None = None) -> str:
     """Wrap inner body html with the full page shell.
 
     Inlines base.css and base.js so the artifact is a single, portable file.


### PR DESCRIPTION
The composer defaulted `page()`'''s `colophon` param to the literal
string "Composed with composing-html", so every artifact got a self-promotional
footer line whether anyone asked for it or not.

Changes:
- `colophon` default -> `None` (off by default; still usable if a caller
  explicitly passes text)
- SKILL.md / palette.md `.colophon` docs updated from "auto-added by
  composer" to "optional ... off by default"

No test or template referenced the default text or called `page()` with an
explicit colophon, so this is a behavior-only default change, not a breaking
API change.