### PR TITLE
declauding v0.1.1 — add README, --skip-quoted, and the fixes that missed #755

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,7 +2,31 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1] - 2026-08-16
+
+### Added
+
+- `README.md`. Missing from 0.1.0: the commits carrying it landed on the branch after the merge and were lost when the branch was deleted.
+- `--skip-quoted` on the linter. Blanks blockquotes, table rows, `*italic*` spans and `<q>` elements while preserving line numbers, so a document that quotes bad prose as specimens does not report its own examples. Handles italics that wrap across lines.
+
+### Fixed
+
+- The `earns/wants/demands` agency rule fired on ordinary second-person prose ("if you want the noise"). Added a lookbehind for personal pronouns.
+- Density checks counted headings, table rows and list bullets as sentences, inflating fragment density on any structured document.
+- The skill's own prose failed its own linter: two coy headers, four `X, not Y` closers, one abstraction-agency subject, and a negation-first closer sitting directly beneath the sentence explaining why negation-first closers are a tic.
+
 ## [0.1.0] - 2026-08-16
+
+### Added
+
+- Initial release. Two modes: clean rewrite (default) and annotated HTML diff.
+- `references/register.md`: 23 entries grouped by mechanism, each with surface tell, why, fix, and a before-and-after from a real published draft. Grouping is by mechanism rather than phrase because phrase blocklists miss the next paraphrase.
+- `references/annotating.md`: spec for the annotated diff.
+- `assets/annotated.template.html`: self-contained output template. No build step, no CDN, opens from `file://`.
+- `scripts/declaude_lint.py`: stdlib-only scan for lexical tells plus header shape, one-line-paragraph beats, fragment runs, em-dash density and sentence-length monotony. Exits 1 on candidates.
+- `tests/sample-tics.md` (29 candidates, 12 categories) and `tests/sample-clean.md` (0). The clean corpus is human-written prose and holding it at zero is the linter's design constraint.
+- Overcorrection guard and earned-exception table in `SKILL.md`.
+- Workflow steps 1 and 6: read the whole piece first, and report contradictions separately rather than fixing them silently.
 
 ### Other
 

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -1,0 +1,142 @@
+# declauding
+
+Removes LLM prose tics from a draft and returns plain human technical prose. The
+input is text; the output is either the rewritten text or an annotated HTML diff
+showing every edit with its original and its reason.
+
+Almost every tic it catches is one move: **the sentence is built to make the
+reader feel a finding arrive, instead of stating the finding.** The register
+catalogues the shapes that move takes. The fix is always the same: put a real
+subject in the subject slot, say the thing, stop.
+
+See [`SKILL.md`](SKILL.md) for the workflow, the overcorrection guard and the
+earned-exception table. See [`references/register.md`](references/register.md)
+for the catalogue. See [`CHANGELOG.md`](CHANGELOG.md) for version history.
+
+## Two modes
+
+| Mode | Output | Use for |
+|---|---|---|
+| **clean** (default) | The rewritten text, nothing else | Fixing your own draft before publishing |
+| **annotated** | One self-contained HTML file: rewritten text, every changed passage marked, each with the original verbatim, the tic name, and why | Reviewing someone else's draft, teaching the register, arguing about a specific edit |
+
+The annotated file has a toggle that hides the marks, so the same artifact
+serves as both the review and the result. No build step, no CDN, no server.
+
+## Tics it catches
+
+Twenty-three entries in the register, grouped by mechanism rather than by
+phrase, since phrase blocklists miss the next paraphrase. The ones that show
+up in nearly every draft:
+
+| Tic | Example |
+|---|---|
+| Negation-first reveal | *It is not a wrong answer. It is a non-answer.* |
+| Significance designation | *It is the leg that answers the actual question.* |
+| Abstraction agency | *Median hides it.* / *The table shows it.* |
+| Deferred noun | *Five of those six rows are one cluster. The sixth is not.* |
+| Coy or thesis-shaped header | *What "exhausted" means* / *The one gap that does clear the bar* |
+| Aphoristic closer | *It is the kind of number that looks like evidence and is not.* |
+| Straw-man knockdown | *"It thinks twice as long" is the obvious reading, and it is wrong.* |
+| Fragment cadence | *Six legs. One GPU, one server build, one sampler, one question set.* |
+
+Each entry carries the surface tell, why it is a tic, the fix, and a real
+before-and-after taken from a published draft.
+
+## The linter
+
+```sh
+python3 scripts/declaude_lint.py DRAFT.md            # human-readable
+python3 scripts/declaude_lint.py DRAFT.md --json     # machine-readable
+python3 scripts/declaude_lint.py - --quiet-slop      # stdin, minus vocabulary noise
+python3 scripts/declaude_lint.py DOC.md --skip-quoted # ignore quoted specimens
+```
+
+Stdlib only. It flags the lexical tells with line numbers and categories, plus
+header shape, one-line-paragraph beats, fragment runs, em-dash density and
+sentence-length monotony.
+
+It finds candidates and does not decide. Every hit still needs the
+sentence-level test, and no regex reaches a staged paragraph shape or a staged
+closer, so **a clean report means nothing on its own.**
+
+Exit code 1 when it finds candidates, 0 when it does not, which makes it usable
+as a pre-commit hook.
+
+## False positives
+
+`tests/sample-clean.md` is human-written prose and must lint to zero.
+`tests/sample-tics.md` is a corpus of real specimens and currently reports 29
+candidates across 12 categories.
+
+```sh
+python3 scripts/declaude_lint.py tests/sample-tics.md    # 29 candidates
+python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
+```
+
+Two rules are deliberately tuned down to hold that zero, so the linter misses
+some real coy headers. A linter that fires on good writing gets ignored, and
+then it catches nothing.
+
+## Overcorrection
+
+The failure mode of this skill is prose stripped of confidence, rhythm and
+personality until every sentence is the same length and the writer has no
+opinions. That is worse than the tics, so the guard is written into `SKILL.md`
+rather than left to judgment:
+
+- Flat is not hedged. *Class imbalance breaks the metric before overfitting
+  does* is flat and certain.
+- First-person judgment stays. *I did not expect the overlap to survive a 3x
+  range in bits per weight* is specific, falsifiable and human.
+- Sentence length varies with content. Uniformity is its own tell.
+- Digression and mild informality are human. Symmetry and antithesis are not.
+
+Several banned shapes have an earned form, tabulated in `SKILL.md`. *X rather
+than Y* is legitimate when the reader was genuinely holding Y; it is staged when
+you supplied Y so you could reject it.
+
+## Tics carry factual errors
+
+Step 1 of the workflow is to read the whole piece before editing anything, and
+step 6 is to report contradictions separately rather than fix them.
+
+A sentence built for shape is disproportionately likely to be wrong. In the
+draft this skill was built on, two significance designations (*the leg that
+answers the actual question*, *the variable the fits exist to test*) both
+designated the wrong thing, and the draft contradicted each of them within two
+paragraphs. Finding those is worth more than the register pass.
+
+## Extending
+
+The register is a working document. To add to it: put the specimen in
+`tests/sample-tics.md` verbatim, write the entry with a real before-and-after,
+add a lint rule if the tell is lexical, confirm `tests/sample-clean.md` still
+reports zero, bump `metadata.version`.
+
+Add a phrase to the register after two sightings in real drafts. One sighting
+can be a choice; two is a habit.
+
+## Provenance
+
+Built from a register pass on an external benchmark post (2026-08-16), where 34
+passages carried about 45 tic instances across ten shapes. Every specimen in the
+register and the test corpus comes from a real published draft.
+
+## Complements
+
+- **[challenging](../challenging)** — its `prose-register` profile runs an
+  adversary against a draft's voice. That one evaluates and returns findings;
+  this one edits and returns text. Run `challenging` on the result if the stakes justify it.
+- **[crafting-instructions](../crafting-instructions)** — writing prompts and
+  instructions, where the target register is different.
+- **[composing-html](../composing-html)** — general single-file HTML artifacts.
+  This skill ships its own template because the annotated diff has one fixed
+  shape and no reason to depend on another skill.
+
+This skill edits register. It does not fact-check, restructure an argument, or
+improve the analysis.
+
+## Dependencies
+
+None — Python 3.9+ and the standard library, with a self-contained HTML template.

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -2,7 +2,7 @@
 name: declauding
 description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.1.0
+  version: 0.1.1
 ---
 
 # Declauding
@@ -19,7 +19,7 @@ Two output modes:
 
 Almost every tic in `references/register.md` is a version of the same move:
 **the sentence is built to make the reader feel a finding arrive, instead of
-stating the finding.** Staging, not stating.
+stating the finding.**
 
 The generative test, applied per sentence: *am I saying the thing, or
 performing having had the thought?* Say the thing.
@@ -28,8 +28,8 @@ performing having had the thought?* Say the thing.
 
 **1. Read the whole piece before editing anything.** Tics carry factual errors.
 A sentence written to sound important is disproportionately likely to be wrong,
-because it was built for shape rather than for accuracy — designations like "the
-X that answers the real question" frequently designate the wrong X, and the
+because it was built for shape rather than for accuracy. Designations of the form
+*the X that answers the real question* frequently designate the wrong X, and the
 draft itself often contradicts them a paragraph later. Note contradictions now;
 they are the most valuable thing this pass produces.
 
@@ -61,8 +61,8 @@ what preceded it? delete it).
 - Mush. See Overcorrection below.
 
 **6. Report factual problems separately.** Never silently fix a contradiction
-found while editing. The author needs to know their draft disagreed with itself,
-and which version is true is their call, not the editor's.
+found while editing. The author needs to know their draft disagreed with
+itself, and only they can say which version is true.
 
 ## Overcorrection
 
@@ -108,7 +108,8 @@ Rules that make the annotation useful rather than decorative:
   an assertion.
 - Name the tic using the register's vocabulary so the reader accumulates a
   vocabulary rather than 40 unrelated opinions.
-- Say why *this instance* is a tic, not what the category means in general.
+- Say why *this instance* is a tic. Explaining the category teaches nothing
+  about the text in front of the reader.
 - Mark what was kept and why. A pass that only flags failures teaches avoidance.
 - Bundle stacked tics into one note per passage. Do not split a sentence into
   four notes to inflate the count.

--- a/declauding/references/annotating.md
+++ b/declauding/references/annotating.md
@@ -57,10 +57,9 @@ write one note that names each.
 **Name the tic from the register's vocabulary.** The reader should finish with
 a vocabulary, not forty unrelated opinions.
 
-**Say why this instance is a tic**, not what the category means. "The reader
-never proposed the wrong answer" is a general truth; "the previous paragraph
-proposed quantization, so this contrast is earned" is a note about the text in
-front of you.
+**Say why this instance is a tic.** Explaining the category teaches nothing. *The reader never proposed the wrong answer* is a general
+truth. *The previous paragraph proposed quantization, so this contrast is
+earned* is a note about the text in front of you.
 
 **Note the earned exceptions where they survive.** When a negation or a short
 closer stays in, mark it and say what made it legitimate. The contrast between
@@ -71,8 +70,8 @@ than either alone.
 notes inflates the count and fragments the reading.
 
 **Report contradictions in their own note, marked.** Use `<aside class="ed
-flag"><b>factual</b> …</aside>`. Do not fix them in the rewrite. The author
-decides which version is true.
+flag"><b>factual</b> …</aside>`. Do not fix them in the rewrite, since only the
+author can say which version is true.
 
 ## Structure of the page
 

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -38,7 +38,7 @@ RULES: list[tuple[str, str, str]] = [
     # --- abstraction agency --------------------------------------------------
     ("agency", r"\b(?:the\s+)?(?:table|chart|graph|data|numbers?|median|mean|metric|figure|plot|log|code|result|headline)\s+(?:shows?|hides?|tells?|reveals?|says?|proves?|admits?|knows?|wants?)\b", "inanimate subject acting"),
     ("agency", r"\b(?:is|are|was|were)\s+doing\s+the\s+work\b", "X is doing the work"),
-    ("agency", r"\b(?:earns?|demands?|wants?|buys?|deserves?)\s+(?:its|their|the)\s+\w+", "abstraction earning something"),
+    ("agency", r"(?<!\bI )(?<!\byou )(?<!\bwe )(?<!\bthey )\b(?:earns?|demands?|buys?|deserves?)\s+(?:its|their|the)\s+\w+", "abstraction earning something"),
     ("agency", r"\b(?:truncation|quantization|rescoring|compression|optimization|abstraction|complexity|scalability)\s+(?:cuts?|adds?|breaks?|solves?|reranks?|is a concern)\b", "nominalization as agent"),
     ("agency", r"\b(?:about to|going to)\s+discover\b", "tool personified"),
 
@@ -116,6 +116,17 @@ CATEGORY_ORDER = [
 COMPILED = [(cat, re.compile(pat, re.I | re.M), note) for cat, pat, note in RULES]
 
 
+def _blank_quoted(text: str) -> str:
+    """Blank out quoted specimens, preserving line numbering."""
+    def blank(m: re.Match) -> str:
+        return "\n" * m.group(0).count("\n")
+
+    text = re.sub(r"(?<!\*)\*[^*]+\*(?!\*)", blank, text)      # *italic*, may wrap lines
+    text = re.sub(r"<q>.*?</q>", blank, text, flags=re.S)
+    return "\n".join("" if ln.lstrip().startswith((">", "|")) else ln
+                      for ln in text.splitlines())
+
+
 def scan_lines(text: str) -> list[dict]:
     hits: list[dict] = []
     lines = text.splitlines()
@@ -184,6 +195,9 @@ def _fragment_runs(text: str) -> list[dict]:
 def scan_density(text: str) -> list[dict]:
     out = []
     body = re.sub(r"```.*?```", "", text, flags=re.S)
+    # headings, table rows and list bullets are not sentences
+    body = "\n".join(ln for ln in body.splitlines()
+                      if not ln.lstrip().startswith(("#", "|", "-", "*", ">")))
     words = len(body.split()) or 1
 
     dashes = len(re.findall(r"—|(?<= )--(?= )", body))
@@ -216,9 +230,13 @@ def main() -> int:
     ap.add_argument("path", help="file to scan, or - for stdin")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     ap.add_argument("--quiet-slop", action="store_true", help="hide the slop/editorializing/time categories")
+    ap.add_argument("--skip-quoted", action="store_true",
+                    help="ignore blockquotes, *italic* spans and table cells — use on docs that quote bad prose as specimens")
     args = ap.parse_args()
 
     text = sys.stdin.read() if args.path == "-" else Path(args.path).read_text(encoding="utf-8")
+    if args.skip_quoted:
+        text = _blank_quoted(text)
 
     hits = scan_lines(text) + scan_density(text)
     if args.quiet_slop:


### PR DESCRIPTION
Follow-up to #755. Five files, none of them new work — this is the tail of the same unit that missed the merge window.

## What happened

#755 merged at 12:13:05Z. The commits carrying `README.md` and a round of fixes landed on `skill/declauding` at ~12:16, after the merge, and went with the branch when it was deleted. Main has the state as of PR-open plus the auto-generated CHANGELOG line.

My fault for pushing to a branch already under review instead of opening a second PR (pr-workflow rule 3), and for not re-checking merge state before pushing.

## Contents

- **`README.md`** — missing entirely from main. Repo shape: what it does, mode table, tic table with examples, linter usage, false-positive rationale, complements, dependencies.
- **`--skip-quoted`** on the linter. Blanks blockquotes, table rows, `*italic*` spans and `<q>` elements while preserving line numbers, so a doc that quotes bad prose as specimens stops reporting its own examples. Found while writing the README, which the linter flagged 15 times, almost all of them quoted specimens. Handles italics that wrap across lines.
- **Two linter bug fixes.** The `earns/wants/demands` agency rule fired on ordinary second-person prose ("if you want the noise") — added a pronoun lookbehind. The density checks counted headings, table rows and list bullets as sentences, inflating fragment density on any structured document.
- **The skill's own prose, run through the skill.** It caught two coy headers of mine, four `X, not Y` closers across SKILL.md and annotating.md, one abstraction-agency subject ("a phrase earns its own entry"), and a negation-first closer sitting directly beneath the sentence explaining why negation-first closers are a tic.
- **`CHANGELOG.md`** — restores the 0.1.0 detail the release automation replaced, keeping its generated line under `### Other`, and adds 0.1.1. If the automation is meant to own this file outright, drop the CHANGELOG from this PR and I will leave it alone in future.

`metadata.version` 0.1.0 → 0.1.1, since declauding-v0.1.0 is already cut.

## Verification

    python3 declauding/scripts/declaude_lint.py declauding/tests/sample-tics.md    # 29 candidates, 12 categories
    python3 declauding/scripts/declaude_lint.py declauding/tests/sample-clean.md   # 0
    python3 declauding/scripts/declaude_lint.py declauding/README.md --skip-quoted # 1 (density note)

`validate_skill_file(..., require_version=True)` passes.
