### PR TITLE
chore: bump invoking-gemini + semantic-grep versions to trigger releases

### DIFF
--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -2,7 +2,7 @@
 name: invoking-gemini
 description: Invokes Google Gemini models for structured outputs, image generation, multi-modal tasks, and Google-specific features. Use when users request Gemini, image generation, structured JSON output, Google API integration, or cost-effective parallel processing.
 metadata:
-  version: 0.6.0
+  version: 0.7.0
 ---
 
 # Invoking Gemini

--- a/semantic-grep/SKILL.md
+++ b/semantic-grep/SKILL.md
@@ -2,7 +2,7 @@
 name: semantic-grep
 description: In-process semantic search over text files or in-memory strings, using Gemini embeddings via the CF AI Gateway. Use when user wants fuzzy/conceptual search where exact-keyword grep would miss — "sessions discussing regulatory constraints", "code about retry logic", "notes mentioning burnout even if the word isn't there". Complements searching-codebases (regex/AST) and extracting-keywords (YAKE). Do NOT use when an exact string/regex match is what's wanted — grep/rg wins on speed and precision there.
 metadata:
-  version: 0.1.1
+  version: 0.2.0
 ---
 
 # Semantic Grep


### PR DESCRIPTION
Bumps `metadata.version` on two skills updated in the last ~20h that cut no release: `skill-release.yml` gates on a **version delta**, so the content-only merges (#741, #743) hit `detect-version-changes.py` and printed "No skills to release".

- **invoking-gemini** 0.6.0 -> **0.7.0** (default->gemini-3.6-flash, retired Gemini 2.5 text)
- **semantic-grep** 0.1.1 -> **0.2.0** (default->gemini-embedding-2, retired gemini-embedding-001)

Minor (not patch) because each retires previously-supported models (capability removal). Adjust before merge if you'd rather treat these as patch.

On merge, the squash commit's `HEAD~1..HEAD` diff carries both deltas, so both release in one run.

Latent, not fixed here: the detector only diffs the tip commit `HEAD~1..HEAD` — fine for squash-merges, but a multi-commit non-squash push whose bump isn't in the last commit is silently missed. Worth switching to `${{ github.event.before }}..${{ github.sha }}`.