### PR TITLE
fix(creating-video): --keep-audio was a no-op — port audio crossfade from the stale branch

### DIFF
--- a/creating-video/CHANGELOG.md
+++ b/creating-video/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `creating-video` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.1] - 2026-07-21
+
+### Fixed
+
+- `assemble.py`: `--keep-audio` was a no-op — trimmed clips kept audio but the
+  stitch stage mapped only video, so the flag silently produced a silent film.
+  Adds the `acrossfade` chain, `afade` out, and explicit `[k:v]`/`[k:a]` stream
+  specifiers; pads the held tail with `apad` so A/V stay equal length.
+
 ## [0.2.0] - 2026-07-21
 
 ### Other

--- a/creating-video/SKILL.md
+++ b/creating-video/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-video
 description: "Create video from prompts by overseeing multi-clip AI generation end to end: write a shot list, generate each scene with Gemini Omni Flash (via the Cloudflare AI Gateway), review the results, and assemble them into a finished cut. Use when the user asks to make/generate a video, a short film, an animatic, or a multi-scene clip from a script or idea; when they mention Omni, Veo, text-to-video, or image-to-video; or when acting as the editing/director agent over generated footage. Triggers on 'make a video', 'generate a clip', 'short film', 'video from this script', 'turn this into a video', 'omni', 'veo', 'text to video', 'storyboard to video'. For transcoding/trimming/merging/GIF/subtitles use processing-video; for reading or summarizing existing video content use parsing-video."
 metadata:
-  version: 0.2.0
+  version: 0.2.1
 ---
 
 # Creating Video

--- a/creating-video/scripts/assemble.py
+++ b/creating-video/scripts/assemble.py
@@ -62,10 +62,14 @@ def assemble(clips, out, beat=5.42, xfade=0.5, keep_audio=False,
             vf += f",tpad=stop_mode=clone:stop_duration={tail_hold}"
         vf += ",format=yuv420p"
         dst = tmp / f"t{i}.mp4"
-        audio = [] if not keep_audio else []
         cmd = ["ffmpeg", "-y", "-ss", "0.4", "-t", f"{beat}", "-i", str(src),
                "-vf", vf, "-r", str(fps)]
-        if not keep_audio:
+        if keep_audio:
+            af = "aresample=48000,aformat=sample_fmts=fltp:channel_layouts=stereo"
+            if last and tail_hold > 0:
+                af += f",apad=pad_dur={tail_hold}"  # keep A/V equal length on the held tail
+            cmd += ["-af", af, "-c:a", "aac", "-b:a", "128k"]
+        else:
             cmd += ["-an"]
         cmd += ["-c:v", "libx264", "-preset", "veryfast", "-crf", "20", str(dst)]
         rc, log = _run(cmd)
@@ -80,17 +84,27 @@ def assemble(clips, out, beat=5.42, xfade=0.5, keep_audio=False,
     D = beat  # clip duration for offset math (tail_hold handled inside last clip)
     T = xfade
     fc = ""
-    prev = "0"
-    total = D + tail_hold  # final clip is longer by tail_hold
+    prev = None
     for k in range(1, n):
         off = k * (D - T)
+        left = "[0:v]" if k == 1 else f"[{prev}]"
         lbl = "v" if k == n - 1 else f"x{k}"
-        fc += f"[{prev}][{k}]xfade=transition=fade:duration={T}:offset={off:.3f}[{lbl}];"
+        fc += f"{left}[{k}:v]xfade=transition=fade:duration={T}:offset={off:.3f}[{lbl}];"
         prev = lbl
     full_len = (n * D) - ((n - 1) * T) + tail_hold
     fc += (f"[v]fade=t=in:st=0:d=0.6,"
            f"fade=t=out:st={full_len-1.0:.2f}:d=1.0,format=yuv420p[vv]")
-    cmd = ["ffmpeg", "-y"] + inputs + ["-filter_complex", fc, "-map", "[vv]",
+    maps = ["-map", "[vv]"]
+    if keep_audio:
+        aprev = None
+        for k in range(1, n):
+            left = "[0:a]" if k == 1 else f"[{aprev}]"
+            albl = "a" if k == n - 1 else f"ax{k}"
+            fc += f";{left}[{k}:a]acrossfade=d={T}[{albl}]"
+            aprev = albl
+        fc += f";[a]afade=t=out:st={full_len-1.0:.2f}:d=1.0[aa]"
+        maps += ["-map", "[aa]", "-c:a", "aac", "-b:a", "160k"]
+    cmd = ["ffmpeg", "-y"] + inputs + ["-filter_complex", fc] + maps + [
            "-r", str(fps), "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
            "-movflags", "+faststart", str(out)]
     rc, log = _run(cmd)


### PR DESCRIPTION
*Filed by Muninn*

Ports the unshipped audio work from the now-stale `creating-video-skill` branch onto current `main` (0.2.0 / Omni).

## The bug

`--keep-audio` is documented in SKILL.md ("`--keep-audio` to `acrossfade` instead") but does nothing. The trim stage kept audio on each clip; the stitch stage built a video-only `filter_complex` and passed `-map "[vv]"` only, so the audio was dropped on the way out. `assemble()` also carried a dead line, `audio = [] if not keep_audio else []`.

## The fix

- Trim stage: `aresample`/`aformat` normalise, `-c:a aac -b:a 128k`, and `apad=pad_dur=<tail_hold>` on the final clip so audio matches the `tpad`-held video tail.
- Stitch stage: `acrossfade` chain mirroring the `xfade` offsets, `afade=t=out` matching the video fade, `-map "[aa]" -c:a aac -b:a 160k`.
- Explicit `[0:v]` / `[k:v]` / `[k:a]` stream specifiers instead of bare `[k]` — with audio present, unlabelled pads are ambiguous.
- Removes the dead `audio = []` line.

## Verification (run in-session, ffmpeg 6.1.1)

Three synthetic 8 s clips (`testsrc` + `sine` at 300/600/900 Hz), `beat=2.0 xfade=0.5 tail_hold=1.0`, expected length `3*2 - 2*0.5 + 1.0 = 6.0 s`:

| version | `--keep-audio` | output streams |
|---|---|---|
| main (0.2.0) | off | video 6.00 s |
| main (0.2.0) | **on** | video 6.00 s — **audio missing** |
| this PR | off | video 6.00 s (no regression) |
| this PR | **on** | video 6.00 s + audio 6.02 s |

A/V drift on the held tail is 20 ms. The default (audio-dropped) path is byte-identical in behaviour.

Repro:
```bash
for i in 1 2 3; do ffmpeg -y -f lavfi -i "testsrc=duration=8:size=320x240:rate=25" \
  -f lavfi -i "sine=frequency=$((300*i)):duration=8" -c:v libx264 -preset ultrafast \
  -c:a aac -shortest c$i.mp4; done
python3 -c "import assemble; assemble.assemble(['c1.mp4','c2.mp4','c3.mp4'],'out.mp4', \
  beat=2.0, xfade=0.5, keep_audio=True, tail_hold=1.0, size='320:240')"
ffprobe -v error -show_entries stream=codec_type,duration -of json out.mp4
```

Bumps SKILL.md to 0.2.1 + CHANGELOG entry. Branch `creating-video-skill` can be deleted once this merges — this is the only thing on it that never shipped.