### PR TITLE
orchestrating-agents 0.6.0: native messaging exists, stop routing around it

### DIFF
--- a/orchestrating-agents/CHANGELOG.md
+++ b/orchestrating-agents/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `orchestrating-agents` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0] - 2026-08-12
+
+### Fixed
+
+- **Surface routing no longer claims the native runtime lacks inter-agent
+  messaging.** The "reach back into this skill for what the runtime lacks" line
+  listed `AgentPool` messaging alongside stall detection and
+  `ConversationThread`. Claude Code and Cowork ship `SendMessage` and
+  `ListAgents`; `AgentPool` reimplements them worse. The skill previously
+  mentioned neither tool anywhere, so a reader following it would hand-roll a
+  fan-out for messaging the runtime already provides.
+
+### Added
+
+- Native inter-agent messaging subsection under the native-subagents branch,
+  covering four behaviors measured 2026-08-12 that the official docs do not
+  state: the incoming envelope's `from` attribute is the agent *type* and fails
+  as a reply address; subagents have no `ListAgents` at all, making the topology
+  a star through the main conversation rather than a mesh; delivery queues and
+  never interrupts a running tool; and a send resumes a completed agent with
+  full context that the agent cannot detect, at transcript-replay cost.
+- Note that `anthropics/claude-code#48160` and `ruvnet/ruflo#2028` report
+  subagents cannot originate `SendMessage`, contradicted by a CCotw measurement
+  on 2026-08-12 — flagged as environment-dependent and to be verified locally
+  rather than designed around.
+
 ## [0.5.0] - 2026-07-30
 
 ### Other

--- a/orchestrating-agents/SKILL.md
+++ b/orchestrating-agents/SKILL.md
@@ -2,7 +2,7 @@
 name: orchestrating-agents
 description: Orchestrates parallel API instances, delegated sub-tasks, and multi-agent workflows with streaming and tool-enabled delegation patterns. Routes by surface — native subagents in Cowork and Claude Code, httpx fan-out on claude.ai — and covers Gemini delegation via the Cloudflare AI Gateway on every surface. Use for parallel analysis, multi-perspective reviews, or complex task decomposition.
 metadata:
-  version: 0.5.0
+  version: 0.6.0
 ---
 
 ## SURFACE ROUTING — read first
@@ -37,8 +37,48 @@ refused in plugin agents for security, so a declared agent inherits the session'
 MCP connections and cannot bring its own.
 
 Reach back into this skill on those surfaces only for what the runtime lacks:
-inter-agent messaging (`AgentPool`), stall detection, or a long-lived
-`ConversationThread`.
+stall detection, or a long-lived `ConversationThread`. **Inter-agent messaging is
+NOT on that list** — the runtime ships `SendMessage` and `ListAgents`, and
+`AgentPool` reimplements them worse. Corrected 2026-08-12; this block previously
+sent readers to `AgentPool` for messaging the runtime already provides.
+
+#### Native inter-agent messaging — `SendMessage` / `ListAgents`
+
+`ListAgents` discovers reachable agents; `SendMessage` delivers plain text to one
+by name or id. Both reach subagents, agent-team teammates, and independent
+sessions. Official docs: `code.claude.com/docs/en/cross-session-messaging`
+(shipped v2.1.224, macOS and Linux).
+
+Four measured behaviors the docs do not state. Each cost a round trip to find;
+full method and verbatim receipts in `oaustegard/experiments` →
+`subagent-messaging/RESULTS.md`.
+
+- **NEVER reply using the incoming envelope's `from` attribute.** For subagents
+  that value is the agent *type* (`general-purpose`), not an address, and the
+  send fails with `No agent named 'general-purpose' is reachable`. Two
+  same-type peers emit identical `from` values, so it cannot distinguish
+  senders even in principle. Both the `SendMessage` description and the harness
+  footer on every delivered message instruct otherwise. **Capture the agentId
+  from the spawn result and address that.**
+- **Subagents have no `ListAgents`.** `ToolSearch("select:ListAgents")` returns
+  `No matching deferred tools found` — absent, not unloaded. A subagent reaches
+  `"main"` and any address handed to it in its prompt, and nothing else. **The
+  topology is a star through the main conversation, not a mesh: hand every peer
+  its siblings' ids at spawn, or they cannot coordinate.**
+- **Delivery queues and never interrupts.** The receiver reads between tool
+  calls, so a peer inside a long `Bash` call is unreachable until it surfaces.
+- **A send to a completed agent resumes it with full context, and the agent
+  cannot tell.** Asked directly, a resumed agent reports no gap or restart
+  marker. Instructions shaped as "if you were resumed, do X" never fire —
+  **state the resume in the message.** Each resume replays the transcript:
+  ~40k tokens for a small agent, and a measured eight-round chain ran
+  199k → 324k. **Batch questions into one send.**
+
+Contested: `anthropics/claude-code#48160` and `ruvnet/ruflo#2028` report that
+subagents can receive but not originate `SendMessage`. A CCotw subagent
+originated three sends successfully on 2026-08-12 with no
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` set. **Verify origination in your own
+environment before designing around either claim.**
 
 ### If native subagents do NOT exist (claude.ai chat and project sessions)
 

--- a/plugins/ai-and-reasoning/skills/orchestrating-agents/CHANGELOG.md
+++ b/plugins/ai-and-reasoning/skills/orchestrating-agents/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `orchestrating-agents` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0] - 2026-08-12
+
+### Fixed
+
+- **Surface routing no longer claims the native runtime lacks inter-agent
+  messaging.** The "reach back into this skill for what the runtime lacks" line
+  listed `AgentPool` messaging alongside stall detection and
+  `ConversationThread`. Claude Code and Cowork ship `SendMessage` and
+  `ListAgents`; `AgentPool` reimplements them worse. The skill previously
+  mentioned neither tool anywhere, so a reader following it would hand-roll a
+  fan-out for messaging the runtime already provides.
+
+### Added
+
+- Native inter-agent messaging subsection under the native-subagents branch,
+  covering four behaviors measured 2026-08-12 that the official docs do not
+  state: the incoming envelope's `from` attribute is the agent *type* and fails
+  as a reply address; subagents have no `ListAgents` at all, making the topology
+  a star through the main conversation rather than a mesh; delivery queues and
+  never interrupts a running tool; and a send resumes a completed agent with
+  full context that the agent cannot detect, at transcript-replay cost.
+- Note that `anthropics/claude-code#48160` and `ruvnet/ruflo#2028` report
+  subagents cannot originate `SendMessage`, contradicted by a CCotw measurement
+  on 2026-08-12 — flagged as environment-dependent and to be verified locally
+  rather than designed around.
+
 ## [0.5.0] - 2026-07-30
 
 ### Other

--- a/plugins/ai-and-reasoning/skills/orchestrating-agents/SKILL.md
+++ b/plugins/ai-and-reasoning/skills/orchestrating-agents/SKILL.md
@@ -2,7 +2,7 @@
 name: orchestrating-agents
 description: Orchestrates parallel API instances, delegated sub-tasks, and multi-agent workflows with streaming and tool-enabled delegation patterns. Routes by surface — native subagents in Cowork and Claude Code, httpx fan-out on claude.ai — and covers Gemini delegation via the Cloudflare AI Gateway on every surface. Use for parallel analysis, multi-perspective reviews, or complex task decomposition.
 metadata:
-  version: 0.5.0
+  version: 0.6.0
 ---
 
 ## SURFACE ROUTING — read first
@@ -37,8 +37,48 @@ refused in plugin agents for security, so a declared agent inherits the session'
 MCP connections and cannot bring its own.
 
 Reach back into this skill on those surfaces only for what the runtime lacks:
-inter-agent messaging (`AgentPool`), stall detection, or a long-lived
-`ConversationThread`.
+stall detection, or a long-lived `ConversationThread`. **Inter-agent messaging is
+NOT on that list** — the runtime ships `SendMessage` and `ListAgents`, and
+`AgentPool` reimplements them worse. Corrected 2026-08-12; this block previously
+sent readers to `AgentPool` for messaging the runtime already provides.
+
+#### Native inter-agent messaging — `SendMessage` / `ListAgents`
+
+`ListAgents` discovers reachable agents; `SendMessage` delivers plain text to one
+by name or id. Both reach subagents, agent-team teammates, and independent
+sessions. Official docs: `code.claude.com/docs/en/cross-session-messaging`
+(shipped v2.1.224, macOS and Linux).
+
+Four measured behaviors the docs do not state. Each cost a round trip to find;
+full method and verbatim receipts in `oaustegard/experiments` →
+`subagent-messaging/RESULTS.md`.
+
+- **NEVER reply using the incoming envelope's `from` attribute.** For subagents
+  that value is the agent *type* (`general-purpose`), not an address, and the
+  send fails with `No agent named 'general-purpose' is reachable`. Two
+  same-type peers emit identical `from` values, so it cannot distinguish
+  senders even in principle. Both the `SendMessage` description and the harness
+  footer on every delivered message instruct otherwise. **Capture the agentId
+  from the spawn result and address that.**
+- **Subagents have no `ListAgents`.** `ToolSearch("select:ListAgents")` returns
+  `No matching deferred tools found` — absent, not unloaded. A subagent reaches
+  `"main"` and any address handed to it in its prompt, and nothing else. **The
+  topology is a star through the main conversation, not a mesh: hand every peer
+  its siblings' ids at spawn, or they cannot coordinate.**
+- **Delivery queues and never interrupts.** The receiver reads between tool
+  calls, so a peer inside a long `Bash` call is unreachable until it surfaces.
+- **A send to a completed agent resumes it with full context, and the agent
+  cannot tell.** Asked directly, a resumed agent reports no gap or restart
+  marker. Instructions shaped as "if you were resumed, do X" never fire —
+  **state the resume in the message.** Each resume replays the transcript:
+  ~40k tokens for a small agent, and a measured eight-round chain ran
+  199k → 324k. **Batch questions into one send.**
+
+Contested: `anthropics/claude-code#48160` and `ruvnet/ruflo#2028` report that
+subagents can receive but not originate `SendMessage`. A CCotw subagent
+originated three sends successfully on 2026-08-12 with no
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` set. **Verify origination in your own
+environment before designing around either claim.**
 
 ### If native subagents do NOT exist (claude.ai chat and project sessions)
 


### PR DESCRIPTION
Fixes a factual defect in the surface-routing block and documents what replaces it.

## The defect

`SKILL.md:39-41` told readers that on Claude Code and Cowork:

> Reach back into this skill on those surfaces only for what the runtime lacks: inter-agent messaging (`AgentPool`), stall detection, or a long-lived `ConversationThread`.

The native runtime does not lack inter-agent messaging. It ships `SendMessage` and `ListAgents`, documented at [code.claude.com/docs/en/cross-session-messaging](https://code.claude.com/docs/en/cross-session-messaging) and available since v2.1.224 (2026-08-07). `grep -rn "SendMessage\|ListAgents"` across the skill returned nothing before this change — neither tool was mentioned anywhere.

The cost of the error is concrete: the block's whole job is to stop readers hand-rolling what the runtime provides ("**Use them. Do not hand-roll from this skill.**"), and on this one capability it did the opposite.

## What the fix adds

A native-messaging subsection under the native-subagents branch, carrying four behaviors measured 2026-08-12 that the official docs do not state. Method and verbatim receipts in `oaustegard/experiments#31` → `subagent-messaging/RESULTS.md`.

- **The documented reply rule fails.** The incoming envelope's `from` attribute is the agent *type* (`general-purpose`), not an address; the send returns `No agent named 'general-purpose' is reachable`. Two same-type peers emit identical `from` values, so it cannot distinguish senders even in principle. Both the `SendMessage` tool description and the harness footer appended to every delivered message instruct exactly this. Address the agentId from the spawn result instead.
- **Subagents have no `ListAgents`.** `ToolSearch("select:ListAgents")` returns `No matching deferred tools found` — absent, not merely unloaded. This is the one with real design consequences: peers cannot be discovered from below, so the topology is a star through the main conversation, not a mesh. Anyone building peer-to-peer coordination must hand every agent its siblings' ids at spawn.
- **Delivery queues and never interrupts**, so a peer inside a long `Bash` call is unreachable until it surfaces.
- **Resume-on-send preserves full context and the agent cannot detect it**, which breaks any instruction shaped as "if you were resumed, do X". Cost is transcript replay — ~40k tokens for a small agent, and a published eight-round chain measured 199k → 324k.

It also flags a contested point rather than asserting it: [anthropics/claude-code#48160](https://github.com/anthropics/claude-code/issues/48160) (closed as duplicate) and [ruvnet/ruflo#2028](https://github.com/ruvnet/ruflo/issues/2028) (open) both report subagents can receive but not originate `SendMessage`. A CCotw subagent originated three sends successfully with no `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` set. Since that may be environment-specific, the skill tells the reader to verify origination locally rather than design around either claim.

## Scope

Confined to `SKILL.md`. `references/*.md` carry no surface claims — they document the httpx path only — so nothing there needed changing. The claude.ai branch still correctly lists inter-agent messaging as a reason to use this skill's fan-out, since that surface has no native subagents.

Mirrored to `plugins/ai-and-reasoning/skills/orchestrating-agents/`, which was byte-identical to the canonical copy and remains so.

## Verification

- `metadata.version` 0.5.0 → 0.6.0 in both copies. Minor, per the bump-size rule: removed capability claim / behavior change in routing.
- `.github/scripts/detect-version-changes.py HEAD~1 HEAD` returns both paths, so the release actually cuts rather than printing "No skills to release".
- `muninn_utils.skill_lint.validate_skill_file` passes on both copies.
- `CHANGELOG.md` updated in both, Keep-a-Changelog format, `Fixed` and `Added` sections.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Fhfe8pje23uMpjp1P6pKK)_