### PR TITLE
semantic-grep: default to gemini-embedding-2, retire gemini-embedding-001

### DIFF
--- a/semantic-grep/CHANGELOG.md
+++ b/semantic-grep/CHANGELOG.md
@@ -1,5 +1,21 @@
 # semantic-grep - Changelog
 
+## 2026-07-21
+
+### Changed — default encoder is now `gemini-embedding-2`
+- `_DEFAULT_MODEL`: `gemini-embedding-001` → `gemini-embedding-2` (GA 2026-04-22).
+- Embedding-2 is a strict superset: same request shape and dims for text, plus
+  image and audio into the same vector space. Verified through the CF gateway
+  2026-07-21 — 001 rejects non-text input with HTTP 400.
+
+### Retired — `gemini-embedding-001`
+- Listed in `_RETIRED_MODELS`; passing it explicitly still works but raises a
+  `DeprecationWarning` pointing at the replacement.
+- **No migration needed.** This skill is serverless and re-embeds on every call
+  (no persistent index), and the memory system stopped generating embeddings in
+  v0.13.0 — so no stored 001 vectors exist to invalidate.
+- Vectors from different encoders are not comparable; never mix them in one index.
+
 All notable changes to the `semantic-grep` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.1.1] - 2026-04-19

--- a/semantic-grep/SKILL.md
+++ b/semantic-grep/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # Semantic Grep
 
-jina-grep-style semantic search, done in-process via Python rather than as an external CLI. Embeds query + corpus chunks with `gemini-embedding-001`, ranks by cosine similarity, returns grep-format output.
+jina-grep-style semantic search, done in-process via Python rather than as an external CLI. Embeds query + corpus chunks with `gemini-embedding-2`, ranks by cosine similarity, returns grep-format output.
 
 ## When Semantic Search Helps
 
@@ -64,7 +64,7 @@ Main search function.
 - `threshold` *(float | None)* — cosine similarity cutoff; `None` = no filter (top_k only)
 - `granularity` *("paragraph" | "line")* — how to chunk files (default paragraph)
 - `include` *(str)* — filename-glob filter when `corpus` is a directory (default `"*.txt"`). Matches against `Path.name` only, not the full path — `"*.md"` works, `"docs/*.md"` does not.
-- `model` *(str)* — default `"gemini-embedding-001"`
+- `model` *(str)* — default `"gemini-embedding-2"`. `gemini-embedding-001` is **retired** (text-only) and warns if passed explicitly.
 - `dim` *(int)* — 128 / 768 / 1536 / 3072 (default 768; MRL-truncated + renormalized)
 - `task` *("text" | "code")* — selects text vs code task types
 
@@ -119,7 +119,10 @@ Use `SEMANTIC_SIMILARITY` (symmetric) only if you're doing pairwise sim, not ret
 
 ## Model Notes
 
-`gemini-embedding-001` (GA since Feb 2026):
+`gemini-embedding-2` (GA since 2026-04-22) — general-purpose **and** multimodal.
+Verified 2026-07-21 via the CF gateway: text, image and audio all embed to the
+same space at the requested dim, L2-normalized. The retired `gemini-embedding-001`
+was text-only and rejected non-text input with HTTP 400:
 - 2,048 input token limit per text. Longer texts are truncated at ~8K chars (approximation).
 - Matryoshka (MRL) — 3072 native dims, safely truncatable to 1536/768/256/128.
 - 3072 is auto-normalized; lower dims need client-side renorm (handled here).

--- a/semantic-grep/scripts/semantic_grep.py
+++ b/semantic-grep/scripts/semantic_grep.py
@@ -4,7 +4,11 @@ semantic_grep: a jina-grep reproduction using Gemini embeddings.
 In-process semantic search over text files or in-memory strings.
 Routes through Cloudflare AI Gateway (proxy.env) when available.
 
-Model: gemini-embedding-001 (GA, 2048 input tokens, MRL truncation supported)
+Model: gemini-embedding-2 (GA 2026-04-22; general-purpose AND multimodal, MRL
+       truncation supported). Supersedes gemini-embedding-001, which is text-only.
+       Verified 2026-07-21 through the CF gateway: text, image (image/png) and
+       audio (audio/wav) all embed to the same space at the requested dim,
+       L2-normalized. 001 rejects non-text with HTTP 400.
 Task types used: RETRIEVAL_QUERY (query) + RETRIEVAL_DOCUMENT (corpus) — asymmetric.
 
 Design notes:
@@ -35,8 +39,8 @@ import requests
 
 _CF_GATEWAY_BASE = "https://gateway.ai.cloudflare.com/v1"
 _DIRECT_BASE = "https://generativelanguage.googleapis.com/v1beta"
-_DEFAULT_MODEL = "gemini-embedding-001"
-_MAX_INPUT_TOKENS = 2048  # per Gemini docs for gemini-embedding-001
+_DEFAULT_MODEL = "gemini-embedding-2"
+_MAX_INPUT_TOKENS = 2048  # conservative; documented for embedding-001, unverified for -2
 # Conservative char-per-token ratio. English prose is ~4 chars/token,
 # but CJK is closer to 1 char/token and emoji can be <1. Picking 1.5 as a safe
 # lower bound means we under-fill for English (some wasted context) in exchange

--- a/semantic-grep/scripts/semantic_grep.py
+++ b/semantic-grep/scripts/semantic_grep.py
@@ -40,6 +40,26 @@ import requests
 _CF_GATEWAY_BASE = "https://gateway.ai.cloudflare.com/v1"
 _DIRECT_BASE = "https://generativelanguage.googleapis.com/v1beta"
 _DEFAULT_MODEL = "gemini-embedding-2"
+
+# Retired 2026-07-21. gemini-embedding-001 is text-only and superseded by
+# gemini-embedding-2 (general-purpose AND multimodal, same request shape and
+# dims). Still callable if explicitly requested, but warns — nothing in this
+# skill persists vectors, so there is no index to migrate.
+_RETIRED_MODELS = {
+    "gemini-embedding-001": "gemini-embedding-2",
+}
+
+
+def _check_retired(model: str) -> None:
+    """Warn once if a caller explicitly asks for a retired embedding model."""
+    if model in _RETIRED_MODELS:
+        import warnings
+        warnings.warn(
+            f"{model} is retired; use {_RETIRED_MODELS[model]} "
+            f"(general-purpose and multimodal, same dims). Vectors from "
+            f"different encoders are not comparable — do not mix them.",
+            DeprecationWarning, stacklevel=3,
+        )
 _MAX_INPUT_TOKENS = 2048  # conservative; documented for embedding-001, unverified for -2
 # Conservative char-per-token ratio. English prose is ~4 chars/token,
 # but CJK is closer to 1 char/token and emoji can be <1. Picking 1.5 as a safe
@@ -98,6 +118,7 @@ TaskType = Literal[
 def _embed_one(text: str, task_type: TaskType, *, model: str, dim: int,
                timeout: float = 30.0, retries: int = 2) -> np.ndarray:
     """Embed a single string. Normalizes output if dim < 3072."""
+    _check_retired(model)
     url, headers = _embed_url(model)
     headers = {**headers, "Content-Type": "application/json"}
     body = {


### PR DESCRIPTION
## What
Retire `gemini-embedding-001` and make `gemini-embedding-2` (GA 2026-04-22) the default encoder.

- `_DEFAULT_MODEL`: `gemini-embedding-001` → `gemini-embedding-2`
- `gemini-embedding-001` added to `_RETIRED_MODELS`; still callable, but raises a `DeprecationWarning` naming the replacement
- SKILL.md + CHANGELOG updated

## Why
Embedding-2 is a **strict superset**, not a trade — same request shape and dims for text, plus non-text modalities in the same vector space.

| | text | text@256 (MRL) | image | audio |
|---|---|---|---|---|
| `gemini-embedding-001` | ✓ | ✓ | ✗ HTTP 400 | ✗ |
| `gemini-embedding-2` | ✓ | ✓ | ✓ | ✓ |

Verified 2026-07-21 through the CF AI Gateway using this module's own `_embed_url` path; all outputs L2-normalized at the requested dim.

The deciding factor is **deployment, not benchmark score**. Other encoders may score better, but from this container `api.jina.ai` (403) and `api-inference.huggingface.co` (unreachable) are not allowlisted, `api.openai.com` is reachable but uncredentialed, and there is no HF cache — so a local encoder re-downloads weights every session. Gemini is the only embedding platform we have both network access and credentials for: 1.21s cold, ~0.6s warm, no weights, no install.

## Migration: none required
- This skill is serverless and re-embeds on every call — **no persistent index**.
- The memory system stopped generating embeddings in v0.13.0, so no stored 001 vectors exist to invalidate.
- Vectors from different encoders are not comparable; the warning says so, since the real hazard is mixing them in one index.

## Verified on the branch
- `py_compile` passes
- default path: `gemini-embedding-2`, dim 768, ‖v‖ = 1.0
- retired path: emits the `DeprecationWarning` and still returns a vector

## Not in scope
- `_MAX_INPUT_TOKENS = 2048` was documented for 001; kept as a conservative bound, comment flags it as unverified for -2.
- No multimodal **entry point** — `_embed_one` is still text-only. Image/audio embedding works at REST level (tested) but needs a public helper before the skill can use it. That is the follow-up that actually unlocks the capability.
- Local-ONNX lane (remax_kb / portable `.skill` bundles) is untouched and should stay on a local encoder — those must run with no key and no network.