### PR TITLE
declauding v0.2.0 — absorb the encyclopedic and chatbot register from humanizer

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-08-16
+
+Absorbs what a comparison against [blader/humanizer](https://github.com/blader/humanizer)
+v2.9.1 (MIT) showed this skill was missing. Humanizer packages the Wikipedia AI
+Cleanup project's *Signs of AI writing*; its coverage of encyclopedic and chatbot
+slop is broader than the two vocabulary entries this register had.
+
+Measured before porting: a probe of 19 humanizer specimens produced 2 candidates
+from `declaude_lint.py`, neither for the right reason. It now produces 33 across
+13 categories.
+
+### Added
+
+- Register entries 24 to 36, in a second block that names itself as a different
+  family from the staging mechanisms: copula avoidance, participle tail, forced
+  triad, elegant variation, false range, inline-header list, typographic tells,
+  chatbot residue, filler and hedge stacking, speculative gap-filling,
+  diff-anchored documentation, subjectless fragment, predicate-position
+  hyphenation. The block states that several of them are phrase lists rather than
+  mechanisms and will leak.
+- "Do not invent specifics" in `SKILL.md`, and a fourth failure mode in workflow
+  step 5. De-vaguing a sentence is how a register pass fabricates, and the skill
+  previously warned only against changing claims, not against supplying a name or
+  number the source does not have.
+- Voice-sample precedence. A sample of the author's writing outranks every rule
+  here, including the em-dash density guard.
+- Three invocation modes: pasted text, file, and embedded (another agent calling
+  this as one step, which returns text and nothing else).
+- "Leave these alone" section: the positive signals of human writing, and the
+  things that are not tells on their own.
+- Linter rules for the new lexical entries, plus Title Case heading detection and
+  document-level curly-quote and emoji counts. Eleven new categories.
+- 13 new specimens in `tests/sample-tics.md`, which now reports 58 candidates
+  across 23 categories. `tests/sample-clean.md` stays at 0.
+
+### Changed
+
+- Content preservation now licenses structural rearrangement: every claim
+  survives, but paragraphs may merge or split and depth need not be uniform.
+
 ## [0.1.1] - 2026-08-16
 
 ### Other

--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -42,6 +42,17 @@ from `declaude_lint.py`, neither for the right reason. It now produces 33 across
 - Content preservation now licenses structural rearrangement: every claim
   survives, but paragraphs may merge or split and depth need not be uniform.
 
+### Fixed
+
+- `--skip-quoted` blanked spans before lines, so a bold marker inside a table
+  cell could mis-pair the italic regex across lines and leave that row's
+  specimens visible. It also never blanked code, so a tell quoted in backticks
+  reported as a hit. Fenced blocks and inline spans are blanked now, and the
+  line pass runs first.
+- The emoji count included U+2190 to U+21FF and U+2300 to U+23FF, so a plain
+  arrow or a technical symbol in ordinary prose reported as decoration.
+  Narrowed to the emoji-presentation blocks.
+
 ## [0.1.1] - 2026-08-16
 
 ### Other

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -87,6 +87,10 @@ header shape, Title Case headings, one-line-paragraph beats, fragment runs,
 inline-header bullets, em-dash density, curly-quote and emoji counts, and
 sentence-length monotony.
 
+`--skip-quoted` blanks blockquotes, table rows, code (fenced and inline),
+`*italic*` spans and `<q>` elements while preserving line numbers. Use it on any
+document that quotes bad prose as a specimen, this README included.
+
 It finds candidates and does not decide. Every hit still needs the
 sentence-level test, and no regex reaches a staged paragraph shape or a staged
 closer, so **a clean report means nothing on its own.**

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -4,16 +4,17 @@ Removes LLM prose tics from a draft and returns plain human technical prose. The
 input is text; the output is either the rewritten text or an annotated HTML diff
 showing every edit with its original and its reason.
 
-Almost every tic it catches is one move: **the sentence is built to make the
-reader feel a finding arrive, instead of stating the finding.** The register
-catalogues the shapes that move takes. The fix is always the same: put a real
-subject in the subject slot, say the thing, stop.
+The register has two halves. Entries 1 to 23 are one move: **the sentence is
+built to make the reader feel a finding arrive, instead of stating the finding.**
+The fix is always the same: put a real subject in the subject slot, say the
+thing, stop. Entries 24 to 36 are the flatter slop patterns, where nothing is
+being staged and the prose is running on defaults.
 
 See [`SKILL.md`](SKILL.md) for the workflow, the overcorrection guard and the
 earned-exception table. See [`references/register.md`](references/register.md)
 for the catalogue. See [`CHANGELOG.md`](CHANGELOG.md) for version history.
 
-## Two modes
+## Two output modes
 
 | Mode | Output | Use for |
 |---|---|---|
@@ -23,11 +24,16 @@ for the catalogue. See [`CHANGELOG.md`](CHANGELOG.md) for version history.
 The annotated file has a toggle that hides the marks, so the same artifact
 serves as both the review and the result. No build step, no CDN, no server.
 
+Three call shapes change what comes back: pasted text returns the rewrite plus a
+short change list, file mode rewrites in place and reports a summary, and
+embedded mode (another agent calling this as one step) returns the final text
+and nothing else.
+
 ## Tics it catches
 
-Twenty-three entries in the register, grouped by mechanism rather than by
-phrase, since phrase blocklists miss the next paraphrase. The ones that show
-up in nearly every draft:
+Thirty-six entries. The first 23 are grouped by mechanism rather than by phrase,
+since phrase blocklists miss the next paraphrase. The ones that show up in nearly
+every draft:
 
 | Tic | Example |
 |---|---|
@@ -40,8 +46,32 @@ up in nearly every draft:
 | Straw-man knockdown | *"It thinks twice as long" is the obvious reading, and it is wrong.* |
 | Fragment cadence | *Six legs. One GPU, one server build, one sampler, one question set.* |
 
-Each entry carries the surface tell, why it is a tic, the fix, and a real
-before-and-after taken from a published draft.
+Entries 24 to 36 come from the Wikipedia AI Cleanup project's *Signs of AI
+writing*, by way of [blader/humanizer](https://github.com/blader/humanizer).
+They cover the register that shows up in encyclopedic summary, product copy,
+README boilerplate and pasted chat:
+
+| Tic | Example |
+|---|---|
+| Copula avoidance | *Gallery 825 serves as the exhibition space and boasts 3,000 square feet.* |
+| Participle tail | *…resonates with the region's beauty, symbolizing bluebonnets, reflecting the community's connection.* |
+| Forced triad | *keynote sessions, panel discussions, and networking opportunities* |
+| Elegant variation | *The protagonist… the main character… the central figure…* |
+| False range | *from the Big Bang to the cosmic web, from stars to dark matter* |
+| Inline-header list | *- **Performance:** Performance has been enhanced through optimized algorithms.* |
+| Chatbot residue | *I hope this helps! Let me know if you'd like me to expand on any section.* |
+| Filler and hedge stacking | *It could potentially possibly be argued that…* |
+| Speculative gap-filling | *…not publicly available, suggesting she maintains a low profile.* |
+| Diff-anchored documentation | *This function was added to replace the previous approach…* |
+| Subjectless fragment | *No configuration file needed. The results are preserved automatically.* |
+
+Each entry carries the surface tell, why it is a tic, the fix, and a
+before-and-after. The first 23 come from a real published draft; the second block
+keeps the Wikipedia specimens.
+
+Several of the second block are phrase lists rather than mechanisms, which is a
+real limitation and is stated as one in the register. They earn their place by
+being cheap to check.
 
 ## The linter
 
@@ -53,7 +83,8 @@ python3 scripts/declaude_lint.py DOC.md --skip-quoted # ignore quoted specimens
 ```
 
 Stdlib only. It flags the lexical tells with line numbers and categories, plus
-header shape, one-line-paragraph beats, fragment runs, em-dash density and
+header shape, Title Case headings, one-line-paragraph beats, fragment runs,
+inline-header bullets, em-dash density, curly-quote and emoji counts, and
 sentence-length monotony.
 
 It finds candidates and does not decide. Every hit still needs the
@@ -66,11 +97,11 @@ as a pre-commit hook.
 ## False positives
 
 `tests/sample-clean.md` is human-written prose and must lint to zero.
-`tests/sample-tics.md` is a corpus of real specimens and currently reports 29
-candidates across 12 categories.
+`tests/sample-tics.md` is a corpus of real specimens and currently reports 58
+candidates across 23 categories.
 
 ```sh
-python3 scripts/declaude_lint.py tests/sample-tics.md    # 29 candidates
+python3 scripts/declaude_lint.py tests/sample-tics.md    # 58 candidates
 python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
 ```
 
@@ -117,11 +148,43 @@ reports zero, bump `metadata.version`.
 Add a phrase to the register after two sightings in real drafts. One sighting
 can be a choice; two is a habit.
 
+## It must not invent specifics
+
+The fix for a vague sentence is a specific one, which is exactly how a register
+pass fabricates. *Experts believe it plays a crucial role* may become *the
+sources here do not say who studies it*, or may be cut. It may not become
+*researchers at Lanzhou University*. No name, number, date, quote or citation
+enters the rewrite unless the source or the author put it there. Stance and
+opinion are voice and stay; a factual claim the author did not make is a defect
+even when the result reads more human.
+
+## The author's own writing wins
+
+Given a sample of the author's writing, match its habits and let it override the
+rules here, including the em-dash density guard. Scrubbing a tell that is
+actually someone's voice makes the text less like them and no more human.
+
 ## Provenance
 
-Built from a register pass on an external benchmark post (2026-08-16), where 34
-passages carried about 45 tic instances across ten shapes. Every specimen in the
-register and the test corpus comes from a real published draft.
+Entries 1 to 23 came from a register pass on an external benchmark post
+(2026-08-16), where 34 passages carried about 45 tic instances across ten shapes.
+Every specimen in that half comes from a real published draft.
+
+Entries 24 to 36 came from a comparison against
+[blader/humanizer](https://github.com/blader/humanizer) (v2.9.1, MIT), which
+packages the Wikipedia AI Cleanup project's
+[Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
+as a portable skill. Measured before porting: a probe file of 19 humanizer
+specimens produced 2 candidates from this linter, neither for the right reason.
+It now produces 33 across 13 categories. The no-fabrication rule, the
+voice-sample precedence, the embedded invocation mode and the "leave these alone"
+list are also from that skill.
+
+The two skills cover different halves of the problem and both remain worth
+reading. Humanizer is broader on encyclopedic and promotional slop and ships as a
+harness-neutral single file; this one goes deeper on the staging mechanisms,
+ships a linter with a false-positive budget, and treats a tic as a signal that
+the sentence may also be factually wrong.
 
 ## Complements
 

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: declauding
-description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
+description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.1.1
+  version: 0.2.0
 ---
 
 # Declauding
@@ -15,6 +15,33 @@ Two output modes:
   passage marked, each with the original, the tic name, and why it goes. A
   toggle hides the marks so the result can be read straight through.
 
+Three ways it gets called, which change what you deliver:
+- **Pasted text** (default) — the user gives text in the conversation. Return
+  the rewrite, plus a short list of what changed if the edit was substantial.
+- **File** — the user points at a path. Rewrite the file in place and report a
+  summary in the conversation rather than pasting the whole result back. Edit
+  prose only: leave code blocks, frontmatter, data, link targets and quoted
+  specimens alone.
+- **Embedded** — another skill or agent is calling this as one step of a larger
+  job (a PR description, a commit message, a doc). Return the final text and
+  nothing else. No preamble, no summary, no tic list.
+
+## Do not invent specifics
+
+The rewrite must not contain a fact, name, number, date, quote or citation that
+is not in the source. This is the failure mode the skill invites rather than
+prevents: the fix for a vague sentence is a specific one, and the specific has
+to come from the source or from the author.
+
+*Experts believe it plays a crucial role* becomes *the sources here do not say
+who studies it*, or gets cut. It does not become *researchers at Lanzhou
+University* unless the source says so. When a sentence needs real-world detail
+to work, ask for it or write the plain version without it.
+
+Opinions and stance are voice, not facts. Keeping the author's judgment is
+required (see Overcorrection); adding a factual claim they did not make is a
+defect even when the result reads more human.
+
 ## The one pattern
 
 Almost every tic in `references/register.md` is a version of the same move:
@@ -23,6 +50,24 @@ stating the finding.**
 
 The generative test, applied per sentence: *am I saying the thing, or
 performing having had the thought?* Say the thing.
+
+Entries 24 to 36 are a second family — the flatter encyclopedic and chatbot
+patterns, where nothing is being staged and the writing is just running on
+defaults. Copula avoidance, participle tails, forced triads, chatbot residue.
+Different mechanism, same pass.
+
+## The author's own writing outranks this skill
+
+If the user supplies a sample of their writing, read it before editing and match
+its habits: sentence lengths, paragraph openings, punctuation, recurring
+phrases, vocabulary level. Do not upgrade casual words, regularize deliberate
+quirks, or apply a register rule the sample contradicts.
+
+The sample wins over every rule here, including the em-dash density guard in
+entry 16. If the author uses em dashes at three per hundred words, that is their
+voice, and scrubbing the tell would make the text less like them and no more
+human. The same holds for their existing published work when it is available and
+the current draft is not.
 
 ## Workflow
 
@@ -52,12 +97,16 @@ lexical. Treat a clean lint report as meaningless on its own.
 questions, and the closer (does the last paragraph paraphrase the subtext of
 what preceded it? delete it).
 
-**5. Check what the edit did.** Three failure modes, all of them common:
+**5. Check what the edit did.** Four failure modes, all of them common:
 - Content lost. Every fact, number, caveat and hedge-with-content in the source
   must survive. A tic wrapping a real qualification is still a real
-  qualification.
+  qualification. Structure is free — merge or split paragraphs, compress the dull
+  parts, dwell where the author would. When keeping the information and mirroring
+  the original's shape pull against each other, the information wins.
 - Claims changed. Rewriting "the drop is largest where chains are longest" into
   "long chains cause the drop" is an edit that invents a finding. Register only.
+- Facts invented. Ask it directly: does the rewrite state any name, number, date
+  or citation that is not in the source? See "Do not invent specifics" above.
 - Mush. See Overcorrection below.
 
 **6. Report factual problems separately.** Never silently fix a contradiction
@@ -83,6 +132,35 @@ opinions. That is worse than the tics.
   stays.
 - Digression, asides and mild informality are human. Symmetry, antithesis and
   balanced parallel clauses are not.
+
+## Leave these alone
+
+These are evidence of a person writing. Editing them out is how a register pass
+makes a draft worse, and each one is easier to destroy than to put back.
+
+- **Specific, hard-to-fabricate detail.** A street name, an odd quote, "the guy
+  who used to run the build before he left". Models round specifics off; people
+  hoard them.
+- **Mixed feelings and unresolved tension.** *I think this is mostly right and it
+  still bothers me and I cannot say why.* Clean takes are the model default.
+- **Genuine self-interruption.** A parenthesis that corrects the sentence it sits
+  in, an aside that goes nowhere. Models rarely interrupt themselves.
+- **Repetition of a word** where a synonym would be worse. That is entry 27 read
+  in the right direction.
+- **Uneven depth.** Three paragraphs on the part the author cares about and one
+  line on the part they do not is how people write.
+- **Dated and subcultural references.** Slang or in-jokes pinned to a year.
+
+Things that are not tells on their own, and should not be edited on their own:
+polished grammar, formal vocabulary, a mixed casual-and-formal register, curly
+quotes, a single em dash, one short emphatic sentence, an unsourced claim, a
+salutation or sign-off. Look for **clusters**. One em dash is punctuation; em
+dashes plus a forced triad plus *vibrant tapestry* plus a Conclusion section is a
+confession.
+
+Do not edit a watched phrase inside a quotation, a title, a proper name, or an
+example where the phrase is being discussed rather than used. The linter's
+`--skip-quoted` does this mechanically; do it by eye too.
 
 ## Earned exceptions
 

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -337,6 +337,267 @@ drop, "exactly" where the contrast already carries it.
 
 ---
 
+# Encyclopedic and chatbot patterns
+
+Entries 1 to 23 are staging mechanisms: a sentence built so the reader feels a
+finding arrive. Entries 24 to 36 are a different family. They come from the
+Wikipedia AI Cleanup project's *Signs of AI writing*, by way of the
+[humanizer](https://github.com/blader/humanizer) skill, and they show up in the
+flatter registers — encyclopedic summary, product copy, README boilerplate,
+pasted chat transcripts — where the writing is not staging anything, just
+running on defaults.
+
+Several of these are surface patterns rather than mechanisms, which is a real
+limitation: a phrase list misses the next paraphrase, and entries 30 and 31 in
+particular are lists. They stay because they are cheap to check and they fire on
+text nobody would otherwise re-read.
+
+---
+
+## 24. Copula avoidance
+
+**Tell:** "serves as", "stands as", "represents", "marks", "boasts", "features",
+"offers" where "is" or "has" would do.
+
+**Why:** the elaborate verb adds a beat of ceremony and usually a claim the
+source does not make. "Serves as" implies purpose; "is" states a fact.
+
+**Fix:** use the copula.
+
+> was: *Gallery 825 serves as LAAA's exhibition space. The gallery features four
+> separate spaces and boasts over 3,000 square feet.*
+> now: *Gallery 825 is LAAA's exhibition space. It has four rooms totalling 3,000
+> square feet.*
+
+---
+
+## 25. Participle tail
+
+**Tell:** a clause tacked onto the end of a sentence with a present participle —
+"highlighting", "underscoring", "emphasizing", "reflecting", "symbolizing",
+"showcasing", "ensuring", "fostering", "contributing to", "encompassing".
+
+**Why:** the tail asserts significance the sentence has not earned, and it is
+almost always unsourced. Two or three stacked in one sentence is the strongest
+single tell in this family.
+
+**Fix:** cut the tail. If the claim inside it is real and sourced, make it its
+own sentence.
+
+> was: *The temple's palette resonates with the region's natural beauty,
+> symbolizing Texas bluebonnets and the Gulf of Mexico, reflecting the
+> community's deep connection to the land.*
+> now: *The temple is painted blue, green and gold, colours chosen to evoke
+> Texas bluebonnets and the Gulf of Mexico.*
+
+---
+
+## 26. Forced triad
+
+**Tell:** three parallel items where the content has two or five — "keynote
+sessions, panel discussions, and networking opportunities", "innovation,
+inspiration, and industry insights".
+
+**Why:** three reads as complete, so the model pads to three or truncates to
+three. The count is chosen by rhythm rather than by the content.
+
+**Fix:** list what there is. Two items is a normal number.
+
+> was: *The event features keynote sessions, panel discussions, and networking
+> opportunities.*
+> now: *The event has talks and panels, with time between them to talk to people.*
+
+**Earned when** there are genuinely three things.
+
+---
+
+## 27. Elegant variation
+
+**Tell:** the same referent renamed on every mention — protagonist, main
+character, central figure, hero; the model, the system, the network, the
+architecture.
+
+**Why:** repetition penalties push the next token away from the word already
+used. Human technical writers repeat the noun, because a second name for a thing
+reads as a second thing.
+
+**Fix:** pick the noun and keep it. Repetition is clarity here, not a defect.
+
+> was: *The protagonist faces many challenges. The main character must overcome
+> obstacles. The central figure eventually triumphs.*
+> now: *The protagonist faces many challenges and eventually wins.*
+
+---
+
+## 28. False range
+
+**Tell:** "from X to Y" where X and Y are not endpoints of any scale — "from the
+Big Bang to dark matter", "from startups to enterprises", "from onboarding to
+retention".
+
+**Why:** the construction promises a spectrum and delivers two examples, so it
+implies coverage the sentence does not have.
+
+**Fix:** list the items, or name the actual range with its actual endpoints.
+
+> was: *Our journey has taken us from the singularity of the Big Bang to the
+> grand cosmic web, from the birth of stars to the dance of dark matter.*
+> now: *The book covers the Big Bang, star formation and current theories about
+> dark matter.*
+
+---
+
+## 29. Inline-header list
+
+**Tell:** bullets that open with a bolded label and a colon, where the label
+restates the first words of the item — `- **Performance:** Performance has been
+improved`.
+
+**Why:** it is an outline rendered as prose. The labels carry no information the
+sentences do not, and the shape survives from the model's plan into the output.
+
+**Fix:** write the paragraph, or cut the labels and keep the bullets, or keep the
+labels only where they are a real index (a term being defined, an option name).
+
+> was: *- **Performance:** Performance has been enhanced through optimized
+> algorithms.*
+> now: *Load times dropped after the index moved off the hot path.*
+
+---
+
+## 30. Typographic tells
+
+**Tell:** bold scattered mid-sentence on phrases that are not terms; Title Case
+On Every Word Of A Heading; emoji as bullet or heading decoration; curly quotes
+in a plain-text or code context.
+
+**Why:** none of these is wrong on its own, and each has an innocent source
+(Word, a CMS, a house style). They matter as a cluster, and they matter most in
+documents where the surrounding convention is clearly different.
+
+**Fix:** bold for terms on first use and nothing else; sentence case in headings;
+no emoji unless the document already uses them; straight quotes in anything a
+program will read.
+
+**Not a tell on its own.** Curly quotes are the default in most editors, and one
+bolded term is normal writing.
+
+---
+
+## 31. Chatbot residue
+
+**Tell:** the conversational wrapper left in the pasted text — "Great question",
+"Certainly", "You're absolutely right", "I hope this helps", "Let me know if
+you'd like", "Would you like me to", "Want me to give examples", "Here is an
+overview of".
+
+**Why:** it is correspondence, not content. It reaches the document because
+someone pasted a reply rather than an artifact.
+
+**Fix:** delete. There is no rewrite; the sentence has no content.
+
+---
+
+## 32. Filler and hedge stacking
+
+**Tell:** phrases that expand without adding — "in order to", "due to the fact
+that", "at this point in time", "in the event that", "has the ability to", "it is
+important to note that"; and hedges in series — "could potentially possibly",
+"might arguably suggest".
+
+**Why:** each is a token-cheap way to sound careful. Stacked hedges do not make a
+claim more careful, only harder to hold to.
+
+**Fix:** "to", "because", "now", "if", "can". One hedge carries all the
+uncertainty three of them do.
+
+> was: *It could potentially possibly be argued that the policy might have some
+> effect on outcomes.*
+> now: *The policy may affect outcomes.*
+
+**Do not overcorrect.** A hedge with content ("on the two runs that finished") is
+a caveat and stays. See the Overcorrection section of `SKILL.md`.
+
+---
+
+## 33. Speculative gap-filling
+
+**Tell:** "while specific details are limited", "based on available information",
+"not publicly available", "maintains a low profile", "keeps personal details
+private", "likely grew up", "it is believed that", "as of my last update".
+
+**Why:** two tells with one cause. The model cannot find a source, writes a
+sentence about not finding one, then fills the gap with the stock guess. The
+guess is unsourced and the meta-sentence is about the model, not the subject.
+
+**Fix:** say what is not known, or cut the sentence. Never dress the guess as
+fact.
+
+> was: *Information about her early life is not publicly available, suggesting
+> she maintains a low profile. She likely grew up in a middle-class household.*
+> now: *Her early life is not documented in the sources used here.*
+
+---
+
+## 34. Diff-anchored documentation
+
+**Tell:** documentation or a code comment that narrates a change rather than
+describing the thing — "this function was added to replace", "we now use", "the
+previous approach was", "this has been updated to".
+
+**Why:** the document is being written from the diff that produced it, so it
+reads coherently only to someone who knows what the last commit did. Six months
+later nobody does.
+
+**Fix:** describe the current state. The change belongs in the commit message or
+the changelog, which are version-scoped by design.
+
+> was: *This function was added to replace the previous approach of iterating
+> through all items, which caused quadratic performance.*
+> now: *Looks up items through a hash map, so cost is constant per item rather
+> than quadratic in the list length.*
+
+---
+
+## 35. Subjectless fragment
+
+**Tell:** a claim with the actor removed — "No configuration file needed", "The
+results are preserved automatically", "Changes applied on save".
+
+**Why:** the reader cannot tell who does the thing, which matters most in exactly
+the documents where these appear: who preserves the results, and can I rely on
+it? Related to abstraction agency (entry 4), which puts the wrong subject in the
+slot rather than none.
+
+**Fix:** name the actor.
+
+> was: *No configuration file needed. The results are preserved automatically.*
+> now: *You do not need a config file. The runner writes results to `out/` when
+> the job exits.*
+
+**Earned when** the register is genuinely clipped throughout — release notes, a
+feature table, a CLI help string.
+
+---
+
+## 36. Predicate-position hyphenation
+
+**Tell:** a compound modifier keeping its hyphen after the noun — "the report is
+high-quality", "the team is cross-functional", "the pipeline is end-to-end".
+
+**Why:** the model hyphenates the pair uniformly wherever it appears. Human
+writers hyphenate attributively and mostly drop it in the predicate.
+
+**Fix:** keep the hyphen before the noun, drop it after.
+
+> was: *The team is cross-functional and the report is data-driven.*
+> now: *The team is cross functional and the report is data driven.*
+
+**Minor.** One instance proves nothing; a document that hyphenates every pair in
+both positions is a cluster member.
+
+---
+
 ## Quick self-check before shipping an edit
 
 1. Does any sentence exist to make a finding feel bigger than it is?
@@ -347,3 +608,7 @@ drop, "exactly" where the contrast already carries it.
 6. Does the last paragraph paraphrase the subtext of the piece?
 7. Did the edit remove content, change a claim, or add hedging?
 8. Does the result still sound like a person with opinions?
+9. Does any sentence end in a participle tail that asserts significance?
+10. Does the rewrite contain a fact, name, number, date or citation that is not
+    in the source? A fabrication is a defect even when it sounds more human than
+    the vague original.

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -174,8 +174,10 @@ TITLE_CASE_SKIP = {
     "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "into",
     "nor", "of", "on", "onto", "or", "over", "the", "to", "up", "via", "with",
 }
+# Emoji-presentation blocks only. An earlier version included U+2190-U+21FF and
+# U+2300-U+23FF, so a plain -> arrow or a technical symbol reported as decoration.
 EMOJI_RE = re.compile(
-    "[\U0001F000-\U0001FAFF←-⇿⌀-➿⬀-⯿️]"
+    "[\U0001F300-\U0001FAFF☀-➿]|.️"
 )
 
 CATEGORY_ORDER = [
@@ -200,6 +202,8 @@ def _blank_quoted(text: str) -> str:
     # leaving the row's own specimens visible to the scanner.
     text = "\n".join("" if ln.lstrip().startswith((">", "|")) else ln
                      for ln in text.splitlines())
+    text = re.sub(r"```.*?```", blank, text, flags=re.S)       # fenced code
+    text = re.sub(r"`[^`\n]+`", blank, text)                   # inline code span
     text = re.sub(r"(?<!\*)\*[^*]+\*(?!\*)", blank, text)      # *italic*, may wrap lines
     return re.sub(r"<q>.*?</q>", blank, text, flags=re.S)
 

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -100,17 +100,91 @@ RULES: list[tuple[str, str, str]] = [
     # --- staging (more) ------------------------------------------------------
     ("staging", r"\b(?:here|this)\s+is\s+what\s+[^.]{0,60}\blooks?\s+like\b", "here is what X looks like"),
     ("staging", r"\bthen\s+the\s+(?:useful|real|interesting)\s+question\b", "heralding your own question"),
+
+    # ===== entries 24-36: encyclopedic and chatbot patterns ==================
+
+    # --- copula avoidance ----------------------------------------------------
+    ("copula", r"\b(?:serves?|stands?|acts?)\s+as\s+(?:a|an|the)\b", "serves as — use is"),
+    ("copula", r"\bboasts?\s+(?:a|an|the|over|more than|some|\d)", "boasts — use has"),
+    ("copula", r"\b(?:it|which|that|the\s+\w+)\s+features\s+(?:a|an|the|over|\d)", "features — use has"),
+    ("copula", r"\b(?:represents|marks)\s+(?:a|an|the)\s+(?:shift|turning point|milestone|step|departure|moment)\b", "represents a shift"),
+
+    # --- participle tail -----------------------------------------------------
+    ("participle", r",\s*(?:highlight|underscor|emphasiz|reflect|symboliz|showcas|ensur|foster|cultivat|encompass|solidif|cement|underlin)\w*ing\b", "participle tail asserting significance"),
+    ("participle", r",\s*contributing\s+to\b", "participle tail asserting significance"),
+
+    # --- false range ---------------------------------------------------------
+    ("false-range", r"\bfrom\s+[^,.;]{3,45}\s+to\s+[^,.;]{3,45},\s*from\s+", "stacked from-X-to-Y ranges"),
+    ("false-range", r"\b(?:everything|anything|ranging)\s+from\b[^.]{0,60}\bto\b", "false range — list the items"),
+
+    # --- inline-header list --------------------------------------------------
+    ("list-shape", r"^\s*[-*+]\s+\*\*[^*\n]{2,45}\*\*\s*:", "inline-header bullet — the label restates the item"),
+    ("list-shape", r"^\s*[-*+]\s+\*\*[^*\n]{2,45}:\*\*", "inline-header bullet — the label restates the item"),
+
+    # --- chatbot residue -----------------------------------------------------
+    ("chatbot", r"\b(?:great|excellent|good)\s+question\b", "chatbot residue"),
+    ("chatbot", r"\byou'?re\s+absolutely\s+right\b", "chatbot residue"),
+    ("chatbot", r"\bI\s+hope\s+this\s+helps\b", "chatbot residue"),
+    ("chatbot", r"\blet\s+me\s+know\s+if\s+you'?d\b", "chatbot residue"),
+    ("chatbot", r"\b(?:would|do)\s+you\s+(?:like|want)\s+me\s+to\b", "chatbot residue"),
+    ("chatbot", r"\bwant\s+me\s+to\s+(?:give|show|expand|continue|explain)\b", "chatbot residue"),
+    ("chatbot", r"\b(?:should|shall)\s+I\s+continue\b", "chatbot residue"),
+    ("chatbot", r"^\s*(?:Certainly|Of course|Absolutely)[!,]", "chatbot residue"),
+    ("chatbot", r"\bhere\s+is\s+an\s+overview\s+of\b", "chatbot residue"),
+
+    # --- filler and hedge stacking -------------------------------------------
+    ("filler", r"\bin\s+order\s+to\b", "in order to — use to"),
+    ("filler", r"\bdue\s+to\s+the\s+fact\s+that\b", "due to the fact that — use because"),
+    ("filler", r"\bat\s+this\s+point\s+in\s+time\b", "at this point in time — use now"),
+    ("filler", r"\bin\s+the\s+event\s+that\b", "in the event that — use if"),
+    ("filler", r"\bhas\s+the\s+ability\s+to\b", "has the ability to — use can"),
+    ("filler", r"\bit\s+is\s+important\s+to\s+note\s+that\b", "delete the frame, keep the claim"),
+    ("filler", r"\b(?:could|might|may|can)\s+(?:potentially|possibly|arguably|conceivably)\b", "stacked hedges — one carries the uncertainty"),
+    ("filler", r"\bpotentially\s+possibly\b", "stacked hedges"),
+
+    # --- speculative gap-filling ---------------------------------------------
+    ("gap-fill", r"\bmaintains?\s+a\s+low\s+profile\b", "stock filler for an absent source"),
+    ("gap-fill", r"\bkeeps?\s+(?:personal\s+)?details?\s+private\b", "stock filler for an absent source"),
+    ("gap-fill", r"\b(?:is|are)\s+not\s+publicly\s+available\b", "say what is not known, or cut"),
+    ("gap-fill", r"\bbased\s+on\s+(?:the\s+)?available\s+information\b", "meta-sentence about the search, not the subject"),
+    ("gap-fill", r"\bas\s+of\s+my\s+last\s+(?:update|training)\b", "knowledge-cutoff disclaimer"),
+    ("gap-fill", r"\bdetails\s+(?:about|are)[^.]{0,50}\b(?:limited|scarce|not\s+extensively)\b", "meta-sentence about the search"),
+    ("gap-fill", r"\bit\s+is\s+believed\s+that\b", "unsourced guess"),
+    ("gap-fill", r"\blikely\s+(?:grew\s+up|studied|began|started|attended)\b", "unsourced guess about a person"),
+
+    # --- diff-anchored documentation -----------------------------------------
+    ("diff-anchored", r"\b(?:was|were)\s+added\s+to\s+(?:replace|fix|handle|support)\b", "documents the change, not the thing"),
+    ("diff-anchored", r"\bthe\s+(?:previous|old|former)\s+(?:approach|implementation|version|behaviour|behavior|method)\b", "documents the change, not the thing"),
+    ("diff-anchored", r"\bhas\s+(?:since\s+)?been\s+(?:updated|changed|replaced|refactored)\s+to\b", "documents the change, not the thing"),
+    ("diff-anchored", r"\bwe\s+now\s+(?:use|do|call|store|write)\b", "documents the change, not the thing"),
+
+    # --- subjectless fragment ------------------------------------------------
+    ("subjectless", r"\bNo\s+\w+(?:\s+\w+){0,2}\s+(?:needed|required)\s*[.!]", "subjectless claim — name the actor"),
+    ("subjectless", r"\b(?:is|are)\s+\w+ed\s+automatically\b", "subjectless claim — who does it?"),
+
+    # --- predicate-position hyphenation --------------------------------------
+    ("hyphenation", r"\b(?:is|are|was|were|feels?|seems?)\s+(?:high-quality|cross-functional|data-driven|end-to-end|real-time|long-term|well-known|client-facing|decision-making|third-party|open-source)\b", "drop the hyphen after the noun"),
 ]
 
 HEADER_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 COY_HEADER_RE = re.compile(r"^(?:what|why|how)\b(?!.*\?$)", re.I)
 VERDICT_HEADER_RE = re.compile(r"\b(?:is|are|isn'?t|aren'?t|was|wasn'?t|does|doesn'?t|actually|really|wrong|right|matters|counts)\b", re.I)
 
+TITLE_CASE_SKIP = {
+    "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "into",
+    "nor", "of", "on", "onto", "or", "over", "the", "to", "up", "via", "with",
+}
+EMOJI_RE = re.compile(
+    "[\U0001F000-\U0001FAFF←-⇿⌀-➿⬀-⯿️]"
+)
+
 CATEGORY_ORDER = [
     "negation-first", "significance", "agency", "deferred-noun", "locator",
     "staging", "rhetorical-q", "self-grading", "humility", "throat-clearing",
     "rtfm", "dev-cliche", "slop", "editorializing", "time-inflation",
-    "header", "cadence", "density",
+    "copula", "participle", "false-range", "list-shape", "chatbot", "filler",
+    "gap-fill", "diff-anchored", "subjectless", "hyphenation",
+    "header", "typography", "cadence", "density",
 ]
 
 COMPILED = [(cat, re.compile(pat, re.I | re.M), note) for cat, pat, note in RULES]
@@ -121,10 +195,13 @@ def _blank_quoted(text: str) -> str:
     def blank(m: re.Match) -> str:
         return "\n" * m.group(0).count("\n")
 
+    # Blockquotes and table rows go first. Doing this after the span pass let a
+    # bold marker inside a table cell mis-pair the italic regex across lines,
+    # leaving the row's own specimens visible to the scanner.
+    text = "\n".join("" if ln.lstrip().startswith((">", "|")) else ln
+                     for ln in text.splitlines())
     text = re.sub(r"(?<!\*)\*[^*]+\*(?!\*)", blank, text)      # *italic*, may wrap lines
-    text = re.sub(r"<q>.*?</q>", blank, text, flags=re.S)
-    return "\n".join("" if ln.lstrip().startswith((">", "|")) else ln
-                      for ln in text.splitlines())
+    return re.sub(r"<q>.*?</q>", blank, text, flags=re.S)
 
 
 def scan_lines(text: str) -> list[dict]:
@@ -156,6 +233,14 @@ def scan_lines(text: str) -> list[dict]:
             elif not title.endswith("?") and VERDICT_HEADER_RE.search(title) and len(title.split()) > 3:
                 hits.append({"line": i, "category": "header",
                              "note": "thesis-shaped header — states a verdict instead of labelling",
+                             "match": title[:90]})
+            words = title.split()
+            minor = [w for w in words[1:] if w.lower() not in TITLE_CASE_SKIP]
+            if len(words) > 3 and minor and all(
+                w[:1].isupper() and not w.isupper() for w in minor
+            ):
+                hits.append({"line": i, "category": "typography",
+                             "note": "Title Case heading — sentence case unless the document says otherwise",
                              "match": title[:90]})
 
         # drama line break: very short standalone paragraph
@@ -213,6 +298,20 @@ def scan_density(text: str) -> list[dict]:
         out.append({"line": 0, "category": "density",
                     "note": f"{len(frags)} of {len(sentences)} sentences are <=5 words — check for fragment cadence",
                     "match": "fragment density"})
+
+    curly = len(re.findall(r"[“”‘’]", body))
+    if curly:
+        out.append({"line": 0, "category": "typography",
+                    "note": f"{curly} curly quote characters — straight quotes in anything a program reads. "
+                            "Not a tell on its own: most editors curl by default",
+                    "match": "curly quotes"})
+
+    emoji = EMOJI_RE.findall(text)
+    if emoji:
+        out.append({"line": 0, "category": "typography",
+                    "note": f"{len(emoji)} emoji — decoration on headings and bullets is a tell "
+                            "unless the document already uses them",
+                    "match": "".join(sorted(set(emoji))[:12])})
 
     lens = [len(s.split()) for s in sentences]
     if len(lens) > 20:

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -53,3 +53,30 @@ It is not a method; it is a lucky escape.
 Everything below is the inference side, which is the part that transfers. --calibrate is the part that matters.
 
 A distinction worth keeping separate: a metric can fail two different ways. Their phrasing for it is better than mine.
+
+# Encyclopedic and chatbot specimens (entries 24-36)
+
+Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets and the Gulf of Mexico, reflecting the community's deep connection to the land.
+
+Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+- **User Experience:** The user experience has been significantly improved with a new interface.
+- **Performance:** Performance has been enhanced through optimized algorithms.
+
+## Strategic Negotiations And Global Partnerships
+
+Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section. Want me to give examples?
+
+Great question! You're absolutely right that this is a complex topic.
+
+In order to achieve this goal, due to the fact that it was raining, at this point in time the system has the ability to process requests. It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s. She likely grew up in a middle-class household and maintains a low profile.
+
+This function was added to replace the previous approach of iterating through all items, which caused quadratic performance.
+
+No configuration file needed. The results are preserved automatically.
+
+The cross-functional team is cross-functional, the report is high-quality, and the methodology is data-driven.


### PR DESCRIPTION
Asked to compare `declauding` with [blader/humanizer](https://github.com/blader/humanizer) and take what is valuable. This is the port.

## The two skills

Humanizer (v2.9.1, MIT, 412-line single `SKILL.md`) packages the Wikipedia AI Cleanup project's [Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) as a harness-neutral skill: 33 numbered patterns, each with a before/after, and no tooling for prose detection (its one script validates package metadata).

They cover different halves. `declauding` goes deep on the staging mechanisms: negation-first, significance designation, aphoristic closers, the shapes a model reaches for when it wants a finding to feel like it arrived. Humanizer is broader on the flat encyclopedic and promotional register: puffery, participle tails, chatbot residue, typographic tells. `declauding` had two vocabulary entries covering that whole territory.

## The measured gap

A probe file of 19 humanizer specimens run through `declaude_lint.py`: **2 candidates, neither for the right reason.** A synonym-cycling specimen tripped the fragment-cadence rule by accident. After this change: **33 candidates across 13 categories.**

## Changes

**Register entries 24 to 36.** Copula avoidance, participle tail, forced triad, elegant variation, false range, inline-header list, typographic tells, chatbot residue, filler and hedge stacking, speculative gap-filling, diff-anchored documentation, subjectless fragment, predicate-position hyphenation. They sit in a second block that says what they are: several are phrase lists rather than mechanisms and will miss the next paraphrase. The register's design principle is grouping by mechanism, and pretending these qualify would have been the wrong absorption.

Two are worth calling out. Participle tail (`, symbolizing X, reflecting Y`) is the most reliable tell in that family and this register had nothing for it. Diff-anchored documentation, a doc that narrates the change that produced it instead of describing the thing, is a pattern we produce constantly in READMEs and comments.

**Do not invent specifics.** The fix for a vague sentence is a specific one, which is how a register pass fabricates: *Experts believe it plays a crucial role* wants to become a named institution. Humanizer added this in 2.9.0 against a real bug report. `declauding` warned against changing claims but not against supplying a name or number the source does not have, which is the likelier failure. Added to `SKILL.md`, to workflow step 5 as a fourth failure mode, and to the register's pre-ship checklist.

**Voice-sample precedence.** A sample of the author's writing outranks every rule here, including the em-dash density guard. Scrubbing a tell that is someone's actual voice makes the text less like them and no more human.

**Embedded invocation mode.** When another skill or agent calls this as one step of a larger job, return the final text and nothing else: no preamble, no tic list. `declauding` had output modes but no notion of being called as a sub-step, which is how it will mostly be used.

**Leave these alone.** Humanizer's "signs of human writing" list, adapted: hard-to-fabricate detail, unresolved tension, genuine self-interruption, uneven depth, repetition where a synonym would be worse. `declauding` had the Overcorrection guard for what not to do and no positive detector for what to protect. Also the cluster rule: one em dash is punctuation, em dashes plus a forced triad plus *vibrant tapestry* plus a Conclusion section is a confession.

**Linter.** Rules for the new lexical entries, Title Case heading detection, document-level curly-quote and emoji counts. Eleven new categories.

**Bug fix in `--skip-quoted`.** Span blanking ran before line blanking, so a bold marker inside a table cell could mis-pair the italic regex across lines and leave that row's specimens visible to the scanner. Reordered. This README self-linted at 10 candidates before the fix and 1 after, all of them quoted examples.

## Not taken

- **The em-dash ban.** Humanizer makes zero em dashes a hard constraint, then patches it with a voice-sample override. `declauding`'s density measure of roughly one per 150 words is the more honest instrument and does not mangle legitimate inline asides.
- **Flat numbered-list architecture.** 412 lines always in context, against a thin `SKILL.md` with the register loaded on demand. Progressive disclosure stays.
- **The 500-line portability budget and package-sync validator.** Sensible for a distributed single-file skill; not what this repo's release pipeline needs.

Humanizer stays worth reading for the half it covers better, and the README links it.

## Verification

```
python3 scripts/declaude_lint.py tests/sample-clean.md   # 0 - the design constraint, held
python3 scripts/declaude_lint.py tests/sample-tics.md    # 58 candidates, 23 categories (was 29 / 12)
python3 -m muninn_utils.ruff_gate --base main            # 0 new violations
```

13 new specimens in `tests/sample-tics.md`, verbatim from humanizer's before/after examples, per the extension protocol. `metadata.version` 0.1.1 to 0.2.0 (behavior change, new capabilities).

## Second commit

Oskar reviewed the first version of this description and found three claudisms in it: two coy `What ...` headers and a negation-first aphoristic closer. He was right, and `declaude_lint.py` catches two of the three, which means I shipped the linter without running it on the artifact I shipped it with. Ceremonial skill use, the failure the skill's own task-routing note warns about.

The second commit fixes what that lint run exposed in the code: the emoji rule counted U+2190-U+21FF as decoration, so a plain arrow in technical prose reported as an emoji. Narrowed to emoji-presentation blocks.

The staged closer is the one the linter missed. That is the documented limit, restated in the README: no regex reaches a staged closer, so a clean report means nothing on its own.


---
_Generated by [Claude Code](https://claude.ai/code)_