### PR TITLE
agent-routing 1.4.0: correct subagent-inheritance claim, add per-node kernel cost

### DIFF
--- a/agent-routing/CHANGELOG.md
+++ b/agent-routing/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `agent-routing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.4.0] - 2026-08-16
+
+### Changed
+
+- Context handoff: corrected "subagents inherit nothing" — measured on a CCotw Workflow node (run `wf_125b7073-75f`): nodes inherit the project layer (system prompt + CLAUDE.md) but not the conversation or in-session artifacts.
+
+### Added
+
+- Fixed per-node kernel cost: ~33k tokens/node measured for trivial tasks under a heavy CLAUDE.md; budget fan-outs as N × kernel and batch small checkable items into fewer agents.
+
 ## [1.3.0] - 2026-07-24
 
 ### Added

--- a/agent-routing/SKILL.md
+++ b/agent-routing/SKILL.md
@@ -4,7 +4,7 @@ description: Decide which model (Haiku/Sonnet/Opus) and effort level each subage
 compatibility: Designed for Claude Code / Claude Code on the Web — assumes an orchestrator with Agent/Workflow subagent tools exposing per-call model and effort options. Not applicable to claude.ai chat use.
 metadata:
   author: Oskar Austegard and Claude (Fable 5)
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Agent Routing — model + effort selection for subagents
@@ -27,12 +27,17 @@ routing; that one engineers the prompt.
 
 ## Context handoff — routing picks the tier; the prompt carries the context
 
-Subagents inherit nothing: not the conversation, not loaded skills, not the
-existence of artifacts already on disk. Every index, scan output, artifact
-path, or tool-invocation recipe the orchestrator relies on must be serialized
-into the subagent's prompt (or written to a file the prompt points at).
-Otherwise the agent falls back to blind rediscovery — and the tier premium is
-spent on crawling, not judgment. A Sonnet with no handoff wastes more than a
+Subagents do not inherit the conversation — but they are not blank either.
+Measured 2026-08-16 (CCotw Workflow node, run `wf_125b7073-75f`): a node asked
+what context it held reported the full project layer — system prompt, CLAUDE.md
+/ project instructions — and zero knowledge of the conversation that spawned
+it. The split: the project kernel travels automatically; everything the
+orchestrator learned or produced in-session does not — not loaded-skill state,
+not scan output, not the existence of artifacts already on disk. Every index,
+artifact path, or tool-invocation recipe the orchestrator relies on must be
+serialized into the subagent's prompt (or written to a file the prompt points
+at). Otherwise the agent falls back to blind rediscovery — and the tier premium
+is spent on crawling, not judgment. A Sonnet with no handoff wastes more than a
 Haiku with a good procedure.
 
 This is the context-side twin of down-skilling: that skill engineers the
@@ -47,6 +52,19 @@ Evidence: 2026-07-16, four Sonnet Explore agents launched onto a 2,300-file
 repo without the handoff opened with `ls` crawls despite a full tree-sitter
 symbol index sitting on disk; relaunched with per-agent index slices + the
 verbatim tool command + anti-crawl rules, discovery cost dropped to ~zero.
+
+**The inherited kernel is a fixed per-node cost — budget fan-outs as
+N × kernel.** The project layer rides along whether the sub-task needs it or
+not: two trivial Haiku nodes measured 67,085 subagent tokens total (~33k each)
+under a heavy CLAUDE.md (same 2026-08-16 run). For small checkable items the
+kernel dwarfs the task, so batch them — one agent handling ten items pays one
+kernel, ten agents pay ten. Two corollaries: (1) the shared-prefix caching note
+below gets the kernel as a byte-stable shared lead for free, which softens but
+does not erase the N× cost; (2) the inheritance runs one way — a prompt can add
+context to a node, but nothing strips the kernel per-node, so a sub-task that
+needs isolation from the project's own vocabulary cannot get it inside the
+session. Measured once, on a CCotw Workflow node; verify on other surfaces
+before leaning on the exact numbers.
 
 ## Routing table
 


### PR DESCRIPTION
## What changed

The Context handoff section opened with "Subagents inherit nothing: not the conversation, not loaded skills, not the existence of artifacts already on disk." A live probe (CCotw Workflow run `wf_125b7073-75f`, 2026-08-16, prompted by Pierrain's "What if /clear was no longer our job?" post) measured that as wrong in one direction: a node asked what context it held reported the full project layer — system prompt plus CLAUDE.md/boot identity — and zero knowledge of the spawning conversation.

Two edits, both in the Context handoff section:

1. **Corrected the inheritance claim.** The split is now stated as measured: the project kernel travels automatically; everything the orchestrator learned or produced in-session does not. The handoff checklist itself is unchanged — conversation-derived artifacts still must be serialized into the prompt.
2. **Added the fixed per-node kernel cost.** Two trivial Haiku nodes cost 67,085 subagent tokens total (~33k each) under a heavy CLAUDE.md. Routing consequence: budget fan-outs as N × kernel and batch small checkable items into fewer agents. Corollaries noted: the kernel is a byte-stable shared-prefix lead for caching, and the inheritance runs one way (context can be added per-node, the kernel cannot be stripped).

Scope caveat is in the text: measured once, on a CCotw Workflow node — verify on other surfaces before trusting the exact numbers.

`metadata.version` bumped 1.3.0 → 1.4.0 (guidance addition + factual correction), CHANGELOG updated. `plugins/` copy untouched — skill-release.yml regenerates it.

## Verification

Docs-only change; no tests to run. Probe evidence stored as memory `ceef3af6`; per-agent results in the run's `journal.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXRKvqwmu6D2PPi581JtFF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXRKvqwmu6D2PPi581JtFF)_