### PR TITLE
atprotoing 0.2.0 — `feed`: AppView-free Following timeline, threaded reader

### DIFF
--- a/atprotoing/CHANGELOG.md
+++ b/atprotoing/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.2.0 — 2026-08-16
+
+- `feed` command: Following timeline rebuilt from the follow graph + PDSes, with
+  hydration (facets, blob→CDN, quotes, one hop of missing reply ancestors,
+  profile names/avatars) and reply-root threading.
+- `--html` emits a self-contained Preact/htm reader; filters by kind, account,
+  and text; reports egress-blocked PDS hosts and dead repos inline.
+- Prompted by a session where the missing command cost 26 tool calls and
+  produced a flat reverse-chron list.
+
 # atprotoing - Changelog
 
 All notable changes to the `atprotoing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/atprotoing/SKILL.md
+++ b/atprotoing/SKILL.md
@@ -2,7 +2,7 @@
 name: atprotoing
 description: Read Bluesky/ATProto without depending on Bluesky's AppView — interactions on a user's posts, thread replies, any repo's records, and layer-by-layer outage diagnosis. Use when bsky.app or the AppView is down or slow, when a Bluesky read returns timeouts or 5xx, when asked who liked/replied/quoted/reposted something, when pulling live Bluesky context cheaply, or when reading records straight from a PDS. Complements browsing-bluesky, which routes everything through the AppView and fails when it does.
 metadata:
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # ATProtoing
@@ -23,6 +23,7 @@ are large and re-reading them into context defeats the purpose.
 
 | Command | Answers |
 |---|---|
+| `feed [actor] [--hours 3] [--html PATH]` | The Following timeline, threaded |
 | `status [--actor X]` | Which layer is broken right now |
 | `interactions <actor> [--hours 8] [--scan 100]` | Who liked/replied/reposted/quoted recent posts |
 | `thread <at-uri>` | Replies to a post |
@@ -41,6 +42,16 @@ PDS for anything a repo owns — it is authoritative and had no outage.
 | Who interacted with a URI | Constellation (`constellation.microcosm.blue`) |
 | handle ↔ DID ↔ PDS | `plc.directory`, entryway `resolveHandle` |
 | Search, feed generators, chat | AppView only — **no substitute; say so** |
+
+`feed` is the one composite read: there is no AppView-free `getTimeline`, so it
+rebuilds the Following timeline from follows → PLC → each followee's PDS, then
+hydrates what the AppView would have inlined — facet byte-ranges to character
+ranges, blob CIDs to `cdn.bsky.app` URLs, quote and parent URIs to fetched
+records — and threads the result by reply root. `--html` writes a self-contained
+Preact reader (same components as `austegard.com/bsky/thread-reader.html`), so a
+feed request is **one call**, not a fan-out the caller re-derives by hand.
+Ranking, mutes, and blocks live in the AppView and are absent by construction:
+this is the raw follow graph.
 
 Constellation is the persistent index. Do not rebuild one locally: it already
 indexes the whole network, is operated independently of Bluesky PLC, and is

--- a/atprotoing/scripts/atproto.py
+++ b/atprotoing/scripts/atproto.py
@@ -394,6 +394,12 @@ def main(argv=None):
     s = sub.add_parser("thread", help="replies to a post, via Constellation + PDSes")
     s.add_argument("uri")
 
+    s = sub.add_parser("feed", help="following timeline, rebuilt from PDSes")
+    s.add_argument("actor", nargs="?", default="austegard.com")
+    s.add_argument("--hours", type=float, default=3.0)
+    s.add_argument("--html", metavar="PATH", help="write the threaded reader here")
+    s.add_argument("--no-reposts", action="store_true")
+
     s = sub.add_parser("records", help="any collection from any repo")
     s.add_argument("actor")
     s.add_argument("collection")
@@ -425,6 +431,15 @@ def main(argv=None):
                                   for x in r], indent=2))
             else:
                 print(fmt_thread(r))
+        elif a.cmd == "feed":
+            from feed import build, fmt, to_html
+            d = build(a.actor, a.hours, want_reposts=not a.no_reposts)
+            if a.html:
+                print(to_html(d, a.html))
+            if as_json:
+                print(json.dumps(d, indent=1))
+            elif not a.html:
+                print(fmt(d))
         elif a.cmd == "records":
             r = records(a.actor, a.collection, limit=a.limit, conn=conn)
             print(json.dumps(r, indent=2) if as_json else fmt_posts(r))

--- a/atprotoing/scripts/feed.py
+++ b/atprotoing/scripts/feed.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Following-feed reconstruction, AppView-free.
+
+There is no AppView-free `getTimeline`, so the feed is rebuilt from primitives:
+
+    own PDS  -> app.bsky.graph.follow records
+    PLC      -> each followee's DID document -> PDS host
+    each PDS -> app.bsky.feed.post + app.bsky.feed.repost, newest page
+    each PDS -> app.bsky.actor.profile (display name, avatar blob)
+
+Records come back RAW, not hydrated: facets are byte ranges, embeds are blob
+refs, quoted posts are bare URIs. Everything the AppView would have inlined is
+resolved here instead -- byte offsets to character offsets, blob CIDs to
+cdn.bsky.app URLs, quote/parent URIs to fetched records -- so the reader gets
+the same shape `getPostThread` would have handed it.
+
+Output is threaded, not a flat reverse-chron list: posts are clustered by reply
+root, ancestors outside the window are fetched one hop for context, and clusters
+are ordered by most recent activity.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import threading
+
+try:
+    from . import atproto as A
+except ImportError:  # run as a script, not a package
+    import atproto as A
+
+CDN = "https://cdn.bsky.app/img"
+TEMPLATE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "feed_reader.html")
+_lock = threading.Lock()
+
+
+# ── hydration helpers ──────────────────────────────────────────────────
+
+def blob_cid(blob):
+    """Blob ref -> CID string. listRecords renders refs as {'$link': cid}."""
+    if not isinstance(blob, dict):
+        return None
+    ref = blob.get("ref")
+    if isinstance(ref, dict):
+        return ref.get("$link")
+    return ref if isinstance(ref, str) else None
+
+
+def img_url(did, blob, kind="feed_thumbnail"):
+    cid = blob_cid(blob)
+    return f"{CDN}/{kind}/plain/{did}/{cid}@jpeg" if cid else None
+
+
+def char_facets(text, facets):
+    """Byte ranges -> character ranges. The wire format indexes UTF-8 bytes;
+    every renderer indexes characters, and the two diverge on any non-ASCII."""
+    if not facets:
+        return []
+    raw = text.encode("utf8")
+    out = []
+    for f in facets:
+        idx = f.get("index") or {}
+        uri = next((ft.get("uri") for ft in f.get("features", [])
+                    if ft.get("$type") == "app.bsky.richtext.facet#link"), None)
+        tag = next((ft.get("tag") for ft in f.get("features", [])
+                    if ft.get("$type") == "app.bsky.richtext.facet#tag"), None)
+        did = next((ft.get("did") for ft in f.get("features", [])
+                    if ft.get("$type") == "app.bsky.richtext.facet#mention"), None)
+        if not (uri or tag or did):
+            continue
+        try:
+            s = len(raw[:idx["byteStart"]].decode("utf8", "ignore"))
+            e = len(raw[:idx["byteEnd"]].decode("utf8", "ignore"))
+        except (KeyError, TypeError):
+            continue
+        if tag:
+            uri = f"https://bsky.app/hashtag/{tag}"
+        elif did:
+            uri = f"https://bsky.app/profile/{did}"
+        out.append({"s": s, "e": e, "uri": uri})
+    return sorted(out, key=lambda f: f["s"])
+
+
+def embed_of(did, v):
+    """Raw embed record -> renderable structure. Quote URIs are returned for
+    the caller to fetch; blobs become CDN URLs."""
+    e = v.get("embed") or {}
+    t = e.get("$type", "")
+    media = e.get("media") if "recordWithMedia" in t else e
+    mt = (media or {}).get("$type", "")
+    out, quote = None, None
+
+    if "images" in mt:
+        imgs = []
+        for im in media.get("images", []):
+            ar = im.get("aspectRatio") or {}
+            imgs.append({
+                "thumb": img_url(did, im.get("image")),
+                "full": img_url(did, im.get("image"), "feed_fullsize"),
+                "alt": im.get("alt", ""),
+                "ar": f'{ar.get("width", 16)}/{ar.get("height", 9)}',
+            })
+        imgs = [i for i in imgs if i["thumb"]]
+        if imgs:
+            out = {"kind": "images", "images": imgs}
+    elif "video" in mt:
+        ar = media.get("aspectRatio") or {}
+        out = {"kind": "video",
+               "thumb": img_url(did, media.get("video"), "feed_thumbnail"),
+               "ar": f'{ar.get("width", 16)}/{ar.get("height", 9)}'}
+    elif "external" in mt:
+        x = media.get("external") or {}
+        out = {"kind": "link", "uri": x.get("uri", ""), "title": x.get("title", ""),
+               "desc": x.get("description", ""),
+               "thumb": img_url(did, x.get("thumb"))}
+
+    if "record" in t:
+        rec = e.get("record") or {}
+        quote = rec.get("uri") or (rec.get("record") or {}).get("uri")
+    return out, quote
+
+
+def parse_uri(uri):
+    try:
+        did, coll, rkey = uri.split("at://", 1)[1].split("/")
+        return did, coll, rkey
+    except (IndexError, ValueError):
+        return None, None, None
+
+
+# ── identity / profile ─────────────────────────────────────────────────
+
+def profiles(dids, cache):
+    """displayName + avatar per DID, straight from each repo's profile record."""
+    todo = [d for d in dids if d not in cache]
+
+    def one(did):
+        try:
+            i = A.resolve(did, A.db())
+            r = A.http(f"{i['pds']}/xrpc/com.atproto.repo.getRecord",
+                       {"repo": did, "collection": "app.bsky.actor.profile",
+                        "rkey": "self"}, timeout=15, tries=2)
+            v = r.get("value", {})
+            p = {"handle": i["handle"], "name": v.get("displayName") or i["handle"],
+                 "avatar": img_url(did, v.get("avatar"), "avatar_thumbnail")}
+        except Exception:
+            try:
+                h = A.resolve(did, A.db())["handle"]
+            except Exception:
+                h = did
+            p = {"handle": h, "name": h, "avatar": None}
+        with _lock:
+            cache[did] = p
+
+    A.parallel(one, todo, workers=24)
+    return cache
+
+
+# ── the fan-out ────────────────────────────────────────────────────────
+
+def collect(actor, hours=3.0, page=30, want_reposts=True):
+    now = dt.datetime.now(dt.UTC)
+    cutoff = now - dt.timedelta(hours=hours)
+    ceiling = now + dt.timedelta(minutes=10)  # clock skew on client-set times
+    conn = A.db()
+    me = A.resolve(actor, conn)
+
+    follows = A.records(actor, "app.bsky.graph.follow", conn=conn)
+    dids = sorted({r["value"]["subject"] for r in follows})
+
+    ident, fail = {}, {}
+
+    def res(did):
+        try:
+            i = A.resolve(did, A.db())
+            if not i.get("pds"):
+                raise A.Unavailable("no PDS in DID document")
+            with _lock:
+                ident[did] = i
+        except Exception as e:
+            with _lock:
+                fail[did] = str(e)[:90]
+
+    A.parallel(res, dids, workers=24)
+
+    def in_window(v):
+        try:
+            t = dt.datetime.fromisoformat(
+                (v.get("createdAt") or "").replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=dt.UTC)
+        return t if cutoff <= t <= ceiling else None
+
+    posts, reposts = [], []
+
+    def pull(did):
+        i = ident[did]
+        for coll, sink in (("app.bsky.feed.post", posts),
+                           ("app.bsky.feed.repost", reposts)):
+            if coll.endswith("repost") and not want_reposts:
+                continue
+            try:
+                pg = A.http(f"{i['pds']}/xrpc/com.atproto.repo.listRecords",
+                            {"repo": did, "collection": coll, "limit": page},
+                            timeout=20, tries=2)
+            except Exception as e:
+                with _lock:
+                    fail.setdefault(did, str(e)[:90])
+                continue
+            for r in pg.get("records", []):
+                t = in_window(r.get("value", {}))
+                if t:
+                    with _lock:
+                        sink.append((did, r, t))
+
+    A.parallel(pull, list(ident), workers=24)
+    return {"me": me, "now": now, "cutoff": cutoff, "hours": hours,
+            "follows": len(dids), "resolved": len(ident), "fail": fail,
+            "posts": posts, "reposts": reposts, "conn": conn}
+
+
+def fetch_post(uri):
+    did, coll, rkey = parse_uri(uri)
+    if not did:
+        return None
+    i = A.resolve(did, A.db())
+    r = A.http(f"{i['pds']}/xrpc/com.atproto.repo.getRecord",
+               {"repo": did, "collection": coll, "rkey": rkey}, timeout=15, tries=2)
+    return did, r.get("value", {}), rkey
+
+
+def shape(did, v, rkey, at=None, ctx=False):
+    emb, quote = embed_of(did, v)
+    reply = v.get("reply") or {}
+    return {
+        "uri": f"at://{did}/app.bsky.feed.post/{rkey}",
+        "did": did, "rkey": rkey,
+        "at": (at.isoformat() if at else v.get("createdAt", "")),
+        "text": v.get("text", ""),
+        "facets": char_facets(v.get("text", ""), v.get("facets")),
+        "parent": ((reply.get("parent") or {}).get("uri")),
+        "root": ((reply.get("root") or {}).get("uri")),
+        "embed": emb, "quoteUri": quote, "quote": None,
+        "repost": None, "ctx": ctx,
+    }
+
+
+def build(actor="austegard.com", hours=3.0, want_reposts=True):
+    raw = collect(actor, hours, want_reposts=want_reposts)
+    items, seen = {}, set()
+
+    for did, r, t in raw["posts"]:
+        p = shape(did, r["value"], r["uri"].rsplit("/", 1)[1], t)
+        items[p["uri"]] = p
+        seen.add(p["uri"])
+
+    # Reposts: the event is the repost, the content is someone else's record.
+    rp_targets = {}
+    for did, r, t in raw["reposts"]:
+        subj = ((r["value"].get("subject") or {}).get("uri"))
+        if subj:
+            rp_targets.setdefault(subj, []).append((did, t))
+
+    fetched = {}
+
+    def grab(uri):
+        try:
+            got = fetch_post(uri)
+            if got:
+                with _lock:
+                    fetched[uri] = got
+        except Exception:
+            pass
+
+    A.parallel(grab, [u for u in rp_targets if u not in items], workers=24)
+
+    for uri, actors in rp_targets.items():
+        for by_did, t in actors:
+            if uri in items and items[uri].get("repost") is None and uri not in fetched:
+                # already in-window from the author; annotate rather than duplicate
+                items[uri]["repost"] = {"did": by_did, "at": t.isoformat()}
+                continue
+            got = fetched.get(uri)
+            if not got:
+                continue
+            d, v, rk = got
+            p = shape(d, v, rk)
+            p["repost"] = {"did": by_did, "at": t.isoformat()}
+            p["at_event"] = t.isoformat()
+            items[uri + "#rp:" + by_did] = p
+
+    # One hop of missing ancestors, so replies are not orphaned, plus quotes.
+    need = set()
+    for p in list(items.values()):
+        if p["parent"] and p["parent"] not in items:
+            need.add(p["parent"])
+        if p["quoteUri"] and p["quoteUri"] not in items:
+            need.add(p["quoteUri"])
+    fetched2 = {}
+
+    def grab2(uri):
+        try:
+            got = fetch_post(uri)
+            if got:
+                with _lock:
+                    fetched2[uri] = got
+        except Exception:
+            pass
+
+    A.parallel(grab2, sorted(need), workers=24)
+
+    ctx = {}
+    for uri, (d, v, rk) in fetched2.items():
+        ctx[uri] = shape(d, v, rk, ctx=True)
+
+    for p in items.values():
+        if p["quoteUri"]:
+            q = items.get(p["quoteUri"]) or ctx.get(p["quoteUri"])
+            if q:
+                p["quote"] = {k: q[k] for k in
+                              ("uri", "did", "rkey", "at", "text", "facets", "embed")}
+
+    for uri, p in ctx.items():
+        if uri not in items and any(x["parent"] == uri for x in items.values()):
+            items[uri] = p
+
+    prof = profiles({p["did"] for p in items.values()}
+                    | {p["repost"]["did"] for p in items.values() if p["repost"]}
+                    | {(p["quote"] or {}).get("did") for p in items.values() if p["quote"]}
+                    - {None}, {})
+
+    out = []
+    for p in items.values():
+        p.update(prof.get(p["did"], {}))
+        if p["repost"]:
+            p["repost"].update(prof.get(p["repost"]["did"], {}))
+        if p["quote"]:
+            p["quote"].update(prof.get(p["quote"]["did"], {}))
+        p.pop("quoteUri", None)
+        out.append(p)
+    out.sort(key=lambda p: p.get("at_event") or p["at"], reverse=True)
+
+    fails = list(raw["fail"].values())
+    blocked = sorted({f.split(": ", 1)[1] for f in fails if f.startswith("egress blocked")})
+    gone = sum(1 for f in fails if "Could not find repo" in f)
+    return {
+        "actor": raw["me"], "hours": hours,
+        "now": raw["now"].isoformat(), "cutoff": raw["cutoff"].isoformat(),
+        "follows": raw["follows"], "resolved": raw["resolved"],
+        "blocked": blocked, "gone": gone,
+        "other": len(fails) - len(blocked) - gone,
+        "posts": out,
+    }
+
+
+# ── output ─────────────────────────────────────────────────────────────
+
+def fmt(data):
+    ps = data["posts"]
+    live = [p for p in ps if not p["ctx"]]
+    lines = [f"{len(live)} posts · {len({p['did'] for p in live})} authors · "
+             f"{data['cutoff'][11:16]}–{data['now'][11:16]}Z · "
+             f"{data['resolved']}/{data['follows']} follows readable"]
+    if data["blocked"]:
+        lines.append(f"egress-blocked PDSes: {', '.join(data['blocked'])}")
+    lines.append("")
+    for p in live[:40]:
+        tag = "RT " if p["repost"] else ("re " if p["parent"] else "   ")
+        lines.append(f"{(p.get('at_event') or p['at'])[11:16]}Z {tag}"
+                     f"{p.get('handle', p['did'])[:28]:<28} "
+                     + re.sub(r"\s+", " ", p["text"])[:70])
+    if len(live) > 40:
+        lines.append(f"… {len(live) - 40} more (use --html)")
+    return "\n".join(lines)
+
+
+def to_html(data, path):
+    with open(TEMPLATE, encoding="utf8") as f:
+        tpl = f.read()
+    payload = json.dumps(data, ensure_ascii=False).replace("</", "<\\/")
+    with open(path, "w", encoding="utf8") as f:
+        f.write(tpl.replace("/*__FEED_DATA__*/null", payload))
+    return path

--- a/atprotoing/scripts/feed_reader.html
+++ b/atprotoing/scripts/feed_reader.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="ai-disclosure" content="ai-assisted">
+<title>Bluesky Following Feed</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script type="importmap">
+{
+  "imports": {
+    "preact": "https://esm.sh/*preact@10.23.1",
+    "preact/": "https://esm.sh/*preact@10.23.1/",
+    "htm": "https://esm.sh/*htm@3.1.1",
+    "htm/preact": "https://esm.sh/*htm@3.1.1/preact"
+  }
+}
+</script>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; }
+  .post-text { overflow-wrap: anywhere; word-break: break-word; }
+  .avatar-wrap {
+    position: relative; width: 36px; height: 36px; border-radius: 50%;
+    overflow: hidden; flex-shrink: 0; display: flex;
+    align-items: center; justify-content: center;
+    font-weight: 600; font-size: 0.875rem; color: white;
+  }
+  .avatar-wrap img { position: absolute; inset: 0; width: 100%; height: 100%;
+    object-fit: cover; opacity: 0; transition: opacity .15s; }
+  .avatar-wrap img.loaded { opacity: 1; }
+  .avatar-sm { width: 20px; height: 20px; font-size: .65rem; }
+  .ctx-card { opacity: .72; }
+  .thread-rail { border-left: 2px solid #e5e7eb; }
+</style>
+<script>
+  window.FEED = /*__FEED_DATA__*/null;
+  window.avatarHue = function (str) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    return Math.abs(hash) % 360;
+  };
+</script>
+</head>
+<body class="bg-gray-50 min-h-screen">
+<div id="app"><div style="padding:2rem;color:#888">Loading…</div></div>
+
+<script type="module">
+import { render } from 'preact';
+import { useState, useMemo, useEffect, useRef } from 'preact/hooks';
+import { html } from 'htm/preact';
+
+const D = window.FEED;
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function timeAgo(iso) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000), h = Math.floor(diff / 3600000);
+  if (m < 1) return 'now';
+  if (h < 1) return m + 'm';
+  return h + 'h';
+}
+const hhmm = iso => new Date(iso).toISOString().slice(11, 16) + 'Z';
+const postUrl = p => 'https://bsky.app/profile/' + p.did + '/post/' + p.rkey;
+const when = p => p.at_event || p.at;
+
+function DynImg({ url, alt, styleObj, cls }) {
+  const ref = useRef(null);
+  useEffect(() => { if (ref.current && url) ref.current.setAttribute('src', url); }, [url]);
+  return html`<img ref=${ref} alt=${alt || ''} class=${cls || ''} style=${styleObj || {}}
+    onError=${e => e.target.style.display = 'none'} />`;
+}
+
+function Avatar({ author, small }) {
+  const hue = window.avatarHue(author.did || author.handle || '');
+  const letter = (author.name || author.handle || '?')[0].toUpperCase();
+  const cover = { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' };
+  return html`
+    <div class=${'avatar-wrap' + (small ? ' avatar-sm' : '')} style=${'background:hsl(' + hue + ',60%,45%)'}>
+      <span>${letter}</span>
+      ${author.avatar && html`<${DynImg} url=${author.avatar} cls="loaded" styleObj=${cover} />`}
+    </div>`;
+}
+
+// Facets arrive as resolved character ranges; the raw record has only byte
+// ranges and shortened display text, so without them a link is dead text.
+function PostText({ text, facets, cls }) {
+  if (!text) return null;
+  if (!facets || !facets.length) return html`<p class=${cls}>${text}</p>`;
+  const out = [];
+  let cur = 0;
+  facets.forEach((f, i) => {
+    if (f.s > cur) out.push(text.slice(cur, f.s));
+    out.push(html`<a key=${i} href=${f.uri} target="_blank" rel="noopener"
+      class="text-sky-600 hover:underline break-words">${text.slice(f.s, f.e)}</a>`);
+    cur = f.e;
+  });
+  if (cur < text.length) out.push(text.slice(cur));
+  return html`<p class=${cls}>${out}</p>`;
+}
+
+function Embed({ embed }) {
+  if (!embed) return null;
+  if (embed.kind === 'images') {
+    return html`
+      <div class=${'mt-2 grid gap-1 rounded-lg overflow-hidden ' +
+        (embed.images.length > 1 ? 'grid-cols-2' : 'grid-cols-1')}>
+        ${embed.images.map((im, i) => html`
+          <a key=${i} href=${im.full} target="_blank" rel="noopener" class="block">
+            <${DynImg} url=${im.thumb} alt=${im.alt} cls="w-full object-cover max-h-48"
+              styleObj=${{ aspectRatio: im.ar, objectFit: 'cover', width: '100%' }} />
+          </a>`)}
+      </div>`;
+  }
+  if (embed.kind === 'video') {
+    return html`
+      <div class="mt-2 relative rounded-lg overflow-hidden bg-black"
+        style=${'aspect-ratio:' + embed.ar + ';max-height:300px'}>
+        <${DynImg} url=${embed.thumb} alt="Video" cls="w-full h-full"
+          styleObj=${{ width: '100%', height: '100%', objectFit: 'cover', opacity: .8 }} />
+        <div class="absolute inset-0 flex items-center justify-center">
+          <div class="bg-black bg-opacity-60 rounded-full w-12 h-12 flex items-center justify-center">
+            <span style="font-size:1.5rem">▶</span></div>
+        </div>
+      </div>`;
+  }
+  if (embed.kind === 'link') {
+    return html`
+      <a href=${embed.uri} target="_blank" rel="noopener"
+        class="block mt-2 rounded-lg border border-gray-200 bg-gray-50 hover:bg-gray-100 overflow-hidden no-underline">
+        ${embed.thumb && html`<${DynImg} url=${embed.thumb} cls="w-full object-cover max-h-32"
+          styleObj=${{ width: '100%', objectFit: 'cover', maxHeight: '8rem' }} />`}
+        <div class="p-2">
+          <div class="text-xs font-semibold text-gray-800 post-text">${embed.title}</div>
+          ${embed.desc && html`<div class="text-xs text-gray-500 post-text mt-0.5 line-clamp-2">${embed.desc}</div>`}
+          <div class="text-xs text-gray-400 mt-1 truncate">${embed.uri}</div>
+        </div>
+      </a>`;
+  }
+  return null;
+}
+
+function Quoted({ q }) {
+  if (!q) return null;
+  return html`
+    <a href=${postUrl(q)} target="_blank" rel="noopener"
+      class="block mt-2 rounded-lg border border-gray-200 bg-white p-2 hover:bg-gray-50 no-underline">
+      <div class="flex items-center gap-1.5 mb-1">
+        <${Avatar} author=${q} small=${true} />
+        <span class="text-xs font-semibold text-gray-700">${q.name || q.handle}</span>
+        <span class="text-xs text-gray-400">@${q.handle}</span>
+      </div>
+      <${PostText} text=${q.text} facets=${q.facets} cls="text-xs text-gray-700 post-text" />
+      <${Embed} embed=${q.embed} />
+    </a>`;
+}
+
+// ── clustering: conversation, not chronology ─────────────────────────────
+
+function cluster(posts) {
+  const byUri = new Map();
+  posts.forEach(p => { if (!byUri.has(p.uri)) byUri.set(p.uri, p); });
+  const groups = new Map();
+  posts.forEach(p => {
+    let key = p.root || p.uri;
+    if (!byUri.has(key)) key = byUri.has(p.parent) ? p.parent : p.uri;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(p);
+  });
+  const out = [];
+  for (const [key, members] of groups) {
+    const kids = new Map();
+    const roots = [];
+    members.forEach(p => {
+      if (p.parent && members.some(m => m.uri === p.parent) && p.parent !== p.uri) {
+        if (!kids.has(p.parent)) kids.set(p.parent, []);
+        kids.get(p.parent).push(p);
+      } else roots.push(p);
+    });
+    const build = p => ({ post: p, kids: (kids.get(p.uri) || [])
+      .sort((a, b) => when(a).localeCompare(when(b))).map(build) });
+    const tree = roots.sort((a, b) => when(a).localeCompare(when(b))).map(build);
+    const latest = members.reduce((m, p) => when(p) > m ? when(p) : m, '');
+    const live = members.filter(p => !p.ctx).length;
+    out.push({ key, tree, latest, size: live, members });
+  }
+  return out.sort((a, b) => b.latest.localeCompare(a.latest));
+}
+
+// ── cards ────────────────────────────────────────────────────────────────
+
+function Card({ node, depth }) {
+  const p = node.post;
+  const [open, setOpen] = useState(true);
+  const kids = node.kids || [];
+  return html`
+    <div class=${depth ? 'mt-2 pl-3 thread-rail' : ''}>
+      <div class=${'rounded-lg border border-gray-200 bg-white p-3 ' + (p.ctx ? 'ctx-card' : '')}>
+        ${p.repost && html`
+          <div class="text-xs text-gray-500 mb-1.5 flex items-center gap-1">
+            <span>🔁</span>
+            <span>reposted by ${p.repost.name || p.repost.handle}</span>
+          </div>`}
+        <div class="flex items-start gap-2">
+          <${Avatar} author=${p} />
+          <div class="min-w-0 flex-1">
+            <div class="flex items-baseline gap-1.5 flex-wrap">
+              <span class="text-sm font-semibold text-gray-900">${p.name || p.handle}</span>
+              <span class="text-xs text-gray-400">@${p.handle}</span>
+              <a href=${postUrl(p)} target="_blank" rel="noopener"
+                class="text-xs text-gray-400 hover:text-sky-600 no-underline"
+                title=${when(p)}>· ${hhmm(when(p))} (${timeAgo(when(p))})</a>
+              ${p.ctx && html`<span class="text-xs px-1.5 rounded bg-gray-100 text-gray-500">context — outside window</span>`}
+              ${kids.length > 0 && html`
+                <button onClick=${() => setOpen(!open)}
+                  class="text-xs text-gray-400 hover:text-sky-600 ml-auto">
+                  ${open ? '▾' : '▸'} ${kids.length}</button>`}
+            </div>
+            <${PostText} text=${p.text} facets=${p.facets} cls="text-sm text-gray-800 post-text mt-1" />
+            <${Embed} embed=${p.embed} />
+            <${Quoted} q=${p.quote} />
+          </div>
+        </div>
+      </div>
+      ${open && kids.map(k => html`<${Card} node=${k} depth=${depth + 1} />`)}
+    </div>`;
+}
+
+function Cluster({ c }) {
+  return html`
+    <div class="mb-4">
+      ${c.size > 1 && html`
+        <div class="text-xs text-gray-400 mb-1 pl-1">
+          ${c.size} posts in conversation</div>`}
+      ${c.tree.map(n => html`<${Card} node=${n} depth=${0} />`)}
+    </div>`;
+}
+
+// ── app ──────────────────────────────────────────────────────────────────
+
+function App() {
+  const [mode, setMode] = useState('all');
+  const [q, setQ] = useState('');
+  const [author, setAuthor] = useState('');
+
+  const live = D.posts.filter(p => !p.ctx);
+  const authors = useMemo(() => {
+    const m = new Map();
+    live.forEach(p => m.set(p.handle, (m.get(p.handle) || 0) + 1));
+    return [...m].sort((a, b) => b[1] - a[1]);
+  }, []);
+
+  const clusters = useMemo(() => {
+    const term = q.trim().toLowerCase();
+    const keep = D.posts.filter(p => {
+      if (p.ctx) return true;
+      const kind = p.repost ? 'repost' : (p.parent ? 'reply' : 'post');
+      if (mode === 'media' ? !p.embed : (mode !== 'all' && kind !== mode)) return false;
+      if (author && p.handle !== author) return false;
+      if (term && !((p.text + ' ' + p.handle + ' ' + (p.name || '')).toLowerCase().includes(term)))
+        return false;
+      return true;
+    });
+    const liveUris = new Set(keep.filter(p => !p.ctx).map(p => p.uri));
+    // context posts survive only when something they anchor did
+    const pruned = keep.filter(p => !p.ctx || keep.some(x => !x.ctx && (x.parent === p.uri)));
+    return cluster(pruned).filter(c => c.size > 0);
+  }, [mode, q, author]);
+
+  const shown = clusters.reduce((n, c) => n + c.size, 0);
+  const chip = (id, label) => html`
+    <button onClick=${() => setMode(id)}
+      class=${'px-2.5 py-1 rounded-full text-xs border ' + (mode === id
+        ? 'bg-sky-600 text-white border-sky-600'
+        : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-100')}>${label}</button>`;
+
+  return html`
+    <div class="max-w-2xl mx-auto p-4">
+      <header class="mb-4">
+        <h1 class="text-xl font-bold text-gray-900">Following feed — last ${D.hours}h</h1>
+        <p class="text-xs text-gray-500 mt-0.5">
+          ${D.actor.handle} · ${D.cutoff.slice(11, 16)}–${D.now.slice(11, 16)}Z ${D.now.slice(0, 10)}
+          · ${live.length} posts from ${authors.length} accounts
+          · ${D.resolved}/${D.follows} follows readable
+          · rebuilt from PDS records, no AppView
+        </p>
+      </header>
+
+      <div class="sticky top-0 bg-gray-50 pt-1 pb-2 z-10">
+        <div class="flex gap-1.5 flex-wrap items-center">
+          ${chip('all', 'all')} ${chip('post', 'originals')} ${chip('reply', 'replies')}
+          ${chip('repost', 'reposts')} ${chip('media', 'media')}
+          <input value=${q} onInput=${e => setQ(e.target.value)} placeholder="filter…"
+            class="flex-1 min-w-[8rem] px-2 py-1 text-xs border border-gray-300 rounded-md" />
+          <select value=${author} onChange=${e => setAuthor(e.target.value)}
+            class="px-2 py-1 text-xs border border-gray-300 rounded-md bg-white max-w-[10rem]">
+            <option value="">all accounts</option>
+            ${authors.map(([h, n]) => html`<option value=${h}>${h} (${n})</option>`)}
+          </select>
+        </div>
+        <div class="text-xs text-gray-400 mt-1">${shown} posts · ${clusters.length} conversations</div>
+      </div>
+
+      ${clusters.map(c => html`<${Cluster} key=${c.key} c=${c} />`)}
+      ${!clusters.length && html`<div class="text-sm text-gray-500 p-6 text-center">Nothing matches.</div>`}
+
+      <footer class="mt-6 pt-3 border-t border-gray-200 text-xs text-gray-500 space-y-1">
+        <div><strong>Coverage.</strong> ${D.resolved} of ${D.follows} follows resolved;
+          ${D.gone} dead repos, ${D.other} transient failures.</div>
+        ${D.blocked.length > 0 && html`
+          <div><strong>Egress-blocked PDSes</strong> (their posts are missing):
+            ${D.blocked.join(', ')}</div>`}
+        <div>Ordering uses each record's client-set <code>createdAt</code> — approximate,
+          not attested. No mutes, blocks, or feed-generator ranking: that logic is
+          AppView-only, so this is the raw Following graph.</div>
+      </footer>
+    </div>`;
+}
+
+render(html`<${App} />`, document.getElementById('app'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
There is no AppView-free `getTimeline`, so a feed request had no command behind it.
The gap cost a live session 26 tool calls of hand-rolled fan-out in `/home/claude`
— thrown away with the container — and still produced a flat reverse-chron list.

**`atproto.py feed [actor] [--hours 3] [--html PATH]`**

- follows (own PDS) → PLC → `listRecords` on each followee's PDS for
  `feed.post` + `feed.repost`, 24-way parallel.
- Hydration, because PDS records are raw where AppView views are not: facet
  **byte** ranges → character ranges, blob CIDs → `cdn.bsky.app` URLs,
  quote/parent URIs fetched from their authors' PDSes, profile records for
  display names and avatars.
- One hop of out-of-window ancestors so replies aren't orphaned; rendered
  dimmed and labelled as context.
- Threading by reply root, clusters ordered by latest activity.
- `--html` writes a self-contained Preact/htm reader reusing
  `austegard.com/bsky/thread-reader.html`'s components (Avatar, PostText
  facets, ImageGrid, ExternalCard, Quoted). Filters by kind, account, text.
- Egress-blocked PDS hosts and dead repos reported in the artifact footer
  rather than reconstructed afterwards.

Measured on 854 follows / 3h: 278 posts, 51 reposts, 140 replies, 36 quotes,
96 embeds, 10 egress-blocked hosts, 18 dead repos. ~90s wall clock, one call.

Limits unchanged and stated in the UI: ranking, mutes, and blocks are AppView
logic and absent by construction.