### PR TITLE
declauding 0.3.0 — HTML-aware header scan + structural review pass

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-08-16
+
+### Added
+
+- `scripts/declaude_review.py` — stage-2 structural pass. Extracts headers, opening and closing sentences, and isolated one-sentence paragraphs, then judges only those against the structural entries in `references/register.md`. Gemini or Anthropic key, `--emit-prompt` fallback, `--slots` for extraction only.
+- `tests/sample-structure.md` and `tests/sample-structure.html` — regression fixtures built from headers that shipped past the linter.
+
+### Fixed
+
+- `declaude_lint.py` now flattens HTML before scanning. `HEADER_RE` matched markdown headings only, so every header rule was silent on an HTML draft — three thesis-shaped headers, a comma-clause header and a coy header shipped past a clean report. Masthead `.subtitle` / `.eyebrow` / `.post-meta` elements are scanned as headings.
+
 ## [0.2.1] - 2026-08-16
 
 ### Other

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -2,7 +2,7 @@
 name: declauding
 description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.2.1
+  version: 0.3.0
 ---
 
 # Declauding
@@ -83,12 +83,44 @@ they are the most valuable thing this pass produces.
 
 ```
 python3 scripts/declaude_lint.py DRAFT.md
+python3 scripts/declaude_lint.py DRAFT.html      # HTML is flattened automatically
 ```
 
 It flags greppable tells with line numbers and categories. It has no judgment —
 it finds candidates, it does not decide. Everything it flags still needs the
 sentence-level test, and it misses every tic that is structural rather than
 lexical. Treat a clean lint report as meaningless on its own.
+
+HTML input is flattened before scanning: `<h1>`–`<h6>` become headings so the
+header rules see them, and a `.subtitle`, `.eyebrow` or `.post-meta` element is
+treated as a heading too, because a subtitle is a header by every test that
+matters. Force with `--html`, disable with `--no-html`. Reported line numbers
+refer to the flattened view.
+
+Lint every string that reaches the reader, not only the body file. Page titles,
+subtitles and deck headers are prose, and a builder that takes them as CLI
+arguments rather than from the file will hide them from this scan.
+
+**2b. Run the structural review.**
+
+```
+python3 scripts/declaude_review.py DRAFT.md
+```
+
+It extracts the slots regex cannot judge — every header, the opening sentence,
+each closing sentence, isolated one-sentence paragraphs — and sends only those
+to a model with the structural entries from `references/register.md`. Slots
+rather than the whole document, because the payload stays small enough to run
+on every draft. Use `--emit-prompt` where no API key is available, `--slots` to
+see the extraction alone.
+
+Run it in a context that did not write the draft. A model reviewing its own
+prose is the actor that chose the words.
+
+For a full-document register review against a named voice signature — positive
+markers, drift across the piece, imposter test — use the `challenging` skill's
+`prose-register` profile instead. This script is the cheap pass; that one is
+the thorough one.
 
 **3. Sentence pass.** For every sentence, in order: stating or staging? Load
 `references/register.md` for the catalogue of tells and their fixes.

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -167,6 +167,47 @@ RULES: list[tuple[str, str, str]] = [
     ("hyphenation", r"\b(?:is|are|was|were|feels?|seems?)\s+(?:high-quality|cross-functional|data-driven|end-to-end|real-time|long-term|well-known|client-facing|decision-making|third-party|open-source)\b", "drop the hyphen after the noun"),
 ]
 
+HTML_HEADING_RE = re.compile(r"<h([1-6])\b[^>]*>(.*?)</h\1>", re.S | re.I)
+HTML_MASTHEAD_RE = re.compile(
+    r'<[^>]+class="[^"]*\b(subtitle|eyebrow|post-meta)\b[^"]*"[^>]*>(.*?)</', re.S | re.I)
+HTML_BLOCK_RE = re.compile(r"<(p|li|figcaption|summary)\b[^>]*>(.*?)</\1>", re.S | re.I)
+HTML_DROP_RE = re.compile(r"<(script|style|pre|code)\b.*?</\1>", re.S | re.I)
+HTML_ENTITIES = {"&nbsp;": " ", "&amp;": "&", "&lt;": "<", "&gt;": ">",
+                 "&quot;": '"', "&#39;": "'", "&#8212;": "\u2014", "&mdash;": "\u2014"}
+
+
+def looks_like_html(text: str) -> bool:
+    head = text[:4000].lower()
+    return "<html" in head or "<!doctype html" in head or bool(HTML_HEADING_RE.search(text))
+
+
+def _detag(fragment: str) -> str:
+    out = re.sub(r"<[^>]+>", " ", fragment)
+    for ent, ch in HTML_ENTITIES.items():
+        out = out.replace(ent, ch)
+    return re.sub(r"\s+", " ", out).strip()
+
+
+def html_to_lines(text: str) -> str:
+    """Flatten HTML into the line-oriented prose the rules expect.
+
+    Headings become markdown headings so the header rules see them, and
+    composing-html's masthead classes are treated as headings too — a subtitle
+    is a header by every test that matters. Line numbers refer to this
+    flattened view, not the source file.
+    """
+    text = HTML_DROP_RE.sub(" ", text)
+    parts: list[tuple[int, str]] = []
+    for m in HTML_HEADING_RE.finditer(text):
+        parts.append((m.start(), "#" * int(m.group(1)) + " " + _detag(m.group(2))))
+    for m in HTML_MASTHEAD_RE.finditer(text):
+        parts.append((m.start(), "## " + _detag(m.group(2))))
+    for m in HTML_BLOCK_RE.finditer(text):
+        parts.append((m.start(), _detag(m.group(2))))
+    lines = [t for _, t in sorted(parts) if t.strip(" #")]
+    return "\n\n".join(lines) + "\n"
+
+
 HEADER_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 COY_HEADER_RE = re.compile(r"^(?:what|why|how)\b(?!.*\?$)", re.I)
 VERDICT_HEADER_RE = re.compile(r"\b(?:is|are|isn'?t|aren'?t|was|wasn'?t|does|doesn'?t|actually|really|wrong|right|matters|counts)\b", re.I)
@@ -336,9 +377,14 @@ def main() -> int:
     ap.add_argument("--quiet-slop", action="store_true", help="hide the slop/editorializing/time categories")
     ap.add_argument("--skip-quoted", action="store_true",
                     help="ignore blockquotes, *italic* spans and table cells — use on docs that quote bad prose as specimens")
+    ap.add_argument("--html", action="store_true",
+                    help="force HTML flattening (headings, masthead subtitle, block prose)")
+    ap.add_argument("--no-html", action="store_true", help="never flatten; scan the raw source")
     args = ap.parse_args()
 
     text = sys.stdin.read() if args.path == "-" else Path(args.path).read_text(encoding="utf-8")
+    if args.html or (not args.no_html and looks_like_html(text)):
+        text = html_to_lines(text)
     if args.skip_quoted:
         text = _blank_quoted(text)
 

--- a/declauding/scripts/declaude_review.py
+++ b/declauding/scripts/declaude_review.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Stage 2 of the register pass: judgment on the slots regex cannot reach.
+
+declaude_lint.py is lexical. It scans for phrases. The tics it cannot see are
+structural — a header that states a verdict, a closer that paraphrases the
+subtext above it, an isolated line used as a drum roll. Those need a reader.
+
+This script extracts only the structural slots (title, subtitle, every header,
+the opening sentence, each section's closing sentence, isolated one-sentence
+paragraphs) and sends them to a model with the matching entries from
+references/register.md. Slots rather than the whole document, because that is
+where the structural tics live and a small payload is cheap enough to run on
+every draft.
+
+    python3 declaude_review.py DRAFT.md                 # judge (needs an API key)
+    python3 declaude_review.py DRAFT.html --emit-prompt # print the prompt instead
+    python3 declaude_review.py DRAFT.md --slots         # show what was extracted
+
+Keys, in order of preference: GEMINI_API_KEY, then ANTHROPIC_API_KEY. With
+neither set the script falls back to --emit-prompt and says so.
+
+Do not run this on your own draft in the context that wrote it. The judgment
+wants a reader who did not choose the words.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REGISTER = Path(__file__).resolve().parent.parent / "references" / "register.md"
+
+# register.md entries that describe structural tics. Loaded verbatim so the
+# catalogue stays single-source; adding an entry there needs no edit here.
+STRUCTURAL_ENTRIES = (1, 2, 3, 7, 9, 12, 13)
+
+SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+TAG = re.compile(r"<[^>]+>")
+
+
+def strip_tags(s: str) -> str:
+    s = re.sub(r"<(script|style)\b.*?</\1>", " ", s, flags=re.S | re.I)
+    s = TAG.sub(" ", s)
+    s = (s.replace("&nbsp;", " ").replace("&amp;", "&")
+          .replace("&lt;", "<").replace("&gt;", ">").replace("&#8212;", "—"))
+    return re.sub(r"[ \t]+", " ", s).strip()
+
+
+def sentences(text: str) -> list[str]:
+    return [s.strip() for s in SENTENCE_END.split(text.strip()) if s.strip()]
+
+
+def load_register(entries=STRUCTURAL_ENTRIES) -> str:
+    if not REGISTER.exists():
+        return ""
+    blocks, current, keep = [], [], False
+    for line in REGISTER.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"^## (\d+)\.", line)
+        if m:
+            if keep and current:
+                blocks.append("\n".join(current).strip())
+            current, keep = [], int(m.group(1)) in entries
+        if keep:
+            current.append(line)
+    if keep and current:
+        blocks.append("\n".join(current).strip())
+    return "\n\n".join(blocks)
+
+
+def extract_html(text: str) -> list[tuple[str, str]]:
+    slots: list[tuple[str, str]] = []
+    for cls, label in (("eyebrow", "eyebrow"), ("subtitle", "subtitle")):
+        for m in re.finditer(rf'class="[^"]*\b{cls}\b[^"]*"[^>]*>(.*?)<', text, re.S):
+            if strip_tags(m.group(1)):
+                slots.append((label, strip_tags(m.group(1))))
+    for m in re.finditer(r"<h([1-6])[^>]*>(.*?)</h\1>", text, re.S | re.I):
+        slots.append((f"h{m.group(1)}", strip_tags(m.group(2))))
+    paras = [strip_tags(m.group(1)) for m in
+             re.finditer(r"<p[^>]*>(.*?)</p>", text, re.S | re.I)]
+    slots += _prose_slots([p for p in paras if p])
+    return slots
+
+
+def extract_markdown(text: str) -> list[tuple[str, str]]:
+    slots: list[tuple[str, str]] = []
+    body: list[str] = []
+    fm = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    if fm:
+        for line in fm.group(1).splitlines():
+            if line.lower().startswith(("title:", "subtitle:", "description:")):
+                k, _, v = line.partition(":")
+                slots.append((k.strip().lower(), v.strip().strip("\"'")))
+        text = text[fm.end():]
+    fenced = False
+    for line in text.splitlines():
+        if line.startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            slots.append((f"h{len(m.group(1))}", m.group(2).strip()))
+        else:
+            body.append(line)
+    paras = [p.strip().replace("\n", " ") for p in "\n".join(body).split("\n\n")]
+    slots += _prose_slots([p for p in paras if p and not p.startswith(("|", ">", "-", "*"))])
+    return slots
+
+
+def _prose_slots(paras: list[str]) -> list[tuple[str, str]]:
+    """Opening sentence, last sentence of the final paragraph, isolated lines."""
+    out: list[tuple[str, str]] = []
+    if not paras:
+        return out
+    first = sentences(paras[0])
+    if first:
+        out.append(("opening", first[0]))
+    last = sentences(paras[-1])
+    if last:
+        out.append(("closer", last[-1]))
+    for p in paras[1:-1]:
+        s = sentences(p)
+        if len(s) == 1 and len(s[0].split()) <= 18:
+            out.append(("isolated-line", s[0]))
+    return out
+
+
+def extract(path: Path) -> list[tuple[str, str]]:
+    text = path.read_text(encoding="utf-8")
+    is_html = path.suffix.lower() in {".html", ".htm"} or "<html" in text[:2000].lower()
+    slots = extract_html(text) if is_html else extract_markdown(text)
+    seen, uniq = set(), []
+    for kind, value in slots:
+        if value and (kind, value) not in seen:
+            seen.add((kind, value))
+            uniq.append((kind, value))
+    return uniq
+
+
+def build_prompt(slots: list[tuple[str, str]]) -> str:
+    listing = "\n".join(f"{i + 1}. [{k}] {v}" for i, (k, v) in enumerate(slots))
+    return f"""You are checking prose for structural register tics. The catalogue below is
+the standard; apply it and nothing else.
+
+{load_register()}
+
+Below are the structural slots pulled from a draft: its headers, its opening
+and closing sentences, and any isolated one-sentence paragraphs. You are not
+seeing the body prose, and you do not need it — judge each slot on its own
+terms.
+
+For a header, apply the table-of-contents test: read it alone. Does it name
+what the section contains, or does it state a verdict, hide its contents, or
+carry a comma-clause? Only the first is acceptable. A header you could agree or
+disagree with is a verdict, however plainly it is worded — "Sales fell in Q3"
+asserts, "Q3 sales" labels. A comma joining parts of a proper name is fine; a
+comma introducing an appositive, participle or relative clause is not.
+
+For a closer, ask whether it paraphrases the subtext of what came before or
+compresses the piece into a contrast or a moral. Either is a button; cut it.
+
+For an isolated line, ask whether it marks a real pivot — new actor, category
+shift, time jump — or supplies a drum roll.
+
+SLOTS:
+{listing}
+
+Return JSON only, no prose around it, no code fences:
+{{"findings": [{{"n": <slot number>, "tic": "<catalogue name>", "why": "<one sentence>", "fix": "<the replacement text>"}}]}}
+
+Return an empty findings list if every slot is clean. Do not invent facts: a
+suggested fix may only rearrange or delete words already present, or use a
+plainly descriptive label drawn from the slot itself."""
+
+
+def call_gemini(prompt: str, key: str) -> str:
+    url = ("https://generativelanguage.googleapis.com/v1beta/models/"
+           f"gemini-3.6-flash:generateContent?key={key}")
+    body = json.dumps({"contents": [{"parts": [{"text": prompt}]}],
+                       "generationConfig": {"temperature": 0}}).encode()
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = json.load(r)
+    return data["candidates"][0]["content"]["parts"][0]["text"]
+
+
+def call_anthropic(prompt: str, key: str) -> str:
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=json.dumps({"model": "claude-sonnet-4-6", "max_tokens": 2000,
+                         "temperature": 0,
+                         "messages": [{"role": "user", "content": prompt}]}).encode(),
+        headers={"content-type": "application/json", "x-api-key": key,
+                 "anthropic-version": "2023-06-01"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = json.load(r)
+    return "".join(b.get("text", "") for b in data["content"])
+
+
+def parse_findings(raw: str) -> list[dict]:
+    raw = re.sub(r"^```(?:json)?|```$", "", raw.strip(), flags=re.M).strip()
+    start, end = raw.find("{"), raw.rfind("}")
+    if start < 0 or end < 0:
+        raise ValueError(f"no JSON object in model reply: {raw[:200]}")
+    return json.loads(raw[start:end + 1]).get("findings", [])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("path", help="file to review (.md or .html)")
+    ap.add_argument("--emit-prompt", action="store_true", help="print the prompt, do not call a model")
+    ap.add_argument("--slots", action="store_true", help="print the extracted slots and stop")
+    ap.add_argument("--json", action="store_true", help="machine-readable findings")
+    args = ap.parse_args()
+
+    slots = extract(Path(args.path))
+    if not slots:
+        print("no structural slots found — check the file parsed as expected")
+        return 0
+
+    if args.slots:
+        for i, (k, v) in enumerate(slots, 1):
+            print(f"{i:>3}. [{k}] {v}")
+        return 0
+
+    prompt = build_prompt(slots)
+    gem, ant = os.environ.get("GEMINI_API_KEY"), os.environ.get("ANTHROPIC_API_KEY")
+    if args.emit_prompt or not (gem or ant):
+        if not (gem or ant) and not args.emit_prompt:
+            print("no GEMINI_API_KEY or ANTHROPIC_API_KEY set — emitting the prompt "
+                  "for a separate call instead\n", file=sys.stderr)
+        print(prompt)
+        return 0
+
+    raw = call_gemini(prompt, gem) if gem else call_anthropic(prompt, ant)
+    findings = parse_findings(raw)
+
+    if args.json:
+        print(json.dumps({"slots": [{"n": i + 1, "kind": k, "text": v}
+                                    for i, (k, v) in enumerate(slots)],
+                          "findings": findings}, indent=2))
+        return 1 if findings else 0
+
+    if not findings:
+        print(f"{len(slots)} slots reviewed, none flagged")
+        return 0
+
+    print(f"{len(findings)} of {len(slots)} slots flagged\n")
+    for f in findings:
+        n = f.get("n", 0)
+        kind, text = slots[n - 1] if 1 <= n <= len(slots) else ("?", "?")
+        print(f"  [{kind}] {text}")
+        print(f"      {f.get('tic', '?')} — {f.get('why', '')}")
+        print(f"      -> {f.get('fix', '')}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/declauding/tests/sample-structure.html
+++ b/declauding/tests/sample-structure.html
@@ -1,0 +1,5 @@
+<article><div class="subtitle">Two decisions, and what the benchmarks actually say</div>
+<h2>Grok 4.6</h2><p>Released 12 August by SpaceXAI.</p>
+<h3>The composite index is a four-way tie</h3><p>Opus 5 scores 63.</p>
+<h3>Vendor response, and its limits</h3><p>Anthropic will watermark Claude output.</p>
+<h3>What this asks of us</h3><p>Decide whether watermarked output is acceptable.</p></article>

--- a/declauding/tests/sample-structure.md
+++ b/declauding/tests/sample-structure.md
@@ -1,0 +1,31 @@
+---
+title: AI Weekly Roundup
+subtitle: Two decisions, and what the benchmarks actually say
+---
+
+Two items from this week warrant a decision. Everything else is tracking.
+
+## Grok 4.6
+
+Released 12 August by SpaceXAI. It is a post-training upgrade on the 4.5 base.
+
+### The composite index is a four-way tie
+
+Opus 5 scores 63, Fable 5 62, Grok 4.6 and GPT-5.6 Sol Max both 61.
+
+### The per-benchmark split is where the signal is
+
+Grok 4.6 leads the knowledge-work evals and trails on software engineering.
+
+## EU AI Act, Article 50
+
+Transparency obligations took effect 2 August 2026.
+
+### Vendor response, and its limits
+
+Anthropic will watermark Claude text output worldwide.
+
+### What this asks of us
+
+Decide whether watermarked output is acceptable in our own deliverables, and say
+so in policy before someone discovers the answer by accident.


### PR DESCRIPTION
Two changes, both from the same failure: five structural tics shipped in a draft that `declaude_lint.py` had passed.

## Header rules and HTML input

`HEADER_RE` matches `^#{1,6}` only. The draft was HTML, so every header rule was silent on `<h3>` elements. The subtitle was worse: it reached the page as a CLI argument to the page builder and never touched a file the linter could read.

Measured on `tests/sample-structure.md`, built from the headers that shipped:

| slot | stage 1 (markdown) | stage 1 (HTML, before) | stage 1 (HTML, after) |
|---|---|---|---|
| `Two decisions, and what the benchmarks actually say` | comma-clause | not scanned | comma-clause |
| `The composite index is a four-way tie` | thesis-shaped | not scanned | thesis-shaped |
| `The per-benchmark split is where the signal is` | thesis-shaped | not scanned | thesis-shaped |
| `Vendor response, and its limits` | comma-clause | not scanned | comma-clause |
| `What this asks of us` | coy | not scanned | coy |

So the fix is flattening, not new rules. `<h1>`–`<h6>` become headings, and `.subtitle` / `.eyebrow` / `.post-meta` are treated as headings because a subtitle is a header by every test that matters. `--html` forces it, `--no-html` disables it.

## declaude_review.py

`declaude_review.py` extracts headers, the opening sentence, each closing sentence, and isolated one-sentence paragraphs, then sends only those to a model with the structural entries from `references/register.md`. Slots rather than the whole document, so the payload stays cheap enough to run on every draft.

Against the same fixture, across four runs: it caught the subtitle, the two coy headers and the aphoristic closer every time; `Vendor response, and its limits` in three of four; `The composite index is a four-way tie` in none. Zero false positives on the eight clean slots, including `EU AI Act, Article 50`, where the comma belongs to a citation — the case the regex flags and a reader does not.

That split is the argument for keeping both. Stage 1 catches the flat verdict header deterministically and over-flags commas. Stage 2 catches the closer, which no regex reaches, and reads a comma in context. Neither subsumes the other.

`challenging`'s `prose-register` profile already does whole-document register review against a caller-supplied voice signature, and remains the thorough pass. This is the cheap one. SKILL.md now points at it explicitly rather than leaving the two to compete.

## Also

- Version 0.2.1 → 0.3.0, CHANGELOG entry.
- Workflow step 2 gains the HTML note, plus an instruction to lint every string that reaches the reader rather than the body file alone.
- New step 2b for the review script, with the warning not to run it in the context that wrote the draft.
- Fixtures `tests/sample-structure.md` and `tests/sample-structure.html`.

## Not verified in-session

No CI gate exists for this skill. Ruff 0.16.0 at defaults reports `FURB167` (regex flag aliases) on the new script; the existing `declaude_lint.py` carries seven of the same at baseline, and the new file follows the file it sits next to. Run before merge:

```
python3 declauding/scripts/declaude_lint.py declauding/tests/sample-structure.md
python3 declauding/scripts/declaude_lint.py declauding/tests/sample-structure.html
python3 declauding/scripts/declaude_review.py declauding/tests/sample-structure.md --slots
uvx ruff@0.16.0 check declauding/scripts/
```
