### PR TITLE
tree-sitting: extract decorated defs, which were silently dropped

### DIFF
--- a/plugins/code-intelligence/skills/tree-sitting/scripts/engine.py
+++ b/plugins/code-intelligence/skills/tree-sitting/scripts/engine.py
@@ -280,10 +280,34 @@ def _python_docstring(node, source: bytes) -> str | None:
 
 # ─── Extractors ───────────────────────────────────────────────────────────
 
+def _unwrap_decorated(node):
+    """Return the def/class inside a ``decorated_definition``, else the node.
+
+    Python's grammar wraps ``@deco\\ndef f(): ...`` in a ``decorated_definition``
+    whose payload is the real ``function_definition`` / ``class_definition``. A
+    walk that matches only the bare types drops every decorated symbol, which in
+    practice is much of a module's public API surface.
+
+    The unwrapped node is deliberately what gets recorded, so ``line`` points at
+    the ``def`` rather than at the first decorator. Callers that seed a language
+    server from these positions (searching-codebases ``--refs``/``--def``) need
+    the line the symbol token is actually on.
+
+    The other extractors survive wrapper nodes already: ``_extract_generic``
+    recurses two levels, and the JS path unwraps ``export_statement`` explicitly.
+    Python's extractor is the only non-recursing one, so it needs this.
+    """
+    if node.type == 'decorated_definition':
+        for c in node.children:
+            if c.type in ('function_definition', 'class_definition'):
+                return c
+    return node
+
+
 def _extract_python(tree, source: bytes, relpath: str) -> list[Symbol]:
     symbols = []
     module = tree.root_node
-    children = list(module.children)
+    children = [_unwrap_decorated(n) for n in module.children]
     for i, node in enumerate(children):
         if node.type == 'function_definition':
             name = next((_get_text(c, source) for c in node.children if c.type == 'identifier'), '')
@@ -303,7 +327,7 @@ def _extract_python(tree, source: bytes, relpath: str) -> list[Symbol]:
                 # Extract methods
                 for child in node.children:
                     if child.type == 'block':
-                        for sc in child.children:
+                        for sc in (_unwrap_decorated(c) for c in child.children):
                             if sc.type == 'function_definition':
                                 mname = next((_get_text(c, source) for c in sc.children if c.type == 'identifier'), '')
                                 if mname:

--- a/plugins/code-intelligence/skills/tree-sitting/tests/test_engine.py
+++ b/plugins/code-intelligence/skills/tree-sitting/tests/test_engine.py
@@ -129,6 +129,80 @@ class UserService:
     assert find_method.doc == 'Find a user.'
 
 
+def test_python_decorated_functions():
+    """Decorated defs must not vanish.
+
+    Python wraps ``@deco``-ed definitions in a ``decorated_definition`` node.
+    A walk matching only ``function_definition`` drops them silently, which is
+    how ``recall``/``remember`` went missing from an indexed module whose whole
+    public API carries a decorator.
+    """
+    syms = parse_and_extract('python', b'''
+import functools
+
+@functools.cache
+def cached(name: str) -> str:
+    """Cached greeting."""
+    return name
+
+@app.route("/x")
+@auth_required
+def multi_decorated(a, b):
+    """Two decorators."""
+    return a
+
+def plain():
+    pass
+
+@decorator
+def _private_decorated():
+    pass
+''')
+    assert 'cached' in names(syms)
+    assert 'multi_decorated' in names(syms)
+    assert 'plain' in names(syms)
+    # The private filter still applies through the wrapper.
+    assert '_private_decorated' not in names(syms)
+
+    cached = find(syms, 'cached')
+    assert cached.kind == 'function'
+    assert cached.signature == '(name: str)'
+    assert cached.doc == 'Cached greeting.'
+    # Position is the `def` line, not the decorator line — callers seed a
+    # language server from it and need the line the token is on.
+    assert cached.line == 5
+
+
+def test_python_decorated_class_and_methods():
+    syms = parse_and_extract('python', b'''
+@dataclass
+class Config:
+    """Settings."""
+
+    @property
+    def name(self) -> str:
+        """The name."""
+        return self._name
+
+    @staticmethod
+    def build(raw: dict) -> "Config":
+        return Config()
+
+    def plain(self):
+        pass
+''')
+    cfg = find(syms, 'Config')
+    assert cfg.kind == 'class'
+    assert cfg.doc == 'Settings.'
+    method_names = [c.name for c in cfg.children]
+    assert 'name' in method_names
+    assert 'build' in method_names
+    assert 'plain' in method_names
+    name_method = next(c for c in cfg.children if c.name == 'name')
+    assert name_method.signature == '(self)'
+    assert name_method.doc == 'The name.'
+
+
 # ── C extractor ──────────────────────────────────────────────────────────
 
 def test_c_functions():

--- a/tree-sitting/scripts/engine.py
+++ b/tree-sitting/scripts/engine.py
@@ -280,10 +280,34 @@ def _python_docstring(node, source: bytes) -> str | None:
 
 # ─── Extractors ───────────────────────────────────────────────────────────
 
+def _unwrap_decorated(node):
+    """Return the def/class inside a ``decorated_definition``, else the node.
+
+    Python's grammar wraps ``@deco\\ndef f(): ...`` in a ``decorated_definition``
+    whose payload is the real ``function_definition`` / ``class_definition``. A
+    walk that matches only the bare types drops every decorated symbol, which in
+    practice is much of a module's public API surface.
+
+    The unwrapped node is deliberately what gets recorded, so ``line`` points at
+    the ``def`` rather than at the first decorator. Callers that seed a language
+    server from these positions (searching-codebases ``--refs``/``--def``) need
+    the line the symbol token is actually on.
+
+    The other extractors survive wrapper nodes already: ``_extract_generic``
+    recurses two levels, and the JS path unwraps ``export_statement`` explicitly.
+    Python's extractor is the only non-recursing one, so it needs this.
+    """
+    if node.type == 'decorated_definition':
+        for c in node.children:
+            if c.type in ('function_definition', 'class_definition'):
+                return c
+    return node
+
+
 def _extract_python(tree, source: bytes, relpath: str) -> list[Symbol]:
     symbols = []
     module = tree.root_node
-    children = list(module.children)
+    children = [_unwrap_decorated(n) for n in module.children]
     for i, node in enumerate(children):
         if node.type == 'function_definition':
             name = next((_get_text(c, source) for c in node.children if c.type == 'identifier'), '')
@@ -303,7 +327,7 @@ def _extract_python(tree, source: bytes, relpath: str) -> list[Symbol]:
                 # Extract methods
                 for child in node.children:
                     if child.type == 'block':
-                        for sc in child.children:
+                        for sc in (_unwrap_decorated(c) for c in child.children):
                             if sc.type == 'function_definition':
                                 mname = next((_get_text(c, source) for c in sc.children if c.type == 'identifier'), '')
                                 if mname:

--- a/tree-sitting/tests/test_engine.py
+++ b/tree-sitting/tests/test_engine.py
@@ -129,6 +129,80 @@ class UserService:
     assert find_method.doc == 'Find a user.'
 
 
+def test_python_decorated_functions():
+    """Decorated defs must not vanish.
+
+    Python wraps ``@deco``-ed definitions in a ``decorated_definition`` node.
+    A walk matching only ``function_definition`` drops them silently, which is
+    how ``recall``/``remember`` went missing from an indexed module whose whole
+    public API carries a decorator.
+    """
+    syms = parse_and_extract('python', b'''
+import functools
+
+@functools.cache
+def cached(name: str) -> str:
+    """Cached greeting."""
+    return name
+
+@app.route("/x")
+@auth_required
+def multi_decorated(a, b):
+    """Two decorators."""
+    return a
+
+def plain():
+    pass
+
+@decorator
+def _private_decorated():
+    pass
+''')
+    assert 'cached' in names(syms)
+    assert 'multi_decorated' in names(syms)
+    assert 'plain' in names(syms)
+    # The private filter still applies through the wrapper.
+    assert '_private_decorated' not in names(syms)
+
+    cached = find(syms, 'cached')
+    assert cached.kind == 'function'
+    assert cached.signature == '(name: str)'
+    assert cached.doc == 'Cached greeting.'
+    # Position is the `def` line, not the decorator line — callers seed a
+    # language server from it and need the line the token is on.
+    assert cached.line == 5
+
+
+def test_python_decorated_class_and_methods():
+    syms = parse_and_extract('python', b'''
+@dataclass
+class Config:
+    """Settings."""
+
+    @property
+    def name(self) -> str:
+        """The name."""
+        return self._name
+
+    @staticmethod
+    def build(raw: dict) -> "Config":
+        return Config()
+
+    def plain(self):
+        pass
+''')
+    cfg = find(syms, 'Config')
+    assert cfg.kind == 'class'
+    assert cfg.doc == 'Settings.'
+    method_names = [c.name for c in cfg.children]
+    assert 'name' in method_names
+    assert 'build' in method_names
+    assert 'plain' in method_names
+    name_method = next(c for c in cfg.children if c.name == 'name')
+    assert name_method.signature == '(self)'
+    assert name_method.doc == 'The name.'
+
+
 # ── C extractor ──────────────────────────────────────────────────────────
 
 def test_c_functions():


### PR DESCRIPTION
## The bug

`_extract_python` walks `module.children` matching only `function_definition` /
`class_definition`. Python's grammar wraps `@deco\ndef f(): ...` in a
`decorated_definition` node whose payload is the real definition — so **every
decorated symbol is absent from the symbol table**. The class-body loop has the
same shape, which hides `@property`, `@staticmethod`, `@classmethod`,
`@pytest.fixture`.

`decorated` appears nowhere in `engine.py` today.

## Why it took a while to see

The failure surfaces downstream and silently. `searching-codebases`
`--refs`/`--def`/`--hover` seeds pyright from `definition_sites()`, backed by
`CodeCache.find_symbol()`. No definition found → `LspUnavailable` → regex
fallback, one line on **stderr** while **stdout** shows a full set of
contaminated text matches. Measured on `muninn-utilities`:

| | before | after |
|---|---|---|
| symbols in `remembering/scripts/memory.py` | 12 | 25 |
| `definition_sites('recall')` | `[]` | `memory.py:480` |
| `--refs recall` | 500 regex matches | 82 binding-resolved refs |

This is a *second, distinct* cause of the same symptom fixed in
searching-codebases 2.1.1 (missing `tree_sitter` at boot). Installing
`tree_sitter` does not fix this one — worth knowing, because the stderr line is
identical in shape and invites the wrong diagnosis.

## Blast radius

Low rate, bad distribution: 30 of 976 defs in `muninn-utilities` (3%) — but 13
of the 25 public functions in its main API module carry `@accept_aliases`, so
`recall`, `remember`, `supersede`, `consolidate` were all unresolvable. Decorated
means public API more often than not: Flask/FastAPI routes, click commands,
`@dataclass`, pytest fixtures.

## The fix

`_unwrap_decorated()` applied at both walk sites. It returns the **unwrapped**
node, so `line` points at `def` rather than the first decorator — callers seeding
an LSP position need the line the token is on.

Python's is the only non-recursing extractor: `_extract_generic` recurses two
levels and the JS path unwraps `export_statement` explicitly, which is why this
is Python-only and why the export-unwrap is the precedent followed here.

## Tests

Two regression tests in `tests/test_engine.py` covering single and stacked
decorators, decorated classes, decorated methods, the `_private` filter through
the wrapper, and the `def`-line position assertion.

- On `main`: **2 failed, 28 passed** (both new tests red)
- With the fix: **30 passed**
- Full suite: 88 passed. The 10 `test_cli_cache` failures are pre-existing on
  `main` and unrelated — verified by running them against unpatched `engine.py`.

Both the top-level skill and the materialized `plugins/` copy are updated, per
the pattern in #747.
