### PR TITLE
invoking-gemini: default to gemini-3.6-flash, retire Gemini 2.5 text models

### DIFF
--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -1,5 +1,20 @@
 # invoking-gemini - Changelog
 
+## 2026-07-21
+- Gemini 3.6 Flash (`gemini-3.6-flash`) reached GA (2026-07-21). Added it to
+  the model registry and made it the new `DEFAULT_MODEL`.
+- Repointed the `flash` alias from `gemini-3.5-flash` to `gemini-3.6-flash`.
+  Added `flash-3.5` as a stable handle for the prior frontier Flash; `flash-3`
+  still pins the older `gemini-3-flash-preview`.
+- Rationale: 3.6 Flash is ~half Sonnet's cost (in $1.50 / out $7.50 vs ~$3 /
+  ~$15) and improves coding/agentic quality with ~17% fewer output tokens than
+  3.5 Flash — making it the default for sub-agent delegation.
+- Updated SKILL.md and references/models.md tables (pricing, 64K output cap,
+  benchmark deltas, tone-regression caveat).
+- Not touched: `gemini-3.5-flash-lite` / `gemini-3.5-flash-cyber` (shipped same
+  day) are not yet aliased; two helper fns still hardcode a
+  `gemini-3-flash-preview` default in their signatures (pre-existing).
+
 ## 2026-05-28
 - Nano Banana 2 (`gemini-3.1-flash-image-preview`) and Nano Banana Pro
   (`gemini-3-pro-image-preview`) reached GA on Vertex / Gemini Enterprise.

--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -1,6 +1,19 @@
 # invoking-gemini - Changelog
 
 ## 2026-07-21
+
+### ⚠️ BREAKING — `lite` alias repointed
+- `MODEL_ALIASES['lite']`: `gemini-2.5-flash-lite` → `gemini-3.5-flash-lite`.
+  Output cost goes from $0.40 to $2.50 per 1M (~6x) for any caller using
+  `model="lite"`. Pin `gemini-2.5-flash-lite` by full ID if you need the old
+  rate, though it is deprecated (below).
+- The Gemini 2.5 **text** generation is retired from routing: `gemini-2.5-flash`,
+  `gemini-2.5-flash-lite`, `gemini-2.5-pro`. Model IDs stay callable and the
+  `stable-flash` / `stable-pro` aliases still resolve, so nothing hard-breaks,
+  but they are no longer recommended targets. Image model `nano-banana`
+  (gemini-2.5-flash-image) is NOT affected.
+- Added `gemini-3.5-flash-lite` (GA 2026-07-21) as the cheap/bulk tier.
+
 - Gemini 3.6 Flash (`gemini-3.6-flash`) reached GA (2026-07-21). Added it to
   the model registry and made it the new `DEFAULT_MODEL`.
 - Repointed the `flash` alias from `gemini-3.5-flash` to `gemini-3.6-flash`.

--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 2026-07-21
 
+### Added — audio (and video) input
+- `image_path` now accepts **any** supported media file, not just images. Audio
+  input verified working 2026-07-21 (3-beep WAV; `gemini-3.6-flash` returned the
+  correct count and pitch direction). The param keeps its legacy name for
+  back compat; docstrings now state what it really accepts.
+- Explicit mimeType overrides for audio/video extensions `mimetypes` guesses
+  wrongly or misses (.m4a/.aac/.flac/.ogg/.opus/.mp3/.wav/.aiff/.mp4/.mov/.webm/
+  .heic/.heif). A wrong guess previously sent a bad mimeType and produced a
+  confused answer rather than an error.
+- New `MediaInputError` (subclass of `ValueError`) for deterministic input
+  problems; retry loops re-raise it immediately instead of burning 3 attempts.
+- 15MB inline cap enforced with an actionable message. Larger files need the
+  Files API, which this client still does not implement.
+- The direct google-generativeai SDK fallback now rejects non-image media with a
+  clear message instead of an opaque PIL `UnidentifiedImageError`. Audio/video
+  require the CF Gateway path.
+
+**Routing note:** send audio to `gemini-3.6-flash`. `gemini-3.5-flash-lite` was
+unreliable on the same clip — it reported three beeps then two on identical
+input, and got the pitch direction wrong both times.
+
 ### ⚠️ BREAKING — `lite` alias repointed
 - `MODEL_ALIASES['lite']`: `gemini-2.5-flash-lite` → `gemini-3.5-flash-lite`.
   Output cost goes from $0.40 to $2.50 per 1M (~6x) for any caller using

--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -135,7 +135,7 @@ from gemini_client import invoke_gemini
 
 response = invoke_gemini(
     prompt="Explain quantum computing in 3 bullet points",
-    model="flash",  # gemini-3.5-flash (default)
+    model="flash",  # gemini-3.6-flash (default)
 )
 print(response)
 ```
@@ -174,16 +174,18 @@ results = invoke_parallel(
 
 ## Available Models
 
-All current Gemini 3.x text/multimodal models are in preview except 3.5
-Flash (GA May 19, 2026). Use the values below — `gemini-3-flash-preview`
-and `gemini-3.1-flash-lite-preview` from earlier docs are out of date.
+The current frontier Flash is **gemini-3.6-flash** (GA 2026-07-21), the
+default and the `flash` alias. Prior-gen `gemini-3.5-flash` (GA May 2026)
+remains callable as `flash-3.5`. `gemini-3-flash-preview` and
+`gemini-3.1-flash-lite-preview` from earlier docs are out of date.
 
 ### Text / Reasoning Models
 
 | Model | Alias | Input/1M | Output/1M | Context | Notes |
 |-------|-------|----------|-----------|---------|-------|
-| gemini-3.5-flash | `flash` | $1.50 | $9.00 | 1M | GA May 2026. Frontier Flash. Beats 3.1 Pro on most coding/agentic benchmarks. Default `thinking_level=medium` — set `minimal` for non-reasoning tasks. |
-| gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Prior-gen Flash, kept for back compat |
+| gemini-3.6-flash | `flash` | $1.50 | $7.50 | 1M in / 64K out | **Default.** GA 2026-07-21. Current frontier Flash: ~17% fewer output tokens than 3.5 Flash, better coding/agentic (DeepSWE 49% vs 37%, OSWorld 83% vs 78%). Default `thinking_level=medium` — set `minimal` for non-reasoning tasks. Model card notes a slight tone regression vs 3.5. |
+| gemini-3.5-flash | `flash-3.5` | $1.50 | $9.00 | 1M | Prior frontier Flash (GA May 2026). Beats 3.1 Pro on most coding/agentic benchmarks. |
+| gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Older preview Flash, kept for back compat |
 | gemini-3.1-pro-preview | `pro` | $2.00 (≤200K) / $4.00 | $12.00 / $24.00 | 1M | Current Pro tier; 3.5 Pro slated for June 2026 |
 | gemini-2.5-flash | `stable-flash` | $0.30 | $2.50 | 1M | Stable production Flash |
 | gemini-2.5-flash-lite | `lite` | **$0.10** | **$0.40** | 1M | Cheapest major-provider production model. Surprisingly strong on multimodal extraction. |
@@ -239,7 +241,7 @@ Common issues: Missing API key → see Setup. Rate limit → auto-retries with b
 ```python
 response = invoke_gemini(
     prompt="Write a haiku",
-    model="flash",                  # gemini-3.5-flash
+    model="flash",                  # gemini-3.6-flash
     temperature=0.9,
     max_output_tokens=200,
     top_p=0.95,

--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -168,7 +168,7 @@ from gemini_client import invoke_parallel
 
 results = invoke_parallel(
     prompts=["Summarize Hamlet", "Summarize Macbeth", "Summarize Othello"],
-    model="lite",  # gemini-2.5-flash-lite — cheapest, fastest for batch
+    model="lite",  # gemini-3.5-flash-lite — cheap/fast tier for batch
 )
 ```
 
@@ -187,9 +187,10 @@ remains callable as `flash-3.5`. `gemini-3-flash-preview` and
 | gemini-3.5-flash | `flash-3.5` | $1.50 | $9.00 | 1M | Prior frontier Flash (GA May 2026). Beats 3.1 Pro on most coding/agentic benchmarks. |
 | gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Older preview Flash, kept for back compat |
 | gemini-3.1-pro-preview | `pro` | $2.00 (≤200K) / $4.00 | $12.00 / $24.00 | 1M | Current Pro tier; 3.5 Pro slated for June 2026 |
-| gemini-2.5-flash | `stable-flash` | $0.30 | $2.50 | 1M | Stable production Flash |
-| gemini-2.5-flash-lite | `lite` | **$0.10** | **$0.40** | 1M | Cheapest major-provider production model. Surprisingly strong on multimodal extraction. |
-| gemini-2.5-pro | `stable-pro` | $1.25 (≤200K) / $2.50 | $10.00 / $20.00 | 1M | Stable production Pro |
+| gemini-3.5-flash-lite | `lite` | $0.30 | $2.50 | 1M | **Cheap/bulk tier.** GA 2026-07-21. Fastest 3.5-class (350 output tok/sec); beats gemini-3-flash on SWE-Bench Pro and OSWorld-Verified. |
+| ~~gemini-2.5-flash~~ | `stable-flash` | $0.30 | $2.50 | 1M | **DEPRECATED** — 2025-era generation, do not route here. |
+| ~~gemini-2.5-flash-lite~~ | — | $0.10 | $0.40 | 1M | **DEPRECATED** — cheaper, but a 2025-era generation. `lite` now resolves to gemini-3.5-flash-lite. |
+| ~~gemini-2.5-pro~~ | `stable-pro` | $1.25 (≤200K) / $2.50 | $10.00 / $20.00 | 1M | **DEPRECATED** — 2025-era generation, do not route here. |
 
 ### Image Models
 

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -220,12 +220,16 @@ availability — announced GA on Vertex AI / Gemini Enterprise Agent Platform,
 where the GA model IDs drop the suffix (`gemini-3.1-flash-image`,
 `gemini-3-pro-image`).
 
-⚠️ This client calls the **Gemini Developer API**
-(`generativelanguage.googleapis.com`, via the CF `google-ai-studio` gateway),
-NOT Vertex. On the Developer API both models are **still served under the
-`-preview` model IDs** (verified against the live image-generation docs,
-2026-05-28). Do NOT drop the `-preview` suffix on this surface — the GA IDs are
-a Vertex-only convention and 404 here.
+⚠️ **Corrected 2026-07-21 (the previous note here was wrong).** The GA IDs
+`gemini-3.1-flash-image` and `gemini-3-pro-image` are **NOT** Vertex-only and do
+**NOT** 404 on the Developer API — they were released on this surface on
+2026-05-28 and were live-tested working through the CF gateway on 2026-07-21.
+The `-preview` IDs also still resolve (their announced 2026-06-25 shutdown
+appears to redirect rather than fail), so nothing is broken either way — but
+**new code should target the GA IDs**.
+
+Also available and not yet wired into this client: `gemini-3.1-flash-lite-image`
+(Nano Banana 2 Lite, GA) — the cheapest image tier, ~$0.034/image.
 
 #### nano-banana-2
 

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -1,15 +1,57 @@
 # Gemini Models Reference
 
-Detailed information about available Gemini models (as of May 2026).
+Detailed information about available Gemini models (as of July 2026).
 
 ## Model Comparison
 
-### Gemini 3.5 — Frontier (GA)
+### Gemini 3.6 — Frontier Flash (GA, current default)
+
+#### gemini-3.6-flash
+
+**Status:** Generally available (released July 21, 2026)
+**Alias:** `flash` (the current default Flash)
+
+**Strengths:**
+- Current frontier Flash — builds on 3.5 Flash for coding, knowledge work,
+  and multimodal tasks
+- ~17% fewer output tokens than 3.5 Flash on the Artificial Analysis index
+  (the headline efficiency win — addresses 3.5's verbosity)
+- Quality gains alongside efficiency: DeepSWE 49% vs 37%, MLE-Bench 63.9%
+  vs 49.7%, OSWorld-Verified 83.0% vs 78.4%, GDPval-AA v2 1421 vs 1349
+- Built-in client-side Computer Use tool via the Gemini API (Preview)
+- Dynamic thinking on by default (configurable via `thinking_level`)
+
+**Specifications:**
+- Context window: ~1M tokens input / 65,536 tokens output
+- Multimodal: text, image, audio, video
+- Default `thinking_level`: `medium` — set explicitly to `minimal` for
+  transcription/classification/extraction or the model will silently spend
+  output tokens on reasoning
+- Enhanced Frontier Safety safeguards (CBRN, cyber-offense); model card
+  notes a slight tone regression vs 3.5 Flash
+
+**Best for:**
+- Default Flash / sub-agent-delegation choice for most tasks
+- Agentic coding loops, terminal automation, multi-file projects
+- Cost-sensitive high-volume agentic work (cheaper output than 3.5)
+
+**Pricing:**
+- Input: $1.50 / 1M tokens
+- Output: $7.50 / 1M tokens (down from 3.5 Flash's $9.00)
+- 1M context window at base price (no surcharge tier)
+
+Shipped alongside `gemini-3.5-flash-lite` (low-latency subagent tier) and
+`gemini-3.5-flash-cyber` (vuln-finding, fine-tuned on 3.5 Flash) — neither
+is wired into this client's alias table yet.
+
+---
+
+### Gemini 3.5 — Prior Frontier Flash (GA)
 
 #### gemini-3.5-flash
 
 **Status:** Generally available (released May 19, 2026 at Google I/O)
-**Alias:** `flash` (this is now the default Flash)
+**Alias:** `flash-3.5` (was `flash` until 3.6 shipped)
 
 **Strengths:**
 - Frontier-class performance — beats Gemini 3.1 Pro on most coding and
@@ -27,10 +69,9 @@ Detailed information about available Gemini models (as of May 2026).
   the model will silently spend output tokens on reasoning)
 
 **Best for:**
-- Default Flash choice for most tasks in 2026
+- Pinning to prior-gen Flash behavior when 3.6 output differs
 - Agentic coding loops, terminal automation, multi-file projects
 - Multimodal document analysis where structure must be preserved
-- Streaming chat with frontier quality
 
 **Pricing:**
 - Input: $1.50 / 1M tokens
@@ -219,12 +260,13 @@ with up to 3 input images.
 ## Model Selection Guide
 
 ```
-Default Flash (frontier)?              → gemini-3.5-flash (alias: flash)
+Default Flash (frontier)?              → gemini-3.6-flash (alias: flash)
 Maximum reasoning?                     → gemini-3.1-pro-preview (alias: pro)
 Production stability with quality?     → gemini-2.5-flash (alias: stable-flash)
 Routine / bulk / cheap?                → gemini-2.5-flash-lite (alias: lite)
 Complex + stable production?           → gemini-2.5-pro (alias: stable-pro)
-Pin to prior-gen Flash (back compat)?  → gemini-3-flash-preview (alias: flash-3)
+Pin to prior frontier Flash (3.5)?     → gemini-3.5-flash (alias: flash-3.5)
+Pin to older preview Flash?            → gemini-3-flash-preview (alias: flash-3)
 Image generation (fast)?               → nano-banana-2 (alias: image)
 Image generation (high-fidelity)?      → nano-banana-pro (alias: image-pro)
 ```

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -44,9 +44,10 @@ Shipped alongside two sibling models, neither wired into this client's alias
 table:
 
 - `gemini-3.5-flash-lite` — GA. Fastest 3.5-class model (350 output tok/sec),
-  $0.30 / $2.50. Note this is *pricier* than the current `lite` alias target
-  (gemini-2.5-flash-lite, $0.10 / $0.40), so repointing `lite` would be a
-  cost/quality trade-off, not a free upgrade.
+  $0.30 / $2.50. **This is now the `lite` alias target** (repointed 2026-07-21
+  from gemini-2.5-flash-lite). It costs ~6x more on output than the 2.5 model it
+  replaces; that was accepted deliberately — the 2.5 generation is retired
+  regardless of price.
 - `gemini-3.5-flash-cyber` — vuln-finding, fine-tuned on 3.5 Flash; powers
   CodeMender. **NOT generally available**: access is limited to governments
   and trusted partners under a pilot program due to dual-use risk. It cannot
@@ -132,7 +133,12 @@ When it ships, `pro` alias will likely repoint there.
 
 ---
 
-### Gemini 2.5 — Stable Production
+### Gemini 2.5 — DEPRECATED (retired 2026-07-21)
+
+⚠️ The Gemini 2.5 text generation is **retired from routing**. A 2025-era
+generation; the cost saving does not justify the quality gap. Model IDs remain
+callable so pinned code does not hard-break, but do not target them in new work.
+The `lite` alias now resolves to `gemini-3.5-flash-lite`.
 
 #### gemini-2.5-flash
 
@@ -159,8 +165,8 @@ When it ships, `pro` alias will likely repoint there.
 
 #### gemini-2.5-flash-lite
 
-**Status:** Stable, generally available
-**Alias:** `lite`
+**Status:** DEPRECATED (retired from routing 2026-07-21)
+**Alias:** none — `lite` now points at gemini-3.5-flash-lite
 
 **Strengths:**
 - **Cheapest major-provider production model** ($0.10 / $0.40)
@@ -270,9 +276,7 @@ with up to 3 input images.
 ```
 Default Flash (frontier)?              → gemini-3.6-flash (alias: flash)
 Maximum reasoning?                     → gemini-3.1-pro-preview (alias: pro)
-Production stability with quality?     → gemini-2.5-flash (alias: stable-flash)
-Routine / bulk / cheap?                → gemini-2.5-flash-lite (alias: lite)
-Complex + stable production?           → gemini-2.5-pro (alias: stable-pro)
+Routine / bulk / cheap / fastest?      → gemini-3.5-flash-lite (alias: lite)
 Pin to prior frontier Flash (3.5)?     → gemini-3.5-flash (alias: flash-3.5)
 Pin to older preview Flash?            → gemini-3-flash-preview (alias: flash-3)
 Image generation (fast)?               → nano-banana-2 (alias: image)
@@ -323,11 +327,11 @@ on Flash-tier models.
 | Model | Status | Migration Target |
 |---|---|---|
 | gemini-3-pro-preview | Retired (March 9, 2026) | gemini-3.1-pro-preview |
-| gemini-2.0-flash-exp | Retiring June 1, 2026 | gemini-3.5-flash |
-| gemini-2.0-flash | Retiring June 1, 2026 | gemini-2.5-flash |
-| gemini-2.0-flash-lite | Retiring June 1, 2026 | gemini-2.5-flash-lite |
+| gemini-2.0-flash-exp | Retiring June 1, 2026 | gemini-3.6-flash |
+| gemini-2.0-flash | Retiring June 1, 2026 | gemini-3.6-flash |
+| gemini-2.0-flash-lite | Retiring June 1, 2026 | gemini-3.5-flash-lite |
 | gemini-1.5-pro | Retired (404) | gemini-2.5-pro |
-| gemini-1.5-flash | Retired (404) | gemini-2.5-flash |
+| gemini-1.5-flash | Retired (404) | gemini-3.6-flash |
 | gemini-1.0-* | Retired (404) | — |
 
 ## Cost Optimization Tips

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -40,9 +40,17 @@ Detailed information about available Gemini models (as of July 2026).
 - Output: $7.50 / 1M tokens (down from 3.5 Flash's $9.00)
 - 1M context window at base price (no surcharge tier)
 
-Shipped alongside `gemini-3.5-flash-lite` (low-latency subagent tier) and
-`gemini-3.5-flash-cyber` (vuln-finding, fine-tuned on 3.5 Flash) — neither
-is wired into this client's alias table yet.
+Shipped alongside two sibling models, neither wired into this client's alias
+table:
+
+- `gemini-3.5-flash-lite` — GA. Fastest 3.5-class model (350 output tok/sec),
+  $0.30 / $2.50. Note this is *pricier* than the current `lite` alias target
+  (gemini-2.5-flash-lite, $0.10 / $0.40), so repointing `lite` would be a
+  cost/quality trade-off, not a free upgrade.
+- `gemini-3.5-flash-cyber` — vuln-finding, fine-tuned on 3.5 Flash; powers
+  CodeMender. **NOT generally available**: access is limited to governments
+  and trusted partners under a pilot program due to dual-use risk. It cannot
+  simply be added as an alias.
 
 ---
 

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -284,6 +284,8 @@ def _cf_request(
                 )
             response.raise_for_status()
             return response.json()
+        except MediaInputError:
+            raise  # deterministic input error — retrying cannot help
         except Exception as e:
             if attempt == max_retries - 1:
                 raise
@@ -312,15 +314,55 @@ def _extract_text(response: dict) -> Optional[str]:
         return None
 
 
+class MediaInputError(ValueError):
+    """Invalid media input. Deterministic — never worth retrying."""
+
+
+# Extensions mimetypes.guess_type() gets wrong or misses, per Gemini's accepted
+# media types. Audio/video matter here: a bad guess silently sends the wrong
+# mimeType and the model returns a confused answer instead of an error.
+_MEDIA_MIME_OVERRIDES = {
+    ".m4a": "audio/mp4", ".aac": "audio/aac", ".flac": "audio/flac",
+    ".ogg": "audio/ogg", ".opus": "audio/opus", ".mp3": "audio/mpeg",
+    ".wav": "audio/wav", ".aiff": "audio/aiff",
+    ".mp4": "video/mp4", ".mov": "video/quicktime", ".webm": "video/webm",
+    ".heic": "image/heic", ".heif": "image/heif",
+}
+
+# generateContent inline payloads must fit the request; base64 inflates ~4/3.
+# Files above this need the Files API (not implemented in this client).
+_INLINE_MEDIA_MAX_BYTES = 15 * 1024 * 1024
+
+
+def _guess_media_mime(path: str) -> str:
+    """Resolve a media mimeType, preferring explicit overrides over mimetypes."""
+    import mimetypes
+    ext = Path(path).suffix.lower()
+    if ext in _MEDIA_MIME_OVERRIDES:
+        return _MEDIA_MIME_OVERRIDES[ext]
+    return mimetypes.guess_type(path)[0] or "application/octet-stream"
+
+
 def _build_contents(prompt: str, image_path: Optional[str]) -> list:
-    """Build the Gemini REST API 'contents' array."""
+    """Build the Gemini REST API 'contents' array.
+
+    `image_path` accepts ANY supported media file — image, audio, or video —
+    despite the legacy name. Audio input is verified working on this path
+    (2026-07-21).
+    """
     parts: list = [{"text": prompt}]
     if image_path:
         import base64
-        import mimetypes
 
+        size = Path(image_path).stat().st_size
+        if size > _INLINE_MEDIA_MAX_BYTES:
+            raise MediaInputError(
+                f"{image_path} is {size/1e6:.1f}MB; inline media is capped at "
+                f"{_INLINE_MEDIA_MAX_BYTES/1e6:.0f}MB. Larger files need the "
+                f"Files API, which this client does not implement yet."
+            )
         image_data = Path(image_path).read_bytes()
-        mime_type = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+        mime_type = _guess_media_mime(image_path)
         parts.append({
             "inlineData": {
                 "mimeType": mime_type,
@@ -362,7 +404,19 @@ def _initialize_direct_client() -> bool:
 
 
 def _build_genai_content(prompt: str, image_path: Optional[str]):
-    """Build content argument for google.generativeai SDK calls."""
+    """Build content argument for google.generativeai SDK calls.
+
+    NOTE: this direct-SDK fallback handles IMAGES only. Non-image media
+    (audio/video) works on the CF Gateway path; PIL cannot open it, so fail
+    with a clear message instead of an opaque UnidentifiedImageError.
+    """
+    if image_path and not _guess_media_mime(image_path).startswith("image/"):
+        raise MediaInputError(
+            f"{image_path} is not an image ({_guess_media_mime(image_path)}). "
+            "Audio/video input requires the Cloudflare AI Gateway path — "
+            "configure proxy.env; the direct google-generativeai SDK fallback "
+            "supports images only."
+        )
     if image_path:
         from PIL import Image  # type: ignore[import]
         return [prompt, Image.open(image_path)]
@@ -430,7 +484,10 @@ def invoke_gemini(
             tasks.
         top_p: Nucleus sampling parameter
         top_k: Top-k sampling parameter
-        image_path: Optional path to image file for multi-modal input
+        image_path: Optional path to a media file for multi-modal input.
+            Despite the name, accepts image, AUDIO, or video (audio verified
+            2026-07-21). Requires the CF Gateway path for non-image media.
+            Inline only — files >15MB need the Files API (not implemented).
         thinking_level: Reasoning budget for thinking models (Gemini 3.x).
             One of 'minimal', 'low', 'medium', 'high'. Default (None) lets
             the model use its built-in default — 'medium' for 3.x Flash
@@ -492,6 +549,8 @@ def invoke_gemini(
                 response = model_instance.generate_content(content)
                 return response.text
 
+        except MediaInputError:
+            raise  # deterministic input error — retrying cannot help
         except Exception as e:
             if attempt < max_retries - 1:
                 wait_time = 2 ** attempt
@@ -609,6 +668,8 @@ def generate_image(
             print(f"Image saved to {output_path}")
             return {"path": output_path, "caption": caption}
 
+        except MediaInputError:
+            raise  # deterministic input error — retrying cannot help
         except Exception as e:
             if attempt < max_retries - 1:
                 wait_time = 2 ** attempt
@@ -671,7 +732,10 @@ def invoke_with_structured_output(
         model: Model name or alias (default: gemini-3-flash-preview).
             Aliases: flash, pro, lite, stable-flash, stable-pro
         temperature: Sampling temperature (0.0–1.0)
-        image_path: Optional path to image file for multi-modal input
+        image_path: Optional path to a media file for multi-modal input.
+            Despite the name, accepts image, AUDIO, or video (audio verified
+            2026-07-21). Requires the CF Gateway path for non-image media.
+            Inline only — files >15MB need the Files API (not implemented).
 
     Returns:
         Instance of pydantic_model if successful, None if error
@@ -719,6 +783,8 @@ def invoke_with_structured_output(
                 json_data = json.loads(response.text)
                 return pydantic_model(**json_data)
 
+        except MediaInputError:
+            raise  # deterministic input error — retrying cannot help
         except Exception as e:
             if attempt < max_retries - 1:
                 wait_time = 2 ** attempt

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -56,7 +56,11 @@ MODELS = {
     # Gemini 3.x — preview (still callable, kept for back compat)
     "gemini-3-flash-preview": "gemini-3-flash-preview",
     "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
-    # Gemini 2.5 — stable production
+    # Gemini 3.5 Flash-Lite — cheap/bulk tier (GA 2026-07-21)
+    "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
+    # Gemini 2.5 — DEPRECATED 2026-07-21. A 2025-era generation; do NOT route
+    # here. IDs kept callable so pinned code does not hard-break, but they are
+    # no longer a recommended target and `lite` no longer points at 2.5.
     "gemini-2.5-flash": "gemini-2.5-flash",
     "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
     "gemini-2.5-pro": "gemini-2.5-pro",
@@ -76,13 +80,16 @@ IMAGE_MODELS = {
 
 # Convenience aliases. `flash` points to the current frontier Flash (3.6, GA
 # 2026-07-21); `flash-3.5` and `flash-3` keep stable handles on the prior Flash
-# generations for code that pinned to them.
+# generations for code that pinned to them. `lite` repointed 2026-07-21 from
+# gemini-2.5-flash-lite to gemini-3.5-flash-lite (BREAKING: ~6x output cost,
+# $0.40 -> $2.50/M, in exchange for a current-generation model).
 MODEL_ALIASES = {
     "flash": "gemini-3.6-flash",
     "flash-3.5": "gemini-3.5-flash",
     "flash-3": "gemini-3-flash-preview",
     "pro": "gemini-3.1-pro-preview",
-    "lite": "gemini-2.5-flash-lite",
+    "lite": "gemini-3.5-flash-lite",
+    # DEPRECATED aliases (Gemini 2.5). Retained for back compat only.
     "stable-flash": "gemini-2.5-flash",
     "stable-pro": "gemini-2.5-pro",
     "image": "nano-banana-2",

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -49,7 +49,9 @@ if not HAS_REQUESTS and not HAS_GENAI:
 
 # Text generation models
 MODELS = {
-    # Gemini 3.5 — frontier (GA May 2026)
+    # Gemini 3.6 — current frontier Flash (GA 2026-07-21)
+    "gemini-3.6-flash": "gemini-3.6-flash",
+    # Gemini 3.5 — prior frontier Flash (GA May 2026)
     "gemini-3.5-flash": "gemini-3.5-flash",
     # Gemini 3.x — preview (still callable, kept for back compat)
     "gemini-3-flash-preview": "gemini-3-flash-preview",
@@ -72,10 +74,12 @@ IMAGE_MODELS = {
     "nano-banana": "gemini-2.5-flash-image",
 }
 
-# Convenience aliases. `flash` points to the current frontier Flash (3.5);
-# `flash-3` keeps a stable handle on the prior preview for code that pinned to it.
+# Convenience aliases. `flash` points to the current frontier Flash (3.6, GA
+# 2026-07-21); `flash-3.5` and `flash-3` keep stable handles on the prior Flash
+# generations for code that pinned to them.
 MODEL_ALIASES = {
-    "flash": "gemini-3.5-flash",
+    "flash": "gemini-3.6-flash",
+    "flash-3.5": "gemini-3.5-flash",
     "flash-3": "gemini-3-flash-preview",
     "pro": "gemini-3.1-pro-preview",
     "lite": "gemini-2.5-flash-lite",
@@ -85,7 +89,7 @@ MODEL_ALIASES = {
     "image-pro": "nano-banana-pro",
 }
 
-DEFAULT_MODEL = "gemini-3.5-flash"
+DEFAULT_MODEL = "gemini-3.6-flash"
 
 # ---------------------------------------------------------------------------
 # Cloudflare AI Gateway constants
@@ -409,9 +413,9 @@ def invoke_gemini(
 
     Args:
         prompt: The text prompt to send
-        model: Model name or alias (default: gemini-3.5-flash).
-            Aliases: flash (3.5), flash-3 (prior preview), pro, lite,
-            stable-flash, stable-pro
+        model: Model name or alias (default: gemini-3.6-flash).
+            Aliases: flash (3.6), flash-3.5 (prior Flash), flash-3 (prior
+            preview), pro, lite, stable-flash, stable-pro
         temperature: Sampling temperature (0.0–1.0)
         max_output_tokens: Maximum tokens in response. Note: with thinking
             models (Gemini 3.x), thinking tokens consume part of this budget;
@@ -422,8 +426,8 @@ def invoke_gemini(
         image_path: Optional path to image file for multi-modal input
         thinking_level: Reasoning budget for thinking models (Gemini 3.x).
             One of 'minimal', 'low', 'medium', 'high'. Default (None) lets
-            the model use its built-in default — 'medium' for 3.5 Flash,
-            which silently eats output budget. Set 'minimal' for tasks that
+            the model use its built-in default — 'medium' for 3.x Flash
+            (incl. 3.6), which silently eats output budget. Set 'minimal' for tasks that
             don't need reasoning (transcription, classification, extraction).
             Ignored by 2.5 models (which use a different parameter).
 


### PR DESCRIPTION
## What
Gemini 3.6 Flash went GA on 2026-07-21. This makes it the default Flash for this client.

- `MODEL_ALIASES['flash']` → `gemini-3.6-flash` (was `gemini-3.5-flash`)
- `DEFAULT_MODEL` → `gemini-3.6-flash`; added `gemini-3.6-flash` to `MODELS`
- Added `flash-3.5` alias to keep a stable handle on the prior frontier Flash; `flash-3` still pins `gemini-3-flash-preview`
- Updated SKILL.md + references/models.md tables (pricing in $1.50 / out $7.50, 64K output cap, benchmark deltas vs 3.5, tone-regression caveat) and CHANGELOG

## Why
3.6 Flash is ~half Sonnet's cost (in $1.50 / out $7.50 vs ~$3 / ~$15) and improves coding/agentic quality with ~17% fewer output tokens than 3.5 Flash. Adopting it as the default sub-agent-delegation model from claude.ai.

## Gate (run in-session)
- `python3 -m py_compile invoking-gemini/scripts/gemini_client.py` — passes
- `skill_lint.validate_skill_file` on SKILL.md — passes
- Alias/default resolution verified: `flash`→3.6, `flash-3.5`→3.5, `DEFAULT_MODEL`→3.6

## ⚠️ Breaking change (added after initial review)
`MODEL_ALIASES['lite']` repointed from `gemini-2.5-flash-lite` to `gemini-3.5-flash-lite` — **~6x output cost** ($0.40 → $2.50 per 1M) for anyone calling `model="lite"`. This repo is a public marketplace, so downstream forks inherit the change silently; called out prominently in CHANGELOG.

The Gemini 2.5 **text** generation (`2.5-flash`, `2.5-flash-lite`, `2.5-pro`) is retired from routing as a 2025-era generation. Model IDs and the `stable-flash`/`stable-pro` aliases still resolve so nothing hard-breaks; they're marked DEPRECATED in the docs. Image model `nano-banana` (gemini-2.5-flash-image) is **not** affected.

## Notes / not in scope
- `plugins/ai-and-reasoning/skills/invoking-gemini/` is **generated** by `registry/generate.py` (skill-release workflow) from the top-level dir — left untouched; it will sync on next release. Hand-editing it would be overwritten.
- `gemini-3.5-flash-lite` and `gemini-3.5-flash-cyber` shipped the same day; neither is aliased here.
  - **Flash-Lite** (GA) is now wired in as the `lite` target — see the breaking-change section above.
  - **Flash Cyber is gated** to governments and trusted partners under a limited-access pilot (dual-use risk). It cannot be aliased — not a viable follow-up.
- Two helper fns still hardcode a `gemini-3-flash-preview` default in their signatures (pre-existing staleness); not changed to keep this PR to one reviewable unit.
