### PR TITLE
declauding v0.1.0 — LLM prose tics in, human technical prose out

### DIFF
--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: declauding
+description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
+metadata:
+  version: 0.1.0
+---
+
+# Declauding
+
+Turn LLM-shaped prose into prose a human technical writer would have written.
+
+Two output modes:
+- **clean** (default) — the rewritten text, nothing else.
+- **annotated** — a single-file HTML artifact: rewritten text, every changed
+  passage marked, each with the original, the tic name, and why it goes. A
+  toggle hides the marks so the result can be read straight through.
+
+## The one pattern
+
+Almost every tic in `references/register.md` is a version of the same move:
+**the sentence is built to make the reader feel a finding arrive, instead of
+stating the finding.** Staging, not stating.
+
+The generative test, applied per sentence: *am I saying the thing, or
+performing having had the thought?* Say the thing.
+
+## Workflow
+
+**1. Read the whole piece before editing anything.** Tics carry factual errors.
+A sentence written to sound important is disproportionately likely to be wrong,
+because it was built for shape rather than for accuracy — designations like "the
+X that answers the real question" frequently designate the wrong X, and the
+draft itself often contradicts them a paragraph later. Note contradictions now;
+they are the most valuable thing this pass produces.
+
+**2. Run the mechanical scan.**
+
+```
+python3 scripts/declaude_lint.py DRAFT.md
+```
+
+It flags greppable tells with line numbers and categories. It has no judgment —
+it finds candidates, it does not decide. Everything it flags still needs the
+sentence-level test, and it misses every tic that is structural rather than
+lexical. Treat a clean lint report as meaningless on its own.
+
+**3. Sentence pass.** For every sentence, in order: stating or staging? Load
+`references/register.md` for the catalogue of tells and their fixes.
+
+**4. Structure pass.** Headers (are they labels or verdicts?), paragraph breaks
+(is an isolated line a real pivot or a drum roll?), fragment runs, rhetorical
+questions, and the closer (does the last paragraph paraphrase the subtext of
+what preceded it? delete it).
+
+**5. Check what the edit did.** Three failure modes, all of them common:
+- Content lost. Every fact, number, caveat and hedge-with-content in the source
+  must survive. A tic wrapping a real qualification is still a real
+  qualification.
+- Claims changed. Rewriting "the drop is largest where chains are longest" into
+  "long chains cause the drop" is an edit that invents a finding. Register only.
+- Mush. See Overcorrection below.
+
+**6. Report factual problems separately.** Never silently fix a contradiction
+found while editing. The author needs to know their draft disagreed with itself,
+and which version is true is their call, not the editor's.
+
+## Overcorrection
+
+The failure mode of this skill is prose stripped of confidence, rhythm and
+personality until every sentence is the same length and the writer has no
+opinions. That is worse than the tics.
+
+- Flat is not hedged. "Class imbalance breaks the metric before overfitting
+  does" is flat *and* certain. Target plain-and-sure, never plain-and-timid.
+- Do not delete first-person judgment. "I did not expect the overlap to survive
+  a 3x range in bits per weight" is exactly right — specific, falsifiable,
+  personal. Human technical writers state preferences and surprise directly.
+- Do not enforce uniform sentence length. Short for facts, compound for
+  dependencies and caveats. Variation carries information; monotony is its own
+  tell.
+- Do not delete metaphor. Delete metaphor that is *doing significance work*
+  where a plain noun fits. A metaphor that is the clearest available description
+  stays.
+- Digression, asides and mild informality are human. Symmetry, antithesis and
+  balanced parallel clauses are not.
+
+## Earned exceptions
+
+Several banned shapes are legitimate in one specific circumstance. Check before
+deleting:
+
+| Shape | Banned when | Earned when |
+|---|---|---|
+| "X rather than Y" | You invented Y so you could reject it | The reader was genuinely holding Y — the draft proposed it, or it is the field's default |
+| "Nobody noticed" | Unfalsifiable claim about others' inattention | You can name the mechanism and duration: "nobody noticed for six weeks because the dashboard only alarms on nulls" |
+| Isolated one-line paragraph | Gravitas beat | Real pivot: new actor, category shift, time jump |
+| Colon before the payload | Withholding for a beat | The payload is a list, a definition, or a code block |
+| Short declarative closer | Compresses the section into a moral | States a fact: "Default retries are back to 3." |
+
+## Annotated mode
+
+Read `references/annotating.md`. It specifies the artifact: markup for changed
+spans and edit notes, the toggle, the tic-tally table, and how to handle
+passages deliberately left alone.
+
+Rules that make the annotation useful rather than decorative:
+- Quote the original verbatim in every note. An edit the reader cannot check is
+  an assertion.
+- Name the tic using the register's vocabulary so the reader accumulates a
+  vocabulary rather than 40 unrelated opinions.
+- Say why *this instance* is a tic, not what the category means in general.
+- Mark what was kept and why. A pass that only flags failures teaches avoidance.
+- Bundle stacked tics into one note per passage. Do not split a sentence into
+  four notes to inflate the count.
+
+## Calibration
+
+When a draft's register is genuinely unclear, read real prose in the target
+genre before editing — the author's own earlier writing, or a well-known human
+writer in that domain. Human technical prose runs on, digresses, states
+preferences without justifying them, and repeats a word rather than reaching for
+elegant variation. Its sentences vary because the thoughts vary.
+
+## Scope
+
+Applies to: blog posts, READMEs, PR and commit descriptions, reports,
+documentation, essays, release notes, technical explainers.
+
+Do not apply to: fiction and poetry (different register entirely), direct
+quotations, other people's text being quoted, marketing copy where the client
+wants the staging, or anything where the "tic" is the author's established
+voice. Ask before running this on someone else's writing rather than a draft.
+
+## Extending
+
+The register is a working document, not a standard. Adding to it:
+
+1. Add the specimen to `tests/sample-tics.md`, verbatim from real prose.
+2. Add a register entry: tell, why, fix, and the real before/after. Entries
+   without a before/after get argued about instead of applied.
+3. If the tell is lexical, add a rule to `scripts/declaude_lint.py` and confirm
+   `tests/sample-clean.md` still reports zero. That file is human-written prose;
+   a rule that fires on it is a bad rule, and the false-positive budget is the
+   thing that keeps the linter worth running.
+4. Bump `metadata.version`.
+
+Promote a phrase to its own register entry only after it appears twice in real
+drafts. Reuse is the strongest evidence that a construction is a habit rather
+than a choice, and a register that grows on single sightings becomes a phrase
+blocklist that misses the next paraphrase.

--- a/declauding/assets/annotated.template.html
+++ b/declauding/assets/annotated.template.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}}</title>
+<style>
+:root{
+  --ivory:#FAF9F5; --paper:#fff; --ink:#141413; --accent:#B85C3E; --accent-bg:#FDF1EC;
+  --ok:#4A6B3A; --flag:#8A6D1F; --g100:#F4F2ED; --g200:#E6E3DB; --g500:#6E6A61; --g700:#3A3733;
+  --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--ivory);color:var(--ink);font:16px/1.65 var(--sans)}
+.wrap{max-width:46rem;margin:0 auto;padding:0 1.25rem 5rem}
+header.mast{padding:2.5rem 0 1.25rem;border-bottom:2px solid var(--ink);margin-bottom:0}
+.eyebrow{font:600 11px/1 var(--mono);letter-spacing:.12em;text-transform:uppercase;color:var(--accent);margin:0 0 .75rem}
+h1{font:500 2rem/1.2 var(--serif);margin:0 0 .6rem}
+.sub{margin:0;color:var(--g500);font-size:.95rem}
+.toolbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;
+  padding:.7rem 0;background:var(--ivory);border-bottom:1px solid var(--g200);margin-bottom:1.5rem}
+.btn{font:600 12px/1 var(--mono);letter-spacing:.04em;text-transform:uppercase;background:var(--ink);
+  color:var(--ivory);border:0;border-radius:6px;padding:.6rem .9rem;cursor:pointer}
+.btn:hover{background:var(--accent)}
+.toolnote{font:12px/1.4 var(--mono);color:var(--g500)}
+h2{font:500 1.35rem/1.3 var(--serif);margin:2.4rem 0 .3rem}
+h2+hr{border:0;border-top:2px solid var(--accent);width:2.5rem;margin:0 0 1rem}
+h3{font:600 1rem/1.3 var(--sans);margin:1.8rem 0 .5rem}
+p{margin:0 0 1rem}
+q{quotes:'"' '"'}
+code{font:.9em var(--mono);background:var(--g100);padding:.1em .3em;border-radius:3px}
+pre{background:var(--ink);color:#EDE9E2;padding:1rem;border-radius:6px;overflow-x:auto;font:13px/1.6 var(--mono)}
+pre code{background:none;padding:0;color:inherit}
+table{width:100%;border-collapse:collapse;margin:0 0 1.5rem;font-size:.9rem}
+th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid var(--g200);vertical-align:top}
+th{font:600 11px/1.3 var(--mono);letter-spacing:.06em;text-transform:uppercase;color:var(--g500);
+  border-bottom:2px solid var(--ink)}
+table.tally td:nth-child(1){font-weight:600;white-space:nowrap}
+table.tally td:nth-child(2){font-family:var(--mono);text-align:right}
+table.data{font-family:var(--mono);font-size:.8rem}
+table.data td:not(:first-child){text-align:right}
+.chg{background:var(--accent-bg);box-shadow:inset 0 -1px 0 var(--accent)}
+.ed{display:block;border-left:3px solid var(--accent);background:var(--paper);padding:.65rem .85rem;
+  margin:.35rem 0 1.4rem;font:13px/1.6 var(--mono);color:var(--g700);border-radius:0 6px 6px 0}
+.ed b{display:inline-block;color:var(--accent);text-transform:uppercase;letter-spacing:.05em;
+  font-size:11px;margin-right:.5rem}
+.ed q{color:var(--g500);font-style:italic}
+.ed.ok{border-left-color:var(--ok)} .ed.ok b{color:var(--ok)}
+.ed.flag{border-left-color:var(--flag)} .ed.flag b{color:var(--flag)}
+.unedited{font:12px/1.5 var(--mono);color:var(--g500);background:var(--g100);padding:.45rem .7rem;border-radius:6px}
+body.clean .ed,body.clean .unedited{display:none}
+body.clean .chg{background:none;box-shadow:none}
+.sep{border:0;border-top:2px solid var(--ink);margin:2.5rem 0}
+footer{margin-top:3rem;padding-top:1rem;border-top:1px solid var(--g200);
+  font:12px/1.6 var(--mono);color:var(--g500)}
+@media print{.toolbar{position:static}}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header class="mast">
+  <p class="eyebrow">de-claude edit</p>
+  <h1>{{TITLE}}</h1>
+  <p class="sub">{{SUBTITLE}}</p>
+</header>
+
+<div class="toolbar">
+  <button id="toggle" class="btn">Hide edit marks</button>
+  <span class="toolnote">toggle to read the clean version</span>
+</div>
+
+<section>
+<h2>How to read this</h2><hr>
+<p>The body below is the piece rewritten. Every rewritten passage is <span class="chg">marked like this</span>, with a note underneath giving the original text, the name of the tic, and why it goes. Turn the marks off to read the result straight through.</p>
+<p>Numbers, tables, quotations and commands are unchanged. The edits are register only; anything factual is flagged rather than fixed.</p>
+
+<table class="tally">
+<thead><tr><th>Tic</th><th>n</th><th>Shape</th></tr></thead>
+<tbody>
+{{TALLY_ROWS}}
+</tbody>
+</table>
+<p>One pattern generates most of them: the sentence is built to make the reader feel a finding arrive, rather than to state the finding. Every fix is the same move — put a real subject in the subject slot, say the thing, stop.</p>
+</section>
+
+<hr class="sep">
+
+<article>
+{{BODY}}
+</article>
+
+<footer>Produced with the <b>declauding</b> skill. The register and the linter are in the skill directory; both are meant to be argued with.</footer>
+</div>
+<script>
+(function(){
+  var b=document.getElementById('toggle');
+  b.addEventListener('click',function(){
+    var clean=document.body.classList.toggle('clean');
+    b.textContent=clean?'Show edit marks':'Hide edit marks';
+  });
+})();
+</script>
+</body>
+</html>

--- a/declauding/references/annotating.md
+++ b/declauding/references/annotating.md
@@ -1,0 +1,93 @@
+# Annotated mode
+
+One self-contained HTML file: the rewritten text, every changed passage marked,
+each with the original verbatim, the tic name, and why. A button toggles the
+marks off so the result reads as prose.
+
+Build it from `assets/annotated.template.html` — substitute `{{TITLE}}`,
+`{{SUBTITLE}}`, `{{TALLY_ROWS}}` and `{{BODY}}`. No build step, no CDN, no
+dependencies. It opens from a file:// URL and survives being emailed.
+
+## Markup
+
+Changed passage, inline:
+
+```html
+<span class="chg">the rewritten text</span>
+```
+
+Its note, immediately after the containing paragraph or list item:
+
+```html
+<aside class="ed"><b>tic name</b> was: <q>the original, verbatim</q> —
+why this instance is a tic.</aside>
+```
+
+Kept passage worth marking:
+
+```html
+<aside class="ed ok"><b>kept</b> Why this one works.</aside>
+```
+
+Section left alone entirely:
+
+```html
+<p class="unedited">Credit section: unchanged.</p>
+```
+
+`body.clean` hides `.ed`, `.unedited` and the `.chg` highlight. The toggle sets
+it. Nothing else depends on it.
+
+## The tally
+
+Head the document with a table of tic categories, counts, and a one-line
+description of each shape. `{{TALLY_ROWS}}` takes `<tr><td>name</td><td>n</td>
+<td>shape</td></tr>`. Order by count descending.
+
+Count honestly. If 34 passages carry 45 instances because several stack, say
+both numbers. Inflated counts are the tic this skill exists to remove, applied
+to its own output.
+
+## Writing the notes
+
+**Quote the original verbatim.** An edit the reader cannot check is an
+assertion. Where a passage carried several tics, quote all of the original and
+write one note that names each.
+
+**Name the tic from the register's vocabulary.** The reader should finish with
+a vocabulary, not forty unrelated opinions.
+
+**Say why this instance is a tic**, not what the category means. "The reader
+never proposed the wrong answer" is a general truth; "the previous paragraph
+proposed quantization, so this contrast is earned" is a note about the text in
+front of you.
+
+**Note the earned exceptions where they survive.** When a negation or a short
+closer stays in, mark it and say what made it legitimate. The contrast between
+a kept instance and a cut instance of the same shape teaches the rule better
+than either alone.
+
+**Bundle stacked tics.** One note per passage. Splitting a sentence into four
+notes inflates the count and fragments the reading.
+
+**Report contradictions in their own note, marked.** Use `<aside class="ed
+flag"><b>factual</b> …</aside>`. Do not fix them in the rewrite. The author
+decides which version is true.
+
+## Structure of the page
+
+1. Toolbar with the toggle and the passage count.
+2. How to read this — two short paragraphs.
+3. The tally table.
+4. A one-line statement of the root pattern.
+5. The rewritten piece with its notes.
+
+Keep 1–4 under a screen. The document is the artifact; the preamble is
+navigation.
+
+## Fidelity
+
+Reproduce tables, code blocks, numbers and commands unchanged, or replace them
+with a `<p class="unedited">` line saying so. Never retype data. A transcription
+error in an editing artifact destroys its credibility, and the numbers are the
+one thing a register pass has no business touching.

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -1,0 +1,349 @@
+# The register
+
+Every entry: the **tell** (surface pattern to scan for), why it is a tic, the
+**fix**, and a real before/after. Entries are grouped by mechanism because the
+lexical bans always leak — new phrasings arrive faster than a phrase list grows.
+Scan at the sentence level, not the phrase level.
+
+---
+
+## 1. Staged reveal (the root)
+
+A sentence is **staged** when it withholds, contrasts, or significance-tags to
+manufacture a beat. It is **stated** when it lands content in subject-verb-object.
+Most entries below are special cases of this one.
+
+Generative test, per sentence: *stating or staging?*
+
+---
+
+## 2. Negation-first reveal
+
+**Tell:** says what something is NOT before saying what it is — "It's not that X,
+it's that Y", "The problem wasn't A. It was B.", "not because P — because Q",
+"X, not Y" as a closer, "doesn't just X, it Y's".
+
+**Why:** the reader never proposed the wrong answer. You supplied it so you could
+knock it down, which converts a plain fact into a small drama in which you are
+right.
+
+**Fix:** state what it is. If the contrast is genuinely informative, keep it in
+one clause.
+
+> was: *It is not a wrong answer. It is a non-answer. Counting it as a failure is
+> the conservative choice, and it is what these numbers do.*
+> now: *It is a non-answer rather than a wrong answer, and these numbers count it
+> as a failure, which is the conservative choice.*
+
+**Earned when** the reader was actually holding the wrong answer — the previous
+paragraph proposed it, or it is the obvious default in the field. Then the
+negation does work.
+
+---
+
+## 3. Significance designation
+
+**Tell:** "the real X", "the actual question", "the part that matters", "the part
+that transfers", "the useful question", "the detail that makes the point", "the
+most interesting number", "the one thing nobody said", "here's the thing", "and
+that's the interesting part", "and it has a name here".
+
+**Why:** it ranks your own sentences for the reader instead of writing a sentence
+worth ranking first. The reader decides what is interesting.
+
+**Fix:** delete the designation and state the content. If the content cannot
+carry itself, the problem is the content.
+
+> was: *Nobody had checked whether it could still think. It is the leg that
+> answers the actual question.*
+> now: *Earlier testing measured its size and not its accuracy, so this run is
+> the first accuracy number for it.*
+
+**Watch for reuse.** Emphasis is a budget. The same designation twice in one
+piece ("the part that matters" / "the part that transfers") is no longer
+emphasis, and reuse is the easiest instance to catch.
+
+---
+
+## 4. Abstraction agency
+
+**Tell:** a non-agent in the subject slot doing something — "the table shows it",
+"the median hides it", "the data tells us", "the failure modes live in different
+places", "the metric lies", "quantization is a concern", "truncation cuts
+compute", "the tool is about to discover", "the joke does the work an argument
+would have to".
+
+**Why:** nothing in the sentence has hands. Nominalized verbs and inanimate
+objects get the subject slot, and the actual actor disappears.
+
+**Fix:** put a real agent in subject position — a person, a named artifact, a
+concrete thing — and let the verb be a verb.
+
+> was: *Median hides it: the middle of every distribution is similar.*
+> now: *The middle of every distribution is similar.*
+
+> was: *Truncation cuts compute natively.*
+> now: *A shorter vector is a shorter dot product.*
+
+---
+
+## 5. Deferred noun
+
+**Tell:** a placeholder where the noun belongs — "One thing is not flat", "The
+sixth is not", "There was just one problem", "That is the variable...", "What X
+means" — when the actual noun and number were available.
+
+**Why:** points at the content instead of writing it, forcing the reader down a
+line to collect what could have been in the subject slot.
+
+**Fix:** name it, with its number.
+
+> was: *Five of those six rows are one cluster. The sixth is not.*
+> now: *Five legs pass 77 to 81 of the 92 and exhaust 6 to 9. fit-17g passes 62
+> and exhausts 21.*
+
+---
+
+## 6. Structural-metaphor locator
+
+**Tell:** "the seam where...", "the hinge", "the joint", "the fault line", "the
+leg that...", "the place where it breaks down", "X is doing the work that Y
+would".
+
+**Why:** makes an ordinary observation sound like architecture you uncovered.
+Usually stacks with abstraction agency.
+
+**Fix:** name the plain mechanism.
+
+> was: *It's the seam where the laugh is doing the work an argument would have to.*
+> now: *The piece never engages the bull case; the joke covers the gap.*
+
+---
+
+## 7. Coy and thesis-shaped headers
+
+**Tell:** a header that states a verdict ("The default was wrong", "The one gap
+that does clear the bar") or hides its contents ("What 'exhausted' means", "What
+the data actually shows", "Why it matters"). Also any comma in a header — an
+appositive, participle or relative clause ("The obvious follow-up, measured";
+"The catch, which is not small").
+
+**Why:** headers are navigation. A header that could top three different sections
+is a thesis, not a label. No real person puts sentence clauses in a headline.
+
+**Fix:** name the content as a flat noun phrase. Or, if the definition is the
+point, make the header the definition.
+
+> was: *What "exhausted" means* → now: *Exhausted cases*
+> was: *The one gap that does clear the bar* → now: *The 2.876-bit gap*
+
+**Test:** read the header alone, as a table-of-contents entry. Does it tell you
+what is in the section?
+
+---
+
+## 8. Suspense construction
+
+**Tell:** a paragraph ending on a colon that introduces the culprit on the next
+line; a sentence that withholds the noun to force a break; "1, 2, and then 3 —
+the killer"; "Then the part that almost killed it."; "But here's where it gets
+interesting."
+
+**Why:** suspense is a fiction technique. In technical writing it costs the
+reader time to buy the writer a beat.
+
+**Fix:** state the finding when you have it.
+
+---
+
+## 9. Drama line break
+
+**Tell:** a single sentence alone on its own line as a gravitas beat — "It isn't.",
+"That is not a result.", "And then everything broke."
+
+**Why:** whitespace is being used as a drum roll.
+
+**Fix:** put the sentence back in its paragraph. **Earned** for a real pivot: new
+actor, category shift, time jump.
+
+---
+
+## 10. Rhetorical question plus fragment answer
+
+**Tell:** "So how does it fail?" / "Mostly by not finishing." — asking the reader
+something in order to answer it yourself.
+
+**Why:** two beats where none are needed, and it stages the writer as a guide
+walking the reader through a discovery.
+
+**Fix:** one declarative. *"fit-17g fails mostly by not finishing."*
+
+---
+
+## 11. Straw-man knockdown
+
+**Tell:** quoting a wrong reading attributed to the reader, then rejecting it —
+*"It thinks twice as long" is the obvious reading of that, and it is wrong.*
+
+**Why:** the negation-first shape wearing a costume. The correction is the same
+length without the invented interlocutor.
+
+**Fix:** give the correction directly. *"That median does not mean it thinks twice
+as long. On the questions it finishes..."*
+
+---
+
+## 12. Aphoristic closer
+
+**Tell:** a final sentence that compresses the paragraph into a contrast, moral,
+or quotable line — "It is the kind of number that looks like evidence and is
+not", "The bridge was the move, not novel math", "Verifier > judge by a wide
+margin", "the failure that looks like diligence", "X is the load-bearing part".
+
+**Why:** it restates what the paragraph already established, in a shape built to
+be quoted. It also grades your own argument.
+
+**Fix:** delete it. If the paragraph needs it, the paragraph is not working.
+Where a landing is genuinely wanted, land on a fact: *"Default retries are back
+to 3."*
+
+---
+
+## 13. Self-grading
+
+**Tell:** "earned, not asserted", "this isn't just X, it's genuinely Y", "to be
+clear, this is rigorous because", "That is what the data shows", "That
+distinction changes what you would predict", "not a relabel", "worth noting", "a
+distinction worth keeping separate".
+
+**Why:** narrates the epistemic status of your own reasoning instead of reasoning.
+If the point is earned, the reader can see it.
+
+**Fix:** make the point and stop.
+
+---
+
+## 14. Performed humility
+
+**Tell:** "Their phrasing for it is better than mine", "This might be a small
+thing, but", "I'm not sure this is worth writing up, but", "Probably nobody cares,
+but", "classic me".
+
+**Why:** a bow. It asks for credit for modesty and weakens the piece.
+
+**Fix:** if it is worth publishing, publish it straight. Attribution without
+ranking: *"from a conversation with X"*.
+
+---
+
+## 15. Staccato fragment cadence
+
+**Tell:** three or more fragments in series for rhythm — *Six legs. One GPU, one
+server build, one sampler, one question set.* — or parallel fragment pairs, *Most
+questions it handles at a normal length. A subset runs away and hits the wall.*
+
+**Why:** rhythm engineering. The content is a list; the drumbeat is decoration.
+
+**Fix:** one sentence. *"Six legs, all on the same GPU with the same server build,
+sampler and question set."*
+
+---
+
+## 16. Em-dash gotcha
+
+**Tell:** a clause after an em-dash that delivers the punch, especially at the end
+of a paragraph.
+
+**Why:** the dash stages the beat. Em-dashes for genuine inline asides are fine
+and human; the tic is the dash-as-drum-roll.
+
+**Fix:** if the clause is the point, make it the sentence. Also: count em-dashes.
+More than roughly one per 150 words reads as machine-written regardless of what
+each one is doing.
+
+---
+
+## 17. Throat-clearing and process narration
+
+**Tell:** "I want to talk about", "In this post, I'll cover", "Let me explain",
+"First, some background", "Before I get into it", "Let me consult my memories",
+"Storing this before I answer", "First I'll X, then Y".
+
+**Why:** preamble wearing a competence badge. The reader sees the result, not the
+procedure.
+
+**Fix:** start where you would start with no preamble budget.
+
+---
+
+## 18. RTFM as revelation
+
+**Tell:** "It turns out that", "I finally discovered", "Hidden in the API",
+"Buried in the docs" — followed by standard documented behaviour.
+
+**Fix:** if the finding is that you missed something obvious, say that.
+
+---
+
+## 19. Generic-developer vocabulary
+
+**Tell:** footgun, shot itself in the foot, almost killed it, fell apart, rabbit
+hole, yak shaving, belt-and-suspenders, load-bearing (as metaphor), moving the
+needle, first-class citizen, under the hood, magic, just works, sane defaults.
+
+**Why:** the writer reached for the easy phrase instead of the accurate one. The
+accurate phrase is usually shorter.
+
+---
+
+## 20. Slop vocabulary
+
+**Tell:** delve, tapestry, testament to, navigate the complexities, in today's
+fast-paced, it's important to note, landscape (figurative), realm, robust,
+seamless, leverage (as verb), utilize, crucial, pivotal, myriad, plethora, elevate,
+unlock, harness, embark, dive deep, at the end of the day, that said.
+
+**Why:** these do not signal a tic so much as an absence of choice. Replace with
+the specific word.
+
+---
+
+## 21. Sanitized quotes
+
+**Tell:** reported speech where the verb is "expressed", "indicated", "voiced
+concern about".
+
+**Fix:** if they said "WTF", write "WTF".
+
+---
+
+## 22. Time-scale inflation
+
+**Tell:** vague durations on recent work — "a month ago", "for a long time", "all
+year", "recently", "yesterday" — when the real timeline is hours or days.
+
+**Fix:** check the timestamp, or drop the time framing. The pull toward narrative
+time is strong and needs an empirical counter.
+
+---
+
+## 23. Editorializing modifiers
+
+**Tell:** adjectives that pre-load the verdict the piece is supposed to reach —
+"aggressive", "surprising", "impressive", "brutal", "collapse" for a 15-point
+drop, "exactly" where the contrast already carries it.
+
+**Fix:** let the number be the adjective.
+
+---
+
+## Quick self-check before shipping an edit
+
+1. Does any sentence exist to make a finding feel bigger than it is?
+2. Does any sentence tell the reader which sentence matters?
+3. Is anything in a subject slot that cannot act?
+4. Does any header state a verdict, hide its contents, or contain a comma?
+5. Is any noun deferred that was available?
+6. Does the last paragraph paraphrase the subtext of the piece?
+7. Did the edit remove content, change a claim, or add hedging?
+8. Does the result still sound like a person with opinions?

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Mechanical scan for LLM prose tics.
+
+Finds candidates. Does not decide. Every hit still needs the sentence-level
+test in references/register.md, and the structural tics (fragment cadence,
+drama line breaks, staged paragraph shape) are only partly reachable by regex.
+A clean report means nothing on its own.
+
+    python3 declaude_lint.py DRAFT.md [--json] [--quiet-slop]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# (category, regex, note). Case-insensitive unless the pattern needs case.
+RULES: list[tuple[str, str, str]] = [
+    # --- negation-first -----------------------------------------------------
+    ("negation-first", r"\b(?:is|it's|its|was|it was)\s+not\s+(?:that\s+)?[^.;]{2,60}[.;—-]\s*(?:it|that)\s+(?:is|was|'s)\b", "is-not / it-is pair"),
+    ("negation-first", r"\bnot\s+because\b[^.]{0,80}—\s*because\b", "not-because / because"),
+    ("negation-first", r"\b(?:doesn't|does not|didn't|did not)\s+just\b[^.]{0,60}\b(?:it|they)\b", "doesn't just X, it Y's"),
+    ("negation-first", r"\bthe\s+(?:problem|failure|issue|point|question|bug|risk)\s+(?:wasn't|isn't|was not|is not)\b", "the problem wasn't X"),
+    ("negation-first", r"[.!?]\s+Not\s+(?:that|because|a|an|the)\b[^.]{0,60}\.", "trailing 'Not X.' fragment"),
+    ("negation-first", r",\s*not\s+[a-z][^.]{0,40}\.\s*$", "X, not Y closer"),
+
+    # --- significance designation -------------------------------------------
+    ("significance", r"\bthe\s+(?:real|actual|true|useful|interesting|important|key)\s+(?:question|problem|issue|point|reason|answer|finding|story|move|tool|test|variable|number)\b", "the real/actual X"),
+    ("significance", r"\bthe\s+(?:part|thing|bit|piece|detail|one|leg|row|line|number|question)\s+that\s+(?:matters|counts|transfers|makes the point|does the work|answers|explains)\b", "the part that matters"),
+    ("significance", r"\b(?:here'?s|this is)\s+(?:the thing|where it gets interesting|what)\b", "here's the thing"),
+    ("significance", r"\band\s+(?:that'?s|it has)\s+(?:the interesting part|a name here)\b", "manufactured reveal"),
+    ("significance", r"\bthe\s+(?:one|only)\s+thing\s+(?:nobody|no one)\b", "the one thing nobody"),
+    ("significance", r"\b(?:most|more)\s+(?:interesting|telling|revealing|surprising)\s+(?:part|thing|number|finding)\b", "significance tag"),
+    ("significance", r"\bNobody\s+(?:had\s+)?(?:checked|noticed|asked|mentioned|said|looked)\b", "unfalsifiable 'nobody' claim — earned only with a named mechanism"),
+
+    # --- abstraction agency --------------------------------------------------
+    ("agency", r"\b(?:the\s+)?(?:table|chart|graph|data|numbers?|median|mean|metric|figure|plot|log|code|result|headline)\s+(?:shows?|hides?|tells?|reveals?|says?|proves?|admits?|knows?|wants?)\b", "inanimate subject acting"),
+    ("agency", r"\b(?:is|are|was|were)\s+doing\s+the\s+work\b", "X is doing the work"),
+    ("agency", r"\b(?:earns?|demands?|wants?|buys?|deserves?)\s+(?:its|their|the)\s+\w+", "abstraction earning something"),
+    ("agency", r"\b(?:truncation|quantization|rescoring|compression|optimization|abstraction|complexity|scalability)\s+(?:cuts?|adds?|breaks?|solves?|reranks?|is a concern)\b", "nominalization as agent"),
+    ("agency", r"\b(?:about to|going to)\s+discover\b", "tool personified"),
+
+    # --- deferred noun -------------------------------------------------------
+    ("deferred-noun", r"\bOne\s+thing\s+(?:is|isn't|is not|that)\b", "One thing ..."),
+    ("deferred-noun", r"\bThe\s+(?:second|third|fourth|fifth|sixth|seventh|other|last)\s+(?:is|isn't|is not|does|doesn't)\b\s*[.,]", "pointer instead of name"),
+    ("deferred-noun", r"\bThere\s+(?:was|is)\s+(?:just\s+)?one\s+(?:problem|catch|issue|wrinkle)\b", "there was just one problem"),
+
+    # --- structural-metaphor locator ----------------------------------------
+    ("locator", r"\bthe\s+(?:seam|hinge|joint|fault[- ]line|crux|linchpin|leg|place)\s+where\b", "structural-metaphor locator"),
+    ("locator", r"\bload[- ]bearing\b", "load-bearing as metaphor"),
+
+    # --- suspense / staging --------------------------------------------------
+    ("staging", r"\b(?:but\s+)?here'?s\s+where\s+it\s+gets\b", "here's where it gets"),
+    ("staging", r"\bwhat\s+(?:I|we|you)\s+(?:didn't|did not)\s+(?:realize|know|expect)\b", "movie-trailer voiceover"),
+    ("staging", r"\bthis\s+is\s+the\s+story\s+of\b", "trailer opener"),
+    ("staging", r"\band\s+that'?s\s+(?:when|where|why)\b", "and that's when"),
+    ("staging", r"^\s*(?:So|Then|And)\s+(?:the|here|now)\b[^.\n]{0,40}:\s*$", "colon-staged section lead"),
+    ("staging", r"\bthe\s+(?:defensible|honest|short|real)\s+(?:statement|answer|version)\s*:", "noun-phrase colon stage"),
+
+    # --- rhetorical question -------------------------------------------------
+    ("rhetorical-q", r"^\s*(?:So\s+)?(?:how|why|what|where|when|does|is|can|should)\b[^?\n]{0,70}\?\s*$", "standalone rhetorical question — check if you answer your own question next"),
+
+    # --- self-grading --------------------------------------------------------
+    ("self-grading", r"\b(?:earned,?\s+not\s+asserted|not\s+a\s+relabel|to be clear,\s*this is)\b", "grading own rigor"),
+    ("self-grading", r"\b(?:that|this)\s+is\s+what\s+the\s+(?:data|numbers?|table|evidence)\s+shows?\b", "that is what the data shows"),
+    ("self-grading", r"\b(?:it'?s|it is)\s+(?:worth|important)\s+(?:noting|mentioning|pointing out)\b", "worth noting"),
+    ("self-grading", r"\ba\s+distinction\s+worth\b", "grading the distinction"),
+    ("self-grading", r"\bgenuinely\s+(?:useful|interesting|hard|novel|different|new)\b", "intensifier as self-grade"),
+
+    # --- performed humility --------------------------------------------------
+    ("humility", r"\b(?:better|sharper|cleaner)\s+than\s+mine\b", "ranking others above yourself"),
+    ("humility", r"\b(?:this\s+might\s+be\s+a\s+small\s+thing|probably\s+nobody\s+cares|not\s+sure\s+this\s+is\s+worth)\b", "apologizing for the piece"),
+    ("humility", r"\bclassic\s+me\b", "self-deprecation as performance"),
+
+    # --- throat-clearing / process narration ---------------------------------
+    ("throat-clearing", r"\b(?:in this (?:post|article|piece),?\s*(?:I|we)'?ll|I want to talk about|let me explain|first,? some background|before I get into)\b", "preamble"),
+    ("throat-clearing", r"\b(?:let me|I'?ll)\s+(?:consult|check|search|pull up|recall)\s+my\b", "AI self-narration"),
+
+    # --- RTFM ----------------------------------------------------------------
+    ("rtfm", r"\b(?:it turns out|I finally (?:discovered|realized|found)|hidden in the|buried in the (?:docs|api))\b", "RTFM as revelation"),
+
+    # --- dev cliché ----------------------------------------------------------
+    ("dev-cliche", r"\b(?:footgun|shot itself in the foot|rabbit hole|yak[- ]shav\w*|belt[- ]and[- ]suspenders|moving the needle|first[- ]class citizen|under the hood|just works|sane defaults|almost killed it)\b", "generic developer vocabulary"),
+
+    # --- slop ----------------------------------------------------------------
+    ("slop", r"\b(?:delve|tapestry|testament to|navigate the complexities|in today'?s fast[- ]paced|realm of|robust|seamless|leverage|utilize|crucial|pivotal|myriad|plethora|elevate|unlock the|harness the|embark|dive deep|at the end of the day)\b", "slop vocabulary"),
+
+    # --- editorializing ------------------------------------------------------
+    ("editorializing", r"\b(?:collapse[sd]?|catastrophic|dramatic(?:ally)?|brutal|staggering|remarkable|impressive)\b", "check the number justifies the adjective"),
+
+    # --- time inflation ------------------------------------------------------
+    ("time-inflation", r"\b(?:a (?:month|few months|while) ago|for a long time|all year|recently|these days)\b", "ground the duration or drop it"),
+    # --- aphoristic closer ---------------------------------------------------
+    ("aphorism", r"\bthe\s+kind\s+of\s+\w+\s+that\b[^.]{0,60}\band\s+is\s+not\b", "X that looks like Y and is not"),
+    ("aphorism", r"\bthe\s+\w+\s+that\s+looks\s+like\s+\w+", "X that looks like Y"),
+    ("aphorism", r"\b(?:by\s+a\s+wide\s+margin|was\s+the\s+move|is\s+the\s+whole\s+(?:point|bug|story))\b", "quotable closer"),
+
+    # --- staging (more) ------------------------------------------------------
+    ("staging", r"\b(?:here|this)\s+is\s+what\s+[^.]{0,60}\blooks?\s+like\b", "here is what X looks like"),
+    ("staging", r"\bthen\s+the\s+(?:useful|real|interesting)\s+question\b", "heralding your own question"),
+]
+
+HEADER_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
+COY_HEADER_RE = re.compile(r"^(?:what|why|how)\b(?!.*\?$)", re.I)
+VERDICT_HEADER_RE = re.compile(r"\b(?:is|are|isn'?t|aren'?t|was|wasn'?t|does|doesn'?t|actually|really|wrong|right|matters|counts)\b", re.I)
+
+CATEGORY_ORDER = [
+    "negation-first", "significance", "agency", "deferred-noun", "locator",
+    "staging", "rhetorical-q", "self-grading", "humility", "throat-clearing",
+    "rtfm", "dev-cliche", "slop", "editorializing", "time-inflation",
+    "header", "cadence", "density",
+]
+
+COMPILED = [(cat, re.compile(pat, re.I | re.M), note) for cat, pat, note in RULES]
+
+
+def scan_lines(text: str) -> list[dict]:
+    hits: list[dict] = []
+    lines = text.splitlines()
+
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+
+        for cat, rx, note in COMPILED:
+            for m in rx.finditer(line):
+                hits.append({
+                    "line": i, "category": cat, "note": note,
+                    "match": m.group(0).strip()[:90],
+                })
+
+        # headers
+        h = HEADER_RE.match(line)
+        if h:
+            title = h.group(2).strip().rstrip("#").strip()
+            if "," in title:
+                hits.append({"line": i, "category": "header",
+                             "note": "comma-clause header — no real person puts sentence clauses in a headline",
+                             "match": title[:90]})
+            if COY_HEADER_RE.match(title):
+                hits.append({"line": i, "category": "header",
+                             "note": "coy header — could top three different sections; name the content",
+                             "match": title[:90]})
+            elif not title.endswith("?") and VERDICT_HEADER_RE.search(title) and len(title.split()) > 3:
+                hits.append({"line": i, "category": "header",
+                             "note": "thesis-shaped header — states a verdict instead of labelling",
+                             "match": title[:90]})
+
+        # drama line break: very short standalone paragraph
+        if stripped and not stripped.startswith(("#", "-", "*", ">", "|", "`")):
+            prev_blank = i == 1 or not lines[i - 2].strip()
+            next_blank = i >= len(lines) or not lines[i].strip()
+            words = len(stripped.split())
+            if prev_blank and next_blank and words <= 8 and stripped.endswith((".", "!")):
+                hits.append({"line": i, "category": "cadence",
+                             "note": "one-line paragraph — gravitas beat unless it is a real pivot",
+                             "match": stripped[:90]})
+
+    hits.extend(_fragment_runs(text))
+    return hits
+
+
+def _fragment_runs(text: str) -> list[dict]:
+    """Three or more short sentences in a row inside one paragraph."""
+    out = []
+    line_no = 1
+    for para in re.split(r"\n\s*\n", text):
+        n = para.count("\n") + 1
+        if not para.strip().startswith(("#", "-", "*", ">", "|", "`")):
+            sents = [x.strip() for x in re.split(r"(?<=[.!?])\s+", para.strip()) if x.strip()]
+            run = 0
+            for x in sents:
+                run = run + 1 if len(x.split()) <= 8 else 0
+                if run == 3:
+                    out.append({"line": line_no, "category": "cadence",
+                                "note": "three or more short sentences in a row — fragment cadence, write it as one sentence",
+                                "match": para.strip()[:90]})
+                    break
+        line_no += n + 1
+    return out
+
+
+def scan_density(text: str) -> list[dict]:
+    out = []
+    body = re.sub(r"```.*?```", "", text, flags=re.S)
+    words = len(body.split()) or 1
+
+    dashes = len(re.findall(r"—|(?<= )--(?= )", body))
+    per150 = dashes / words * 150
+    if per150 > 1.0:
+        out.append({"line": 0, "category": "density",
+                    "note": f"{dashes} em-dashes in {words} words ({per150:.1f} per 150) — above ~1.0 reads machine-written",
+                    "match": "em-dash density"})
+
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", body) if s.strip()]
+    frags = [s for s in sentences if 1 <= len(s.split()) <= 5 and not s.startswith(("#", "-", "|"))]
+    if sentences and len(frags) / len(sentences) > 0.12:
+        out.append({"line": 0, "category": "density",
+                    "note": f"{len(frags)} of {len(sentences)} sentences are <=5 words — check for fragment cadence",
+                    "match": "fragment density"})
+
+    lens = [len(s.split()) for s in sentences]
+    if len(lens) > 20:
+        mean = sum(lens) / len(lens)
+        var = sum((x - mean) ** 2 for x in lens) / len(lens)
+        if var ** 0.5 < 5:
+            out.append({"line": 0, "category": "density",
+                        "note": f"sentence-length sd {var ** 0.5:.1f} — uniform length is its own tell; vary by content",
+                        "match": "sentence monotony"})
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("path", help="file to scan, or - for stdin")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--quiet-slop", action="store_true", help="hide the slop/editorializing/time categories")
+    args = ap.parse_args()
+
+    text = sys.stdin.read() if args.path == "-" else Path(args.path).read_text(encoding="utf-8")
+
+    hits = scan_lines(text) + scan_density(text)
+    if args.quiet_slop:
+        hits = [h for h in hits if h["category"] not in {"slop", "editorializing", "time-inflation"}]
+
+    hits.sort(key=lambda h: (CATEGORY_ORDER.index(h["category"]) if h["category"] in CATEGORY_ORDER else 99, h["line"]))
+
+    if args.json:
+        print(json.dumps({"hits": hits, "total": len(hits)}, indent=2))
+        return 1 if hits else 0
+
+    if not hits:
+        print("no lexical tells found — this says nothing about the structural tics; run the sentence pass anyway")
+        return 0
+
+    counts: dict[str, int] = {}
+    for h in hits:
+        counts[h["category"]] = counts.get(h["category"], 0) + 1
+
+    print(f"{len(hits)} candidates in {len(counts)} categories\n")
+    current = None
+    for h in hits:
+        if h["category"] != current:
+            current = h["category"]
+            print(f"\n[{current}]  ({counts[current]})")
+        loc = f"L{h['line']}" if h["line"] else "  —"
+        print(f"  {loc:>6}  {h['match']}")
+        print(f"          {h['note']}")
+
+    print("\nCandidates, not verdicts. Check each against references/register.md,")
+    print("and note that no regex reaches staged paragraph shape or a staged closer.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/declauding/tests/sample-clean.md
+++ b/declauding/tests/sample-clean.md
@@ -1,0 +1,13 @@
+# A few words on DS4
+
+I didn't expect DwarfStar 4 to become so popular so fast. It is clear that there was a need for single-model integration focused local AI experience, and that a few things happened together: the release of a quasi-frontier model that is large and fast enough to change the game of local inference, and the fact that it works extremely well with an extremely asymmetric quants recipe of 2/8 bit, so that 96 or 128GB of RAM are enough to run it.
+
+The last week was funny and also tiring, I worked 14 hours per day on average. My normal average is 4/6 since early Redis times, but the first few months of Redis were like that.
+
+So, what's next? Is this a project that starts and ends with DeepSeek v4 Flash? Nope, the model can change over time. The space will be occupied, in my vision, by the best current open weights model that is practically fast on a high end Mac or GPU in a box gear.
+
+## Power capping
+
+Long local inference runs can keep the GPU busy for extended periods. If you care more about heat, fan noise, battery life on MacBooks, or reducing thermal stress on the hardware than about maximum throughput, use --power N. --power 100 is the default and means full speed. Lower values ask DwarfStar to target that percentage of GPU usage. DwarfStar does this by measuring GPU work time and inserting small sleeps between work units: during prefill it sleeps between layers, and during generation it sleeps between decoded tokens. This reduces sustained load without changing model output.
+
+I did not expect the overlap to survive a 3x range in bits per weight and two different quant families.

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -1,0 +1,55 @@
+# Does a budget-exact quant cost accuracy?
+
+## The question
+
+So: does solving for the budget cost you anything? A mix chosen to fill a number is a different object from a recipe chosen for quality.
+
+## The setup
+
+Six legs. One GPU, one server build, one sampler, one question set.
+
+Nobody had checked whether it could still think. It is the leg that answers the actual question.
+
+One thing is not flat, and the table shows it. That is the variable the fits exist to test.
+
+fit-17g is the exception in both directions. Its row is not a test of long context — it is a test of what 2.876 bits per weight does to the model's reasoning.
+
+## Where the misses go
+
+Five of those six rows are one cluster. The sixth is not.
+
+## What "exhausted" means
+
+It is not a wrong answer. It is a non-answer. Counting it as a failure is the conservative choice, and it is what these numbers do.
+
+The same questions exhaust in every leg.
+
+When only the fits had run, that looked like it might be a property of the fits. It isn't.
+
+So the failure mode is not mostly about the quantization. It is mostly about the question. The two failure modes also live in different places.
+
+## The one gap that does clear the bar
+
+Here is what the same instrument looks like when it can resolve a difference.
+
+So how does it fail?
+
+Mostly by not finishing.
+
+"It thinks twice as long" is the obvious reading of that, and it is wrong.
+
+That is what the data shows.
+
+Median hides it: the middle of every distribution is similar.
+
+## An earlier baseline that did not count
+
+The detail that makes the point: in that older config the higher-precision KV cache scored lower. Not because f16 KV hurts — because a comparison across four simultaneous changes carries no information about any one of them. It is the kind of number that looks like evidence and is not.
+
+It is not a method; it is a lucky escape.
+
+## Method notes
+
+Everything below is the inference side, which is the part that transfers. --calibrate is the part that matters.
+
+A distinction worth keeping separate: a metric can fail two different ways. Their phrasing for it is better than mine.


### PR DESCRIPTION
New skill. Claudisms in, human technical prose out.

Grew out of a register pass on an external benchmark post (ApeChat / claude-mini,
2026-08-16), where 34 passages carried ~45 tic instances across ten shapes.

## Contents

- `SKILL.md` — workflow, the overcorrection guard, the earned-exception table.
- `references/register.md` — 23 entries, each with tell / why / fix / real
  before-after. Grouped by mechanism, since phrase blocklists always leak.
- `references/annotating.md` — spec for the annotated-diff output mode.
- `assets/annotated.template.html` — self-contained, no build step, no CDN.
- `scripts/declaude_lint.py` — regex scan for the lexical tells plus header
  shape, one-line-paragraph beats, fragment runs, em-dash density and
  sentence-length monotony.
- `tests/` — a tic corpus and a human-prose corpus.

## Design notes

**The linter's false-positive budget is the constraint.** `tests/sample-clean.md`
(antirez's own writing) must report zero. A rule that fires on human prose gets
the linter ignored, which costs more than the tic it caught.

**Two things the skill insists on that a phrasing pass would miss:**

1. Read the whole piece before editing. Tics carry factual errors — a sentence
   built for shape is disproportionately likely to be wrong. The source post had
   two designations ("the leg that answers the actual question", "the variable
   the fits exist to test") that the draft itself contradicted a paragraph later.
2. Overcorrection is the failure mode. Flat is not hedged; first-person judgment,
   digression and varied sentence length all stay.

**Earned exceptions are tabulated,** so "X rather than Y" survives when the
reader was genuinely holding Y. Banning the shape outright produces mush.

## Verification

    python3 declauding/scripts/declaude_lint.py declauding/tests/sample-tics.md   # 29 candidates, 12 categories
    python3 declauding/scripts/declaude_lint.py declauding/tests/sample-clean.md  # 0

`validate_skill_file(..., require_version=True)` passes. No CI gate exists for
skills in this repo, so those are the commands to run before merge.
