### PR TITLE
gating 0.2.0: lessons from the first substantial use of the skill

### DIFF
--- a/gating/CHANGELOG.md
+++ b/gating/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `gating` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-08-02
+
+Lessons from the first substantial use of the skill — auditing and rebuilding
+the calibration gate in `oaustegard/experiments/remex-vs-higgs-ablation`
+(8 checks -> 166, 91 mutants, four false reds in the rebuilt gate). Every item
+below is something the skill led into or failed to warn about, not a
+hypothetical.
+
+### Added
+
+- `bracket()` takes `lo_inclusive` / `hi_inclusive`. A strict edge at an
+  *attainable* theoretical bound reports red on a perfect result: a randomized
+  Hadamard maps a coordinate spike to exactly 1/sqrt(d), the information-
+  theoretic floor, and a strict `lo` blocked a real run.
+- `known_bad(..., covers=(...))` names the checks a case exercises, and
+  `report()` prints the checks no known-bad reaches. "We have a known-bad" and
+  "we know which checks fire" are different claims; an audited gate had one
+  known-bad covering 1 of 8 checks, and the check its result rested on
+  *accepted* the same bad case.
+- SKILL.md: validate a known-bad at the configuration it will run in — one
+  tuned at m=2/K=16 stopped being bad at m=8/K=65536.
+- SKILL.md + `anchors.md`: a statistical margin is not a practical floor. A
+  paired estimator's se shrinks as the arms converge, so a 3-sigma threshold
+  admitted a +0.0001 dB effect where real ones were 0.35-1.41 dB. The
+  magnitude that matters has to come from an anchor.
+- SKILL.md: two anti-pattern rows (significant-but-not-meaningful; strict
+  bracket at an attainable optimum) and an explicit statement that a gate
+  checks *correctness* and cannot check *comparability* — performance claims
+  have no anchor in this framework.
+- `auditing.md`: disable on-disk caches before mutation testing, or every
+  mutation of the producing code survives for the wrong reason; and pin
+  permanent mutation fixtures by code snippet, because survivor line numbers
+  go stale the moment anyone edits above them.
+
 ## [0.1.0] - 2026-08-02
 
 ### Added

--- a/gating/SKILL.md
+++ b/gating/SKILL.md
@@ -2,7 +2,7 @@
 name: gating
 description: Build and audit deterministic verification gates — checks that block a pipeline and can be shown to go red. Use when writing a calibration gate, CI check, validation script, or pre-publication check for a numeric or empirical result; when a result is about to be published, acted on, or merged and a plausible-but-wrong value would survive review; when asking whether an existing test suite, linter rule, or check could actually fail; and when a check suite passes first try, passes suspiciously often, or was written by the same process that produced the thing it checks. Triggers on "verification loop", "calibration gate", "can this check fail", "known-bad", "negative control", "sanity check my results", "is this test actually testing anything".
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # gating
@@ -28,6 +28,21 @@ ever tells you the code still does what it did. See `references/anchors.md`.
 plausibly break, run the gate, confirm red. Until you have done this you have
 not shown the gate works — you have shown it runs. This is the obligation
 people skip, because a passing gate feels like evidence.
+
+Two things about known-bads that are easy to get wrong:
+
+- **Validate it at the configuration it will run in.** A case tuned on a small
+  or fast setting can stop being bad at full size. An "untrained" grid built
+  from one Lloyd iteration was genuinely zero-gain at m=2/K=16 and earned a
+  real +0.10 dB at m=8/K=65536, where one iteration relocates ~63,000 empty
+  cells toward the mode. It passed the fast gate and certified nothing about
+  the real one. This matters more than it sounds, because `mutate.py` needs a
+  fast gate variant and it is tempting to validate everything there.
+- **Measure its *reach*.** One known-bad is the floor, not the goal. Name which
+  checks it exercises (`known_bad(..., covers=(...))`); the harness prints the
+  checks no known-bad reaches. An audited gate had a single known-bad covering
+  1 of 8 checks — and the check its whole result rested on *accepted* the same
+  bad case.
 
 **3. A written statement of what it cannot catch.** Coverage holes are
 invisible from inside a green run: the gate is silent about the thing it does
@@ -61,6 +76,18 @@ silently does nothing gets certified.
 how much it moves, put the threshold outside that. A tolerance picked for
 comfort tends to land wider than the defect you are trying to catch, and then
 it swallows it.
+
+**Then check it is not too tight to mean anything.** The opposite failure is
+real and less obvious: a margin can be statistically impeccable and practically
+empty. A *paired* estimator — scoring both arms on one shared sample so the
+common fluctuation cancels — is the right way to measure a difference, and its
+standard error *shrinks as the two arms converge*. So "beats the baseline by
+3 se" degenerates: a codebook perturbed by N(0, 1e-3) gained +0.0001 dB against
+a 3-se margin of 1.2e-06 and was accepted, while real ones gained 0.35–1.41 dB.
+The check certified *the effect is real*, not *the effect is worth having*.
+Those are different assertions and need different thresholds — and the second
+one has to come from an anchor (there, a published lattice codebook), never
+from the estimator, which knows nothing about what magnitude would matter.
 
 **Build the known-bad and confirm red.** Then run `scripts/mutate.py` for the
 failures you did not think of.
@@ -116,6 +143,8 @@ convincingly they impersonate a working gate.
 | **Comparing against your own previous output** | Regenerated goldens ratify drift. If the golden came from the code under test, it is a changelog, not an oracle. |
 | **A cache keyed on the problem rather than the method** | `cache[(m, K)]` cannot notice that the code producing the value changed. Version-stamp the artifact and delete on mismatch instead of trusting. |
 | **A self-matching predicate** | `until ! pgrep -f trainer` never exits, because the watching shell's own argv contains `trainer`. Worse, a malformed variant exits immediately and reports the job finished while it runs. Wait on a PID. |
+| **A margin that is significant but not meaningful** | A threshold derived purely from estimator noise certifies that an effect is *real*, not that it is *worth having* — and a paired estimator's noise shrinks as the arms converge, so the margin can approach zero. Pair every noise-derived floor with a magnitude an anchor says would matter. |
+| **A strict bracket at an attainable optimum** | A theoretical bound is often reachable, and reaching it is the best possible outcome. A strict edge then goes red on a perfect result and blocks real work. Ask of each edge whether the subject can legitimately sit exactly there. |
 | **A gate written by whatever produced the artifact** | Shared assumptions produce shared blind spots, and the convention both inherited is the one neither questions. Anchors are the defence, because an anchor is the one input the producer did not choose. |
 
 ## Division of labour
@@ -134,6 +163,18 @@ This skill is for results and pipelines where the failure mode is a
 check go red?* They are complements and they miss different things: an
 adversarial reviewer will not recompute your constants, and a gate will not
 notice that your framing is wrong.
+
+**A gate checks correctness, and cannot check comparability.** If two arms of a
+comparison are each individually correct but not *comparably implemented*, no
+anchor and no mutant will see it: nothing is broken, so nothing goes red. A
+published ablation reported one transform 11–24× slower than another and
+carried a caveat saying the number was implementation-bound; both arms passed
+every correctness check, and the real finding — one arm was a tuned BLAS call
+and the other an interpreted loop — was found by a human reviewer months of
+gate-work later. Related: **performance claims have no anchor in this
+framework at all.** There is no published constant for how fast your code
+should be. Wall-clock belongs to benchmarking discipline (matched
+implementation effort, min-of-trials, stated hardware), not to gating.
 
 One caution about pairing them. A same-model reviewer is an independent
 *context*, not an independent *reviewer* — it shares your priors, so the

--- a/gating/references/anchors.md
+++ b/gating/references/anchors.md
@@ -134,6 +134,28 @@ directions. Neither is the answer; together they are a bracket.
 
 ---
 
+## An anchor is also where a *magnitude* comes from
+
+Anchors are usually discussed as sources of correctness — is this value right?
+They are equally the only source of **practical significance**: is a difference
+big enough to care about?
+
+A threshold derived from measurement noise answers "is this effect real". It
+cannot answer "is this effect worth having", and the two diverge badly when the
+things being compared are similar: a paired estimator's standard error shrinks
+as the arms converge, so a 3-sigma margin can approach zero and admit an effect
+three orders of magnitude below anything that matters.
+
+So when a check exists to certify that something *helps*, it needs two floors:
+
+- a **statistical** floor from measured noise — the effect is not sampling luck;
+- a **practical** floor from an anchor — the effect is at least as large as
+  <published method / theoretical gain / the smallest difference that would
+  change a decision>.
+
+State which anchor supplies the second one. If none does, say so as a coverage
+limit: "this check certifies the effect is real, not that it is useful."
+
 ## Anchor hygiene
 
 - **Write the source next to the number.** `0.0716821  # Conway & Sloane,

--- a/gating/references/auditing.md
+++ b/gating/references/auditing.md
@@ -56,6 +56,22 @@ python3 scripts/mutate.py --target src/thing.py -- <your gate command>
 
 Every survivor is a behaviour nothing checks.
 
+**First, disable any on-disk cache the subject keeps.** If the code under test
+caches artifacts keyed on the *problem* (`grid_m8_K65536.npz`) rather than on
+the *method*, a mutation of the producing code changes nothing observable: the
+gate loads the pre-mutation artifact and reports green. Every mutation to the
+trainer then "survives" for a reason that has nothing to do with the gate, and
+the survivor count is noise. Point the cache at a temporary directory for the
+mutation run. This is the same anti-pattern the gate section warns about, and
+it is far more damaging here because it inflates rather than hides.
+
+**Budget for it.** `mutate.py` runs the gate command once per mutation, so a
+90-second gate over 100 sites is two and a half hours. That pressure is what
+produces a fast gate variant — which is fine, as long as you remember that a
+known-bad validated only in the fast variant may not be bad at full size, and
+that the fast variant's reduced dimensions may make whole classes of mutation
+unobservable. Record which ones in the gate's stated coverage limits.
+
 **Reading the report.** Survivors cluster, and the cluster is the diagnosis:
 
 - Survivors on one function → that function is untested. Usually the fix is
@@ -71,7 +87,18 @@ Every survivor is a behaviour nothing checks.
 **Legitimate survivors exist.** Equivalent mutants (a change with no
 observable effect), and code genuinely outside the gate's remit. Do not chase
 them to zero — move them to the gate's stated coverage limits, which converts
-an invisible hole into a written one.
+an invisible hole into a written one. Write down *why* each is equivalent: an
+unexplained survivor and an equivalent mutant look identical in a report, and
+six months later nobody can tell which they are looking at.
+
+**Survivor line numbers are ephemeral — pin permanent fixtures by content.**
+The report says `grids.py:166`, and that reference is correct for exactly as
+long as nobody edits the file above line 166. If you promote survivors into a
+standing fixture (recommended — see the meta-check below), locate each target
+by a unique snippet of the line, not by its number. A fixture pinned by line
+survived until an upstream refactor shifted one file by ~50 lines, then failed
+with "line 206 does not contain '*'" — an error about the fixture, not about
+the subject, which is the most confusing kind to receive.
 
 ---
 

--- a/gating/scripts/gate.py
+++ b/gating/scripts/gate.py
@@ -44,6 +44,7 @@ class _Check:
     label: str
     detail: str
     kind: str  # "anchor" | "bracket" | "check" | "known-bad"
+    covers: tuple[str, ...] = ()  # known-bad only: checks it exercises
 
 
 @dataclass
@@ -58,9 +59,10 @@ class Gate:
 
     # -- primitives --------------------------------------------------------
 
-    def check(self, ok: bool, label: str, detail: str = "", *, kind: str = "check") -> bool:
+    def check(self, ok: bool, label: str, detail: str = "", *,
+              kind: str = "check", covers: tuple[str, ...] = ()) -> bool:
         """Record a plain boolean check."""
-        self.checks.append(_Check(bool(ok), label, detail, kind))
+        self.checks.append(_Check(bool(ok), label, detail, kind, covers))
         return bool(ok)
 
     def anchor(self, label: str, *, measured: float, published: float,
@@ -78,28 +80,55 @@ class Gate:
             f"rel={rel:.2e} tol={rel_tol:.0e}", kind="anchor")
 
     def bracket(self, label: str, *, value: float, lo: float, hi: float,
-                why: str = "") -> bool:
-        """Assert lo < value < hi.
+                why: str = "", lo_inclusive: bool = False,
+                hi_inclusive: bool = False) -> bool:
+        """Assert lo < value < hi, or <= at either edge.
 
         Two-sided by construction.  A one-sided check passes for a value that
         collapsed as readily as for one that is right, which is how an
         implementation that silently does nothing gets certified.
+
+        **Use the inclusive flag when an edge is ATTAINABLE.**  A theoretical
+        bound is frequently reachable, and reaching it is optimal, not a
+        failure.  A strict bound then reports red on the best possible result:
+        a randomized-Hadamard rotation maps a coordinate spike to exactly
+        ±1/sqrt(d), the information-theoretic floor for max|coord|, so
+        `lo=1/sqrt(d)` rejected a perfect rotation and blocked a run.  Ask of
+        each edge: can the subject legitimately sit exactly here?  If yes, make
+        it inclusive.
         """
-        ok = lo < value < hi
+        lo_ok = (lo <= value) if lo_inclusive else (lo < value)
+        hi_ok = (value <= hi) if hi_inclusive else (value < hi)
+        lo_op = "<=" if lo_inclusive else "<"
+        hi_op = "<=" if hi_inclusive else "<"
         suffix = f" — {why}" if why else ""
-        return self.check(ok, label,
-                          f"{lo:.6g} < {value:.6g} < {hi:.6g}{suffix}",
+        return self.check(lo_ok and hi_ok, label,
+                          f"{lo:.6g} {lo_op} {value:.6g} {hi_op} {hi:.6g}{suffix}",
                           kind="bracket")
 
-    def known_bad(self, label: str, *, rejected: bool, detail: str = "") -> bool:
+    def known_bad(self, label: str, *, rejected: bool, detail: str = "",
+                  covers: tuple[str, ...] = ()) -> bool:
         """Register a case the gate MUST reject, and whether it did.
 
         Build the bad case out of the same machinery the real subject uses and
         break it the way it would plausibly break — an under-trained model, a
         dropped term, an off-by-one — not a nonsense input that anything would
         catch.  A known-bad that is too obviously bad certifies nothing.
+
+        **Validate it at the configuration it will actually run in.**  A
+        known-bad tuned on a small/fast setting can stop being bad at full
+        size: an "untrained" grid built from one Lloyd iteration was genuinely
+        zero-gain at m=2/K=16 and earned a real +0.10 dB at m=8/K=65536, where
+        a single iteration relocates ~63,000 empty cells toward the mode.  It
+        passed the fast gate and certified nothing about the real one.
+
+        `covers` names the check labels (or substrings of them) this case
+        exercises.  Supplying it turns "we have a known-bad" into "we know
+        WHICH checks have been shown to fire", which is a different and much
+        stronger claim — see `report()`.
         """
-        return self.check(rejected, label, detail, kind="known-bad")
+        return self.check(rejected, label, detail, kind="known-bad",
+                          covers=tuple(covers))
 
     def note(self, text: str) -> None:
         """Record a number worth seeing that is not itself pass/fail."""
@@ -154,6 +183,29 @@ class Gate:
                   "thing\nthis gate cannot catch (g.coverage(...)); if you truly "
                   "believe there is\nnothing, say that explicitly.", file=w)
             return 2
+        # Known-bad REACH.  "We have a known-bad" and "we know which checks
+        # have been shown to fire" are different claims, and only the second
+        # is worth much.  An audit of a real gate found its single known-bad
+        # exercised 1 of 8 checks -- and the check the whole result rested on
+        # ACCEPTED the same bad case.  That gate reported PASS.
+        substantive = [c for c in self.checks if c.kind != "known-bad"]
+        if any(kb.covers for kb in self.known_bads):
+            claimed = [t for kb in self.known_bads for t in kb.covers]
+            reached = {c.label for c in substantive
+                       if any(t in c.label for t in claimed)}
+            unreached = [c.label for c in substantive if c.label not in reached]
+            print(f"\n  known-bad reach: {len(reached)}/{len(substantive)} "
+                  f"checks exercised by a known-bad", file=w)
+            for lab in unreached[:12]:
+                print(f"    [unreached] {lab}", file=w)
+            if len(unreached) > 12:
+                print(f"    ... and {len(unreached) - 12} more", file=w)
+        else:
+            print(f"\n  known-bad reach: UNDECLARED — {len(self.known_bads)} "
+                  f"known-bad(s), none naming the checks they exercise.\n"
+                  f"  Pass covers=(...) to known_bad() to turn 'we have one' "
+                  f"into 'we know which checks fire'.", file=w)
+
         print(f"\nPASSED — {len(self.checks)} checks, "
               f"{len(self.known_bads)} known-bad rejected, "
               f"{len(self.limits)} coverage limit(s) stated.", file=w)


### PR DESCRIPTION
Applied `gating` to a real calibration gate — [`remex-vs-higgs-ablation`](https://github.com/oaustegard/experiments/pull/11) — taking it from 8 checks to 166, running 91 mutants, and producing four false reds in the rebuilt gate along the way.

**Everything here is something the skill led me into or failed to warn about.** None of it is hypothetical.

## Code

**`bracket()` gains `lo_inclusive` / `hi_inclusive`.** The current `lo < value < hi` is strict on both edges, and a theoretical bound is frequently **attainable** — reaching it is optimal, not a failure. A randomized Hadamard maps a coordinate spike to *exactly* `1/√d`, the information-theoretic floor for `max|coord|`, so a strict `lo` reported red on a perfect rotation and blocked a run. I had to abandon `bracket()` for a hand-rolled `check()` to express it.

**`known_bad(..., covers=(...))` and known-bad *reach* in `report()`.** The harness enforced that *some* known-bad exists. The skill's own audit procedure then found a gate whose single known-bad exercised **1 of 8 checks** — and the check the whole result rested on *accepted* the same bad case. That gate reported PASS, and this harness would have too. Declaring reach turns "we have a known-bad" into "we know which checks fire":

```
  known-bad reach: 1/2 checks exercised by a known-bad
    [unreached] rotation is incoherent
```

Back-compatible — gates passing no `covers` report `UNDECLARED` and still pass.

## Prose

**Validate a known-bad at the configuration it will run in** *(SKILL.md, obligation 2)*. Mine was built from a single Lloyd iteration: genuinely zero-gain at m=2/K=16, and a real **+0.10 dB** at m=8/K=65536, where one iteration relocates ~63,000 empty cells toward the mode. It passed the fast gate and certified nothing about the real one. This matters because the skill *actively pushes toward* a fast variant — `mutate.py` has to run the gate ~100 times.

**A statistical margin is not a practical floor** *(SKILL.md + `anchors.md`)*. The existing advice — "derive the tolerance from measured noise" — is right about slack-wider-than-the-defect and silent on the opposite failure. A **paired** estimator is the correct way to measure a difference, and its standard error *shrinks as the arms converge*, so "beats the baseline by 3 se" degenerates. Measured: a codebook perturbed by `N(0, 1e-3)` gained **+0.0001 dB** against a 3-se margin of **1.2e-06** and was accepted, while real ones gained 0.35–1.41 dB. The check certified *the effect is real*, not *the effect is worth having*. The second floor has to come from an anchor — the estimator knows nothing about what magnitude would matter.

**A gate checks correctness and cannot check comparability** *(division-of-labour section)*. If two arms are each individually correct but not *comparably implemented*, no anchor and no mutant sees it — nothing is broken. My ablation reported one transform 11–24× slower than another, **with a caveat admitting the number was implementation-bound**, and published it as a result anyway. Both arms passed every correctness check. The real finding (one arm a tuned BLAS call, the other an interpreted Python loop) came from a human reviewer. Related: performance claims have no anchor in this framework at all.

Plus two anti-pattern rows: *significant but not meaningful*, and *strict bracket at an attainable optimum*.

**Disable the subject's on-disk cache before mutating** *(`auditing.md`, Pass 3)*. A cache keyed on the problem rather than the method serves pre-mutation artifacts, so every mutation of the producing code "survives" for a reason unrelated to the gate — the survivor count becomes noise. This is the same anti-pattern the gate section already names, but it *inflates* here rather than hiding, which is worse.

**Survivor line numbers are ephemeral** *(`auditing.md`)*. Promoting survivors into a standing fixture is right; pinning them by line number is not. Mine failed with `line 206 does not contain '*'` after an upstream refactor shifted a file by ~50 lines — an error about the fixture rather than the subject, which is the most confusing kind to get.

## Verification

The updated harness runs the real 166-check gate unchanged (exit 0), and the inclusive-edge and reach-reporting paths are exercised directly:

```
--- 1. attainable lower edge ---
  strict edge -> False (was the false red)   inclusive -> True
--- 2. known-bad reach, declared ---
  known-bad reach: 1/2 checks exercised by a known-bad
--- 3. known-bad reach, undeclared (back-compat) ---
  rc = 0 | known-bad reach: UNDECLARED
```

`marketplace.json` left alone — CI regenerates it on release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEiqBzoFAtwjQhXzu71Nn5)_