### PR TITLE
declauding v0.3.0 — two stages: HTML-aware scan, triad and reuse detection, and a slot-based model pass

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,151 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-08-17
+
+Three branches folded into one version: a recall pass on the linter, the
+structural-pass work from #762, and the guard work from an unmerged 0.2.2. They
+were three answers to the same complaint and shipping them separately would have
+meant three 0.3.0s.
+
+The shape that results is two stages. Stage 1 is `declaude_lint.py`, which now
+sees HTML and detects triads, reuse and repetition. Stage 2 is
+`declaude_review.py`, which sends only the slots regex cannot judge — headers,
+opening sentence, closers, isolated lines — to a model. Neither subsumes the
+other: stage 1 over-flags a comma that belongs to a citation, stage 2 reads it in
+context; stage 1 finds a verdict header every time, stage 2 finds the aphoristic
+closer no regex reaches.
+
+Measured by scoring the linter against a hand annotation of the same 900-word
+draft: 31 candidates, 24 of them real, against 68 instances a full
+sentence pass found. Recall 35 percent, precision 77. After this release the same
+draft reports 60 candidates, 45 real, for 66 percent recall at 90 percent
+precision, with `tests/sample-clean.md` still at zero.
+
+Every miss had the same cause. The rules were closed vocabulary lists, and real
+prose used a word that was not on the list: the participle rule listed
+`highlighting|underscoring|emphasizing` and walked past `hitting`, `genuinely`
+had a six-word whitelist and walked past `genuinely considered`, and
+`the (part|thing) that` required `matters|counts|transfers` and walked past
+`the thing that made it slow`. Widening those to shapes rather than words
+recovered 21 instances at zero cost to the clean corpus.
+
+### Added
+
+- **Forced triad detection**, category `triad`. Entry 26 had no rule at all, and
+  it was the largest single category in the evaluation draft at seven instances.
+  Two detectors: a comma list with negative lookaheads for relative pronouns, and
+  an anaphora form covering three consecutive sentences or three consecutive
+  clauses opening on the same two words. The anaphora form catches
+  `It was a message. It was a permission slip. It was an out.` and
+  `something to steer toward, something to be measured against, something to fear`,
+  neither of which the comma rule can see. The new earned-exception row for entry
+  26 is the guard on it, and entry 27 read in the right direction is the guard on
+  the repetition statistics below.
+- **`reuse` block.** Groups the hits already found and reports any construction
+  used more than once, with its line numbers. No new rules, no new scanning. The
+  evaluation draft used `the part that` three times and the linter previously
+  reported three unrelated hits.
+- **Per-instance em-dash gotcha**, category `em-dash`: a dash whose clause runs to
+  the end of the sentence, which is the drum-roll shape rather than the aside.
+  Density was already reported; the individual dashes were not. Entry 16 gains a
+  demotion test: replace the dashes with commas, and see whether the aside
+  survives. A beat does not, because the beat was the punctuation.
+- **Document-level repetition statistics**: repeated sentence openings and
+  repeated content trigrams. Uniformity is the tell, and it is measurable without
+  a reference corpus, which is why this is a statistic rather than a model.
+- Widened rules for participle tails at sentence end, `genuinely` as a
+  self-grade, `the part/thing that`, `Nobody` claims, `Not X.` fragments,
+  `represents a kind of X`, sentence-initial from-X-to-Y, `Here is what X:`,
+  `which was this:`, `that's not quite right`, a doubled adverb, and
+  `the entire architecture of the thing`.
+- Specimens for all of the above in `tests/sample-tics.md`, which now reports 91
+  candidates across 28 categories, up from 62 across 24.
+
+Stage 2, from #762:
+
+- `scripts/declaude_review.py`. Extracts headers, opening and closing sentences,
+  and isolated one-sentence paragraphs, then judges only those against the
+  structural entries in `references/register.md`. Gemini or Anthropic key,
+  `--emit-prompt` fallback, `--slots` for extraction only. Against the structure
+  fixture across four runs it caught the subtitle, both coy headers and the
+  aphoristic closer every time, with zero false positives on the eight clean
+  slots — including `EU AI Act, Article 50`, where the comma belongs to a
+  citation and stage 1 flags it.
+- Entry 26 added to its register slice. Stage 1 detects a triad deterministically
+  but cannot judge whether the content had three things, and a closer is where
+  the padded ones land.
+- `tests/sample-structure.md` and `tests/sample-structure.html`, built from
+  headers that shipped past a clean report.
+- Workflow step 2b, with the warning not to run stage 2 in the context that wrote
+  the draft. A model reviewing its own prose is the actor that chose the words.
+
+From the folded 0.2.2 branch:
+
+- Earned exceptions now covers 17 of the 37 entries, in two tables, with the
+  entry number on every row. It covered 5, all from the first block, while the
+  second block carried its exceptions as prose buried inside individual entries.
+- The paragraph naming what hides inside a watched phrase: superlatives,
+  rankings, simultaneity, scope words, and the condition attached to a hedge.
+- A dropped-claim check in workflow step 5 and as self-check 11, asked as a
+  question and answered claim by claim. A dropped superlative leaves the
+  paragraph looking intact, which is why a read-through misses it.
+- `Earned when` notes on entries 25, 27, 28, 29 and 34, which had none.
+
+### Fixed
+
+- A one-line paragraph that is a line of dialogue reported as a drama line break.
+  `tests/sample-clean.md` now carries a four-line exchange as the regression
+  control and still reports zero.
+- `aphorism` was missing from `CATEGORY_ORDER`, so its hits sorted after the
+  document-level density block instead of with the sentence-level tells.
+- The `reuse` counter treated two rules matching the same span as two uses.
+  Deduplicated on offset, so a genuine repeat on one line still counts twice.
+- Entry 11 explained itself with "the negation-first shape wearing a costume",
+  which is entry 37. The skill cannot ban a shape in one entry and use it in
+  another. (From the folded 0.2.2 branch.)
+- `declaude_lint.py` scanned markdown headings only, so every header rule was
+  silent on an HTML draft: three thesis-shaped headers, a comma-clause header and
+  a coy header shipped past a clean report. HTML is now flattened before
+  scanning, and masthead `.subtitle` / `.eyebrow` / `.post-meta` elements are
+  scanned as headings, because a subtitle is a header by every test that matters.
+  Step 2 also now says to lint every string that reaches the reader, since a
+  builder taking the subtitle as a CLI argument hides it from any file scan.
+  (From #762.)
+
+### Changed
+
+- Workflow step 2 no longer claims the linter misses every structural tic, which
+  stopped being true with this release. It now says which third it does miss:
+  staged paragraph shape, staged closers, dressed metaphor, and every earned
+  exception in the tables. That third is the expensive one and it stays with the sentence pass.
+- Step 2 shows `--skip-quoted` alongside the bare invocation. The evaluation run
+  did not use it and spent two of its seven false positives on the draft's own
+  quoted specimens.
+
+### Not shipped
+
+A TF-IDF classifier over model-written and human-written corpora was considered
+and rejected. Bag-of-n-grams is a strictly weaker feature space than regex plus
+the positional checks already here, so it can surface no tic class this cannot;
+its output is a score with no span and no register entry, which does not fit a
+tool whose contract is candidates a reader can check; and it would learn "not
+this author" rather than "machine-shaped", which conflicts with the rule that the
+author's own writing outranks the register. It remains useful offline as a rule
+miner: train it, read the coefficients, hand-pick the real ones, ship regexes.
+The document-level repetition statistics above are the part of that idea that
+survives, and they need no corpus and no training. The model-shaped part of the
+problem it was aimed at is answered by stage 2 instead, which sends slots to a
+model that can name the tic and cite the entry rather than returning a score.
+
+A widened bolded-bullet rule was also cut. It caught one real instance in the
+evaluation draft and fired seven times on this skill's own "Leave these alone"
+list, where the labels are exactly the real index the folded branch wrote into
+entry 29's earned form. The rule now tests for the restatement with a
+backreference, which is entry 29's actual tell, and the looser shape stays with
+the sentence pass. Two branches reached that boundary independently, one by
+reading the register and one by watching a rule misfire.
+
 ## [0.2.1] - 2026-08-16
 
 ### Other

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -86,8 +86,28 @@ python3 scripts/declaude_lint.py DOC.md --skip-quoted # ignore quoted specimens
 
 Stdlib only. It flags the lexical tells with line numbers and categories, plus
 header shape, Title Case headings, one-line-paragraph beats, fragment runs,
-inline-header bullets, em-dash density, curly-quote and emoji counts, and
+forced triads in both their comma-list and anaphora forms, inline-header bullets
+whose label restates the item, per-instance em-dash drum rolls, em-dash density,
+repeated sentence openings and phrases, curly-quote and emoji counts, and
 sentence-length monotony.
+
+The `reuse` block groups the hits the scan already produced and reports any
+construction used more than once. It adds no rules and costs nothing, and reuse
+is the strongest available evidence that a construction is a habit rather than a
+choice: one `the part that` is emphasis, three is a tic.
+
+HTML is flattened before scanning, so `<h1>`–`<h6>` and masthead
+`.subtitle` / `.eyebrow` / `.post-meta` elements reach the header rules. Before
+0.3.0 every header rule was silent on an HTML draft.
+
+`scripts/declaude_review.py` is stage 2. It extracts the slots regex cannot judge
+— headers, the opening sentence, each closing sentence, isolated one-sentence
+paragraphs — and sends only those to a model with the structural register
+entries. Slots rather than the whole document, so it is cheap enough to run every
+time. The two stages are complementary rather than redundant: stage 1 catches the
+verdict header deterministically and over-flags commas that belong to citations,
+stage 2 reads the comma in context and catches the aphoristic closer that no
+regex reaches.
 
 `--skip-quoted` blanks blockquotes, table rows, code (fenced and inline),
 `*italic*` spans and `<q>` elements while preserving line numbers. Use it on any
@@ -103,17 +123,22 @@ as a pre-commit hook.
 ## False positives
 
 `tests/sample-clean.md` is human-written prose and must lint to zero.
-`tests/sample-tics.md` is a corpus of real specimens and currently reports 62
-candidates across 24 categories.
+`tests/sample-tics.md` is a corpus of real specimens and currently reports 91
+candidates across 28 categories.
 
 ```sh
-python3 scripts/declaude_lint.py tests/sample-tics.md    # 62 candidates
+python3 scripts/declaude_lint.py tests/sample-tics.md    # 91 candidates
 python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
+python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 7, all checked
+python3 scripts/declaude_lint.py tests/sample-structure.html   # 10, HTML path
+python3 scripts/declaude_review.py tests/sample-structure.md --slots
 ```
 
-Two rules are deliberately tuned down to hold that zero, so the linter misses
-some real coy headers. A linter that fires on good writing gets ignored, and
-then it catches nothing.
+Several rules are deliberately tuned down to hold that zero, so the linter misses
+some real coy headers and some real inline-header bullets. A linter that fires on
+good writing gets ignored, and then it catches nothing. This skill's own prose is
+the second clean corpus: a rule that fires seven times on `SKILL.md` is a bad
+rule, and one did.
 
 ## Overcorrection
 
@@ -129,9 +154,13 @@ rather than left to judgment:
 - Sentence length varies with content. Uniformity is its own tell.
 - Digression and mild informality are human. Symmetry and antithesis are not.
 
-Several banned shapes have an earned form, tabulated in `SKILL.md`. *X rather
-than Y* is legitimate when the reader was genuinely holding Y; it is staged when
-you supplied Y so you could reject it.
+Every entry fires on a shape, and a shape sometimes carries a claim. Cutting it
+then removes content while looking like it removed only style. `SKILL.md`
+tabulates the earned form of 17 of the 37 entries, and names what hides inside a
+watched phrase: superlatives, rankings, simultaneity, scope words, and the
+condition attached to a hedge. *X rather than Y* is legitimate when the reader
+was genuinely holding Y; it is staged when you supplied Y so you could reject
+it.
 
 ## Tics carry factual errors
 

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -2,7 +2,7 @@
 name: declauding
 description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.2.1
+  version: 0.3.0
 ---
 
 # Declauding
@@ -38,9 +38,9 @@ who studies it*, or gets cut. It does not become *researchers at Lanzhou
 University* unless the source says so. When a sentence needs real-world detail
 to work, ask for it or write the plain version without it.
 
-Opinions and stance are voice, not facts. Keeping the author's judgment is
-required (see Overcorrection); adding a factual claim they did not make is a
-defect even when the result reads more human.
+Opinions and stance count as voice rather than fact. Keeping the author's
+judgment is required (see Overcorrection); adding a factual claim they did not
+make is a defect even when the result reads more human.
 
 ## The one pattern
 
@@ -83,12 +83,61 @@ they are the most valuable thing this pass produces.
 
 ```
 python3 scripts/declaude_lint.py DRAFT.md
+python3 scripts/declaude_lint.py DRAFT.html               # HTML is flattened automatically
+python3 scripts/declaude_lint.py DRAFT.md --skip-quoted   # if the draft quotes bad prose
 ```
 
-It flags greppable tells with line numbers and categories. It has no judgment —
-it finds candidates, it does not decide. Everything it flags still needs the
-sentence-level test, and it misses every tic that is structural rather than
-lexical. Treat a clean lint report as meaningless on its own.
+It flags greppable tells with line numbers and categories, plus four shapes that
+are not lexical: forced triads in both their comma-list and anaphora forms,
+one-line-paragraph beats, fragment runs, and constructions the document uses more
+than once. The `reuse` block is the cheapest signal it produces, because a
+construction used twice is a habit and counting is free.
+
+It has no judgment. Everything it flags still needs the sentence-level test, it
+reaches roughly two thirds of what a careful pass finds, and the third it misses
+is the expensive third: staged paragraph shape, staged closers, dressed metaphor,
+and every earned exception in the tables below. Step 2b takes part of that third;
+the rest is yours. Treat a clean report as meaningless on its own.
+
+Use `--skip-quoted` on any draft that quotes bad prose as a specimen. Without it
+the scan reports the draft's own examples, which is how a real pass loses time.
+
+HTML input is flattened before scanning: `<h1>`–`<h6>` become headings so the
+header rules see them, and a `.subtitle`, `.eyebrow` or `.post-meta` element is
+treated as a heading too, because a subtitle is a header by every test that
+matters. Force with `--html`, disable with `--no-html`. Reported line numbers
+refer to the flattened view.
+
+Lint every string that reaches the reader, not only the body file. Page titles,
+subtitles and deck headers are prose, and a builder that takes them as CLI
+arguments rather than from the file will hide them from this scan.
+
+**2b. Run the structural review.**
+
+```
+python3 scripts/declaude_review.py DRAFT.md
+```
+
+This is the third the scan cannot reach. It extracts the slots regex cannot
+judge — every header, the opening sentence, each closing sentence, isolated
+one-sentence paragraphs — and sends only those to a model with the structural
+entries from `references/register.md`. Slots rather than the whole document,
+because the payload stays small enough to run on every draft. Use
+`--emit-prompt` where no API key is available, `--slots` to see the extraction
+alone.
+
+The two stages do not subsume each other. Stage 1 finds the flat verdict header
+deterministically and over-flags commas, including the ones that belong to a
+citation. Stage 2 reads a comma in context and finds the aphoristic closer, which
+no regex reaches. Run both.
+
+Run stage 2 in a context that did not write the draft. A model reviewing its own
+prose is the actor that chose the words.
+
+For a full-document register review against a named voice signature — positive
+markers, drift across the piece, imposter test — use the `challenging` skill's
+`prose-register` profile instead. This script is the cheap pass; that one is the
+thorough one.
 
 **3. Sentence pass.** For every sentence, in order: stating or staging? Load
 `references/register.md` for the catalogue of tells and their fixes.
@@ -99,11 +148,15 @@ questions, and the closer (does the last paragraph paraphrase the subtext of
 what preceded it? delete it).
 
 **5. Check what the edit did.** Four failure modes, all of them common:
-- Content lost. Every fact, number, caveat and hedge-with-content in the source
-  must survive. A tic wrapping a real qualification is still a real
-  qualification. Structure is free — merge or split paragraphs, compress the dull
-  parts, dwell where the author would. When keeping the information and mirroring
-  the original's shape pull against each other, the information wins.
+- Content lost. Ask it as a question and answer it claim by claim, not paragraph
+  by paragraph: *does the rewrite drop a claim the source made?* A dropped
+  superlative leaves the paragraph looking intact, which is why the
+  read-through misses it. Every fact, number, caveat and hedge-with-content must
+  survive; a tic wrapping a real qualification is still a real qualification.
+  See Earned exceptions for what hides inside a watched phrase. Structure is
+  free — merge or split paragraphs, compress the dull parts, dwell where the
+  author would. When keeping the information and mirroring the original's shape
+  pull against each other, the information wins.
 - Claims changed. Rewriting "the drop is largest where chains are longest" into
   "long chains cause the drop" is an edit that invents a finding. Register only.
 - Facts invented. Ask it directly: does the rewrite state any name, number, date
@@ -165,16 +218,42 @@ example where the phrase is being discussed rather than used. The linter's
 
 ## Earned exceptions
 
-Several banned shapes are legitimate in one specific circumstance. Check before
-deleting:
+Every entry fires on a shape, and a shape sometimes carries a claim. Cutting it
+then removes content while looking like it removed only style, and the result
+reads fluently, so a read-through does not catch it. Check before deleting.
+
+Staging shapes, entries 1 to 23 and 37:
 
 | Shape | Banned when | Earned when |
 |---|---|---|
-| "X rather than Y" | You invented Y so you could reject it | The reader was genuinely holding Y — the draft proposed it, or it is the field's default |
-| "Nobody noticed" | Unfalsifiable claim about others' inattention | You can name the mechanism and duration: "nobody noticed for six weeks because the dashboard only alarms on nulls" |
-| Isolated one-line paragraph | Gravitas beat | Real pivot: new actor, category shift, time jump |
-| Colon before the payload | Withholding for a beat | The payload is a list, a definition, or a code block |
-| Short declarative closer | Compresses the section into a moral | States a fact: "Default retries are back to 3." |
+| "X rather than Y" (2) | You invented Y so you could reject it | The reader was genuinely holding Y — the draft proposed it, or it is the field's default |
+| "Nobody noticed" (3) | Unfalsifiable claim about others' inattention | You can name the mechanism and duration: "nobody noticed for six weeks because the dashboard only alarms on nulls" |
+| Isolated one-line paragraph (9) | Gravitas beat | Real pivot: new actor, category shift, time jump |
+| Colon before the payload (8) | Withholding for a beat | The payload is a list, a definition, or a code block |
+| Short declarative closer (12) | Compresses the section into a moral | States a fact: "Default retries are back to 3." |
+| Em dash (16) | The dash stages a beat before the punch | A genuine inline aside, or the author's sample uses them at that rate |
+| Metaphor (6, 37) | It dresses a mechanism you could name | It is the clearest available description and no plain noun fits |
+
+Encyclopedic shapes, entries 24 to 36:
+
+| Shape | Banned when | Earned when |
+|---|---|---|
+| Participle tail (25) | The tail asserts significance the sentence has not earned | The clause carries a sourced claim — make it its own sentence rather than cutting it |
+| Forced triad (26) | The count came from rhythm | There are genuinely three things, or a superlative or ranking rides on the phrasing |
+| Elegant variation (27) | The same referent renamed for variety | The second term names a genuinely different thing |
+| False range (28) | X and Y are not endpoints of any scale | A real range with real endpoints |
+| Inline-header list (29) | The label restates the item | The label is a real index: a term being defined, an option name, a case name |
+| Typographic tells (30) | Bold, emoji or Title Case scattered mechanically | Bold on a term at first use; the document already uses emoji; a house style requires Title Case |
+| Filler and hedging (32) | Hedges stack and none names a condition | One hedge names a real condition: "on the two runs that finished" |
+| Diff-anchored (34) | The doc narrates the change that produced it | The document is version-scoped by design: changelogs, release notes, migration guides |
+| Subjectless fragment (35) | The actor is known and matters | The register is clipped throughout — release notes, a feature table, a CLI help string |
+| Predicate hyphenation (36) | Every pair is hyphenated in both positions | House style or a quoted source sets it |
+
+**Modifiers inside a watched phrase carry content.** "The single most important
+new build" ranks that item against every other item; "the important new build"
+ranks nothing. "Simultaneously X, Y and Z" claims the three hold at once; "X, Y
+and Z" does not. Superlatives, rankings, simultaneity, scope words, and the
+condition attached to a hedge all live inside phrasings this skill cuts.
 
 ## Annotated mode
 

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -61,7 +61,9 @@ carry itself, the problem is the content.
 
 **Watch for reuse.** Emphasis is a budget. The same designation twice in one
 piece ("the part that matters" / "the part that transfers") is no longer
-emphasis, and reuse is the easiest instance to catch.
+emphasis, and reuse is the easiest instance to catch. `declaude_lint.py` groups
+its own hits and reports a `reuse` block for any construction used twice, so this
+one costs nothing to check.
 
 ---
 
@@ -185,8 +187,9 @@ walking the reader through a discovery.
 **Tell:** quoting a wrong reading attributed to the reader, then rejecting it —
 *"It thinks twice as long" is the obvious reading of that, and it is wrong.*
 
-**Why:** the negation-first shape wearing a costume. The correction is the same
-length without the invented interlocutor.
+**Why:** entry 2's negation-first shape with an invented interlocutor supplying
+the negated half. The correction is the same length without them. (This sentence
+used to read "the negation-first shape wearing a costume", which is entry 37.)
 
 **Fix:** give the correction directly. *"That median does not mean it thinks twice
 as long. On the questions it finishes..."*
@@ -259,7 +262,12 @@ and human; the tic is the dash-as-drum-roll.
 
 **Fix:** if the clause is the point, make it the sentence. Also: count em-dashes.
 More than roughly one per 150 words reads as machine-written regardless of what
-each one is doing.
+each one is doing. The linter reports the density and, separately, each dash
+whose clause runs to the end of its sentence, which is the drum-roll shape rather
+than the aside.
+
+**Demotion test:** replace the dashes with commas. An aside survives it. A beat
+does not, because the beat was the punctuation.
 
 ---
 
@@ -390,6 +398,9 @@ own sentence.
 > now: *The temple is painted blue, green and gold, colours chosen to evoke
 > Texas bluebonnets and the Gulf of Mexico.*
 
+**Earned when** the clause carries a sourced claim. Then it is the shape that is
+wrong, not the content: promote it to its own sentence rather than cutting it.
+
 ---
 
 ## 26. Forced triad
@@ -407,7 +418,17 @@ three. The count is chosen by rhythm rather than by the content.
 > opportunities.*
 > now: *The event has talks and panels, with time between them to talk to people.*
 
-**Earned when** there are genuinely three things.
+**Earned when** there are genuinely three things, or a superlative or ranking
+rides on the phrasing.
+
+**Two shapes, one tic.** The comma list ("keynote sessions, panel discussions,
+and networking opportunities") is the obvious one. The anaphora form carries the
+parallelism in the opening words instead: *It was a message. It was a permission
+slip. It was an out.* across sentences, or *something to steer toward, something
+to be measured against, something to fear* inside one. The linter catches both,
+and the document-level `opening repetition` count is the same tic spread thin
+enough that no single passage looks wrong. Entry 27 read in the right direction
+is the guard: repetition that is the point stays.
 
 ---
 
@@ -427,6 +448,9 @@ reads as a second thing.
 > obstacles. The central figure eventually triumphs.*
 > now: *The protagonist faces many challenges and eventually wins.*
 
+**Earned when** the second term names a genuinely different thing. Check that the
+referents really are identical before collapsing them.
+
 ---
 
 ## 28. False range
@@ -445,6 +469,9 @@ implies coverage the sentence does not have.
 > now: *The book covers the Big Bang, star formation and current theories about
 > dark matter.*
 
+**Earned when** the endpoints are real: "from 2 to 8 bits", "from onboarding to
+offboarding". A range with a scale under it is a range.
+
 ---
 
 ## 29. Inline-header list
@@ -462,6 +489,9 @@ labels only where they are a real index (a term being defined, an option name).
 > was: *- **Performance:** Performance has been enhanced through optimized
 > algorithms.*
 > now: *Load times dropped after the index moved off the hot path.*
+
+**Earned when** the label is a real index rather than a restatement: a term being
+defined, an option or flag name, a case name in a table of cases.
 
 ---
 
@@ -550,7 +580,10 @@ reads coherently only to someone who knows what the last commit did. Six months
 later nobody does.
 
 **Fix:** describe the current state. The change belongs in the commit message or
-the changelog, which are version-scoped by design.
+the changelog.
+
+**Earned when** the document is version-scoped by design — a changelog, release
+notes, a migration guide, an upgrade path. Narrating the change is the job there.
 
 > was: *This function was added to replace the previous approach of iterating
 > through all items, which caused quadratic performance.*
@@ -645,3 +678,7 @@ clean lint report.
 10. Does the rewrite contain a fact, name, number, date or citation that is not
     in the source? A fabrication is a defect even when it sounds more human than
     the vague original.
+11. Does the rewrite drop a claim the source made? Check claim by claim, not
+    paragraph by paragraph. Superlatives, rankings, simultaneity, scope words and
+    the condition attached to a hedge all sit inside phrasings this register
+    cuts, and the paragraph looks intact after they go.

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -23,18 +23,19 @@ RULES: list[tuple[str, str, str]] = [
     ("negation-first", r"\bnot\s+because\b[^.]{0,80}—\s*because\b", "not-because / because"),
     ("negation-first", r"\b(?:doesn't|does not|didn't|did not)\s+just\b[^.]{0,60}\b(?:it|they)\b", "doesn't just X, it Y's"),
     ("negation-first", r"\bthe\s+(?:problem|failure|issue|point|question|bug|risk)\s+(?:wasn't|isn't|was not|is not)\b", "the problem wasn't X"),
-    ("negation-first", r"[.!?]\s+Not\s+(?:that|because|a|an|the)\b[^.]{0,60}\.", "trailing 'Not X.' fragment"),
+    ("negation-first", r"[.!?]\s+Not\s+\w+[^.]{0,60}\.", "trailing 'Not X.' fragment"),
     ("negation-first", r",\s*not\s+[a-z][^.]{0,40}\.\s*$", "X, not Y closer"),
     ("negation-first", r"\b(?:is|are|was|were)\s+[a-z]{3,20},\s*not\s+[a-z]{3,20}\.", "X is A, not B — mid-paragraph, check the reader was holding B"),
 
     # --- significance designation -------------------------------------------
     ("significance", r"\bthe\s+(?:real|actual|true|useful|interesting|important|key)\s+(?:question|problem|issue|point|reason|answer|finding|story|move|tool|test|variable|number)\b", "the real/actual X"),
-    ("significance", r"\bthe\s+(?:part|thing|bit|piece|detail|one|leg|row|line|number|question)\s+that\s+(?:matters|counts|transfers|makes the point|does the work|answers|explains)\b", "the part that matters"),
+    ("significance", r"\bthe\s+(?:part|thing|bit|piece|detail)\s+(?:that|which)\b", "the part that — designation; the reader decides what matters"),
+    ("significance", r"\bthe\s+(?:one|leg|row|line|number|question)\s+that\s+(?:matters|counts|transfers|makes the point|does the work|answers|explains)\b", "the X that matters"),
     ("significance", r"\b(?:here'?s|this is)\s+(?:the thing|where it gets interesting|what)\b", "here's the thing"),
     ("significance", r"\band\s+(?:that'?s|it has)\s+(?:the interesting part|a name here)\b", "manufactured reveal"),
     ("significance", r"\bthe\s+(?:one|only)\s+thing\s+(?:nobody|no one)\b", "the one thing nobody"),
     ("significance", r"\b(?:most|more)\s+(?:interesting|telling|revealing|surprising)\s+(?:part|thing|number|finding)\b", "significance tag"),
-    ("significance", r"\bNobody\s+(?:had\s+)?(?:checked|noticed|asked|mentioned|said|looked)\b", "unfalsifiable 'nobody' claim — earned only with a named mechanism"),
+    ("significance", r"\bNobody\s+(?:had\s+)?(?:checked|noticed|asked|mentioned|said|told|saw|knew|looked|realized|realised|caught|tried|bothered|thought)\b", "unfalsifiable 'nobody' claim — earned only with a named mechanism"),
 
     # --- abstraction agency --------------------------------------------------
     ("agency", r"\b(?:the\s+)?(?:table|chart|graph|data|numbers?|median|mean|metric|figure|plot|log|code|result|headline)\s+(?:shows?|hides?|tells?|reveals?|says?|proves?|admits?|knows?|wants?)\b", "inanimate subject acting"),
@@ -60,6 +61,12 @@ RULES: list[tuple[str, str, str]] = [
     ("staging", r"^\s*(?:So|Then|And)\s+(?:the|here|now)\b[^.\n]{0,40}:\s*$", "colon-staged section lead"),
     ("staging", r"\bthe\s+(?:defensible|honest|short|real)\s+(?:statement|answer|version)\s*:", "noun-phrase colon stage"),
 
+    # --- em-dash gotcha, per instance ----------------------------------------
+    ("em-dash", r"—\s*[^—\n]{3,90}[.!?]\s*$", "clause after a dash running to the end of the sentence — dash as drum roll"),
+
+    # --- forced triad ---------------------------------------------------------
+    ("triad", r"\b(?!who\b|which\b|that\b|when\b)(\w+(?:\s+\w+){0,2}),\s+(?!who\b|which\b|that\b|when\b|obviously\b|however\b)(\w+(?:\s+\w+){0,2}),\s+and\s+(?!who\b|which\b|that\b|when\b)(\w+(?:\s+\w+){0,2})\b", "three parallel items — check the content has three, not two padded or five truncated"),
+
     # --- rhetorical question -------------------------------------------------
     ("rhetorical-q", r"^\s*(?:So\s+)?(?:how|why|what|where|when|does|is|can|should)\b[^?\n]{0,70}\?\s*$", "standalone rhetorical question — check if you answer your own question next"),
 
@@ -68,7 +75,7 @@ RULES: list[tuple[str, str, str]] = [
     ("self-grading", r"\b(?:that|this)\s+is\s+what\s+the\s+(?:data|numbers?|table|evidence)\s+shows?\b", "that is what the data shows"),
     ("self-grading", r"\b(?:it'?s|it is)\s+(?:worth|important)\s+(?:noting|mentioning|pointing out)\b", "worth noting"),
     ("self-grading", r"\ba\s+distinction\s+worth\b", "grading the distinction"),
-    ("self-grading", r"\bgenuinely\s+(?:useful|interesting|hard|novel|different|new)\b", "intensifier as self-grade"),
+    ("self-grading", r"\bgenuinely\s+(?:useful|interesting|hard|novel|different|new|considered|rigorous|surprising|original|important)\b", "intensifier as self-grade"),
 
     # --- performed humility --------------------------------------------------
     ("humility", r"\b(?:better|sharper|cleaner)\s+than\s+mine\b", "ranking others above yourself"),
@@ -90,6 +97,7 @@ RULES: list[tuple[str, str, str]] = [
 
     # --- editorializing ------------------------------------------------------
     ("editorializing", r"\b(?:collapse[sd]?|catastrophic|dramatic(?:ally)?|brutal|staggering|remarkable|impressive)\b", "check the number justifies the adjective"),
+    ("editorializing", r"\b(?:finally|belatedly|ultimately|eventually|inevitably),\s+(?:finally|belatedly|ultimately|eventually|inevitably),?\s", "doubled adverb — one of them is the verdict"),
 
     # --- time inflation ------------------------------------------------------
     ("time-inflation", r"\b(?:a (?:month|few months|while) ago|for a long time|all year|recently|these days)\b", "ground the duration or drop it"),
@@ -97,10 +105,14 @@ RULES: list[tuple[str, str, str]] = [
     ("aphorism", r"\bthe\s+kind\s+of\s+\w+\s+that\b[^.]{0,60}\band\s+is\s+not\b", "X that looks like Y and is not"),
     ("aphorism", r"\bthe\s+\w+\s+that\s+looks\s+like\s+\w+", "X that looks like Y"),
     ("aphorism", r"\b(?:by\s+a\s+wide\s+margin|was\s+the\s+move|is\s+the\s+whole\s+(?:point|bug|story))\b", "quotable closer"),
+    ("aphorism", r"\bthe\s+(?:entire|whole)\s+\w+\s+of\s+the\s+thing\b", "quotable closer"),
 
     # --- staging (more) ------------------------------------------------------
     ("staging", r"\b(?:here|this)\s+is\s+what\s+[^.]{0,60}\blooks?\s+like\b", "here is what X looks like"),
     ("staging", r"\bthen\s+the\s+(?:useful|real|interesting)\s+question\b", "heralding your own question"),
+    ("staging", r"\b(?:Here|This)\s+is\s+what\s+[^.\n]{0,60}:", "announces a list before giving it"),
+    ("staging", r"\bwhich\s+(?:was|is)\s+this\s*:", "withheld payload — the colon buys a beat"),
+    ("staging", r"\bthat'?s\s+not\s+quite\s+right\b", "self-correcting opener — the correction is the sentence; the error was supplied"),
 
     # ===== entries 24-36: encyclopedic and chatbot patterns ==================
 
@@ -108,19 +120,23 @@ RULES: list[tuple[str, str, str]] = [
     ("copula", r"\b(?:serves?|stands?|acts?)\s+as\s+(?:a|an|the)\b", "serves as — use is"),
     ("copula", r"\bboasts?\s+(?:a|an|the|over|more than|some|\d)", "boasts — use has"),
     ("copula", r"\b(?:it|which|that|the\s+\w+)\s+features\s+(?:a|an|the|over|\d)", "features — use has"),
-    ("copula", r"\b(?:represents|marks)\s+(?:a|an|the)\s+(?:shift|turning point|milestone|step|departure|moment)\b", "represents a shift"),
+    ("copula", r"\b(?:represents?|represented|marks?|marked)\s*(?:,\s*[^,\n]{0,45},)?\s*(?:a|an|the)\s+(?:kind|sort|type)\s+of\b", "represents a kind of X — use is"),
+    ("copula", r"\b(?:represents|represented|marks|marked)\s*(?:,\s*[^,\n]{0,45},)?\s*(?:a|an|the)\s+(?:shift|turning point|milestone|step|departure|moment|horizon|threshold)\b", "represents a shift"),
 
     # --- participle tail -----------------------------------------------------
     ("participle", r",\s*(?:highlight|underscor|emphasiz|reflect|symboliz|showcas|ensur|foster|cultivat|encompass|solidif|cement|underlin)\w*ing\b", "participle tail asserting significance"),
     ("participle", r",\s*contributing\s+to\b", "participle tail asserting significance"),
+    ("participle", r",\s+\w{3,}ing\b[^.!?\n]{0,70}[.!?]", "participle tail at sentence end — cut it, or make the claim its own sentence"),
 
     # --- false range ---------------------------------------------------------
     ("false-range", r"\bfrom\s+[^,.;]{3,45}\s+to\s+[^,.;]{3,45},\s*from\s+", "stacked from-X-to-Y ranges"),
     ("false-range", r"\b(?:everything|anything|ranging)\s+from\b[^.]{0,60}\bto\b", "false range — list the items"),
+    ("false-range", r"^From\s+the\s+[^,.;\n]{3,45}\s+to\s+the\s+[^,.;\n]{3,45},", "sentence-initial from-X-to-Y — check X and Y are endpoints of something"),
 
     # --- inline-header list --------------------------------------------------
     ("list-shape", r"^\s*[-*+]\s+\*\*[^*\n]{2,45}\*\*\s*:", "inline-header bullet — the label restates the item"),
     ("list-shape", r"^\s*[-*+]\s+\*\*[^*\n]{2,45}:\*\*", "inline-header bullet — the label restates the item"),
+    ("list-shape", r"^\s*[-*+]\s+\*\*(\w{4,})[^*\n]{0,44}\*\*\s*:?\s+(?:the|a|an)?\s*\1\b", "the bold label restates the item — an outline showing through the prose"),
 
     # --- chatbot residue -----------------------------------------------------
     ("chatbot", r"\b(?:great|excellent|good)\s+question\b", "chatbot residue"),
@@ -142,6 +158,7 @@ RULES: list[tuple[str, str, str]] = [
     ("filler", r"\bit\s+is\s+important\s+to\s+note\s+that\b", "delete the frame, keep the claim"),
     ("filler", r"\b(?:could|might|may|can)\s+(?:potentially|possibly|arguably|conceivably)\b", "stacked hedges — one carries the uncertainty"),
     ("filler", r"\bpotentially\s+possibly\b", "stacked hedges"),
+    ("filler", r"\bin\s+its\s+own\s+way,?\s+a\s+kind\s+of\b", "double hedge on a plain noun"),
 
     # --- speculative gap-filling ---------------------------------------------
     ("gap-fill", r"\bmaintains?\s+a\s+low\s+profile\b", "stock filler for an absent source"),
@@ -167,6 +184,47 @@ RULES: list[tuple[str, str, str]] = [
     ("hyphenation", r"\b(?:is|are|was|were|feels?|seems?)\s+(?:high-quality|cross-functional|data-driven|end-to-end|real-time|long-term|well-known|client-facing|decision-making|third-party|open-source)\b", "drop the hyphen after the noun"),
 ]
 
+HTML_HEADING_RE = re.compile(r"<h([1-6])\b[^>]*>(.*?)</h\1>", re.S | re.I)
+HTML_MASTHEAD_RE = re.compile(
+    r'<[^>]+class="[^"]*\b(subtitle|eyebrow|post-meta)\b[^"]*"[^>]*>(.*?)</', re.S | re.I)
+HTML_BLOCK_RE = re.compile(r"<(p|li|figcaption|summary)\b[^>]*>(.*?)</\1>", re.S | re.I)
+HTML_DROP_RE = re.compile(r"<(script|style|pre|code)\b.*?</\1>", re.S | re.I)
+HTML_ENTITIES = {"&nbsp;": " ", "&amp;": "&", "&lt;": "<", "&gt;": ">",
+                 "&quot;": '"', "&#39;": "'", "&#8212;": "\u2014", "&mdash;": "\u2014"}
+
+
+def looks_like_html(text: str) -> bool:
+    head = text[:4000].lower()
+    return "<html" in head or "<!doctype html" in head or bool(HTML_HEADING_RE.search(text))
+
+
+def _detag(fragment: str) -> str:
+    out = re.sub(r"<[^>]+>", " ", fragment)
+    for ent, ch in HTML_ENTITIES.items():
+        out = out.replace(ent, ch)
+    return re.sub(r"\s+", " ", out).strip()
+
+
+def html_to_lines(text: str) -> str:
+    """Flatten HTML into the line-oriented prose the rules expect.
+
+    Headings become markdown headings so the header rules see them, and
+    composing-html's masthead classes are treated as headings too — a subtitle
+    is a header by every test that matters. Line numbers refer to this
+    flattened view, not the source file.
+    """
+    text = HTML_DROP_RE.sub(" ", text)
+    parts: list[tuple[int, str]] = []
+    for m in HTML_HEADING_RE.finditer(text):
+        parts.append((m.start(), "#" * int(m.group(1)) + " " + _detag(m.group(2))))
+    for m in HTML_MASTHEAD_RE.finditer(text):
+        parts.append((m.start(), "## " + _detag(m.group(2))))
+    for m in HTML_BLOCK_RE.finditer(text):
+        parts.append((m.start(), _detag(m.group(2))))
+    lines = [t for _, t in sorted(parts) if t.strip(" #")]
+    return "\n\n".join(lines) + "\n"
+
+
 HEADER_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 COY_HEADER_RE = re.compile(r"^(?:what|why|how)\b(?!.*\?$)", re.I)
 VERDICT_HEADER_RE = re.compile(r"\b(?:is|are|isn'?t|aren'?t|was|wasn'?t|does|doesn'?t|actually|really|wrong|right|matters|counts)\b", re.I)
@@ -183,12 +241,20 @@ EMOJI_RE = re.compile(
 
 CATEGORY_ORDER = [
     "negation-first", "significance", "agency", "deferred-noun", "locator",
-    "staging", "rhetorical-q", "self-grading", "humility", "throat-clearing",
+    "staging", "triad", "em-dash", "aphorism", "rhetorical-q", "self-grading", "humility", "throat-clearing",
     "rtfm", "dev-cliche", "slop", "editorializing", "time-inflation",
     "copula", "participle", "false-range", "list-shape", "chatbot", "filler",
     "gap-fill", "diff-anchored", "subjectless", "hyphenation",
-    "header", "typography", "cadence", "density",
+    "header", "typography", "cadence", "reuse", "density",
 ]
+
+# A one-line paragraph that is a line of dialogue is a line of dialogue.
+DIALOGUE_RE = re.compile("^[\"\u201c\u2018']|[\"\u201d'](\\s*,)?\\s*(\\w+\\s+)?(said|asked|replied|answered)\\b")
+
+STOPWORDS = frozenset(
+    "the a an and or but if of to in for on at by is are was were be been it its "
+    "this that these those as with from not no so then than there here".split()
+)
 
 COMPILED = [(cat, re.compile(pat, re.I | re.M), note) for cat, pat, note in RULES]
 
@@ -220,7 +286,7 @@ def scan_lines(text: str) -> list[dict]:
             for m in rx.finditer(line):
                 hits.append({
                     "line": i, "category": cat, "note": note,
-                    "match": m.group(0).strip()[:90],
+                    "col": m.start(), "match": m.group(0).strip()[:90],
                 })
 
         # headers
@@ -253,13 +319,54 @@ def scan_lines(text: str) -> list[dict]:
             prev_blank = i == 1 or not lines[i - 2].strip()
             next_blank = i >= len(lines) or not lines[i].strip()
             words = len(stripped.split())
-            if prev_blank and next_blank and words <= 8 and stripped.endswith((".", "!")):
+            if (prev_blank and next_blank and words <= 8
+                    and stripped.endswith((".", "!"))
+                    and not DIALOGUE_RE.search(stripped)):
                 hits.append({"line": i, "category": "cadence",
                              "note": "one-line paragraph — gravitas beat unless it is a real pivot",
                              "match": stripped[:90]})
 
     hits.extend(_fragment_runs(text))
+    hits.extend(_anaphora_runs(text))
     return hits
+
+
+def _anaphora_runs(text: str) -> list[dict]:
+    """Three units in a row opening on the same two words.
+
+    Across sentences this is the `It was a message. It was a permission slip.
+    It was an out.` shape; within one sentence it is `something to X, something
+    to Y, something to Z`. Both are entry 26 with the parallelism carried by
+    the opening rather than by a comma list, and neither is reachable by the
+    triad regex.
+    """
+    out = []
+    line_no = 1
+
+    def key(unit: str) -> str:
+        return " ".join(unit.lower().split()[:2]).strip(",;:.\"'()")
+
+    for para in re.split(r"\n\s*\n", text):
+        n = para.count("\n") + 1
+        if not para.strip().startswith(("#", "-", "*", ">", "|", "`")):
+            sents = [s.strip() for s in re.split(r"(?<=[.!?])\s+", para.strip()) if s.strip()]
+            for scope, units in (("sentences", sents),
+                                 *(("clauses", [c.strip() for c in re.split(r"[,;]\s+", s) if c.strip()])
+                                   for s in sents)):
+                keys = [key(u) for u in units]
+                run = 1
+                for i in range(1, len(keys)):
+                    run = run + 1 if keys[i] and keys[i] == keys[i - 1] else 1
+                    if run == 3:
+                        out.append({
+                            "line": line_no, "category": "triad",
+                            "note": f"three consecutive {scope} opening on the same two words — "
+                                    "forced triad carried by anaphora",
+                            "match": f"{keys[i]!r} x3: {units[i][:60]}",
+                        })
+                        break
+        line_no += n + 1
+    return out
 
 
 def _fragment_runs(text: str) -> list[dict]:
@@ -279,6 +386,40 @@ def _fragment_runs(text: str) -> list[dict]:
                                 "match": para.strip()[:90]})
                     break
         line_no += n + 1
+    return out
+
+
+def scan_reuse(hits: list[dict]) -> list[dict]:
+    """Constructions the document uses more than once.
+
+    Emphasis is a budget. One `the part that` is emphasis; three is a habit,
+    and it is the cheapest structural tic to catch because you only have to
+    count. This adds no rules — it groups the hits already found.
+    """
+    groups: dict[tuple[str, str], list[int]] = {}
+    seen: set[tuple] = set()
+    for h in hits:
+        if h["category"] in {"density", "typography", "reuse"} or not h["line"]:
+            continue
+        norm = " ".join(h["match"].lower().split())[:40]
+        # two rules firing on one span is one instance, not a repetition. Hits
+        # from the header and cadence scans carry no offset, so fall back to the
+        # matched text, which is the whole line for those.
+        ident = (h["category"], h["line"], h["col"] if h.get("col") is not None else norm)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        groups.setdefault((h["category"], norm), []).append(h["line"])
+
+    out = []
+    for (cat, match), lines in groups.items():
+        if len(lines) < 2:
+            continue
+        where = ", ".join(f"L{n}" for n in sorted(lines))
+        out.append({"line": 0, "category": "reuse",
+                    "note": f"[{cat}] used {len(lines)} times ({where}) — "
+                            "reuse is the evidence that a construction is a habit, not a choice",
+                    "match": match})
     return out
 
 
@@ -318,6 +459,35 @@ def scan_density(text: str) -> list[dict]:
                             "unless the document already uses them",
                     "match": "".join(sorted(set(emoji))[:12])})
 
+    if len(sentences) >= 10:
+        openings: dict[str, int] = {}
+        for s in sentences:
+            k = " ".join(s.lower().split()[:2]).strip(",;:.\"'()")
+            if k:
+                openings[k] = openings.get(k, 0) + 1
+        floor = max(3, len(sentences) * 0.03)
+        hot = sorted((n, k) for k, n in openings.items() if n >= floor)
+        if hot:
+            worst = ", ".join(f"{k!r} x{n}" for n, k in reversed(hot[-3:]))
+            out.append({"line": 0, "category": "density",
+                        "note": f"repeated sentence openings: {worst} — anaphora spread across a "
+                                "document is the diffuse form of the forced triad",
+                        "match": "opening repetition"})
+
+    toks = re.findall(r"[a-z']+", body.lower())
+    grams: dict[tuple[str, ...], int] = {}
+    for i in range(len(toks) - 2):
+        g = tuple(toks[i:i + 3])
+        if not all(w in STOPWORDS for w in g):
+            grams[g] = grams.get(g, 0) + 1
+    repeats = sorted((n, g) for g, n in grams.items() if n >= 3)
+    if repeats:
+        worst = ", ".join(f"{' '.join(g)!r} x{n}" for n, g in reversed(repeats[-3:]))
+        out.append({"line": 0, "category": "density",
+                    "note": f"repeated phrases: {worst} — check each is the deliberate "
+                            "repetition entry 27 protects and not a cadence",
+                    "match": "phrase repetition"})
+
     lens = [len(s.split()) for s in sentences]
     if len(lens) > 20:
         mean = sum(lens) / len(lens)
@@ -336,13 +506,19 @@ def main() -> int:
     ap.add_argument("--quiet-slop", action="store_true", help="hide the slop/editorializing/time categories")
     ap.add_argument("--skip-quoted", action="store_true",
                     help="ignore blockquotes, *italic* spans and table cells — use on docs that quote bad prose as specimens")
+    ap.add_argument("--html", action="store_true",
+                    help="force HTML flattening (headings, masthead subtitle, block prose)")
+    ap.add_argument("--no-html", action="store_true", help="never flatten; scan the raw source")
     args = ap.parse_args()
 
     text = sys.stdin.read() if args.path == "-" else Path(args.path).read_text(encoding="utf-8")
+    if args.html or (not args.no_html and looks_like_html(text)):
+        text = html_to_lines(text)
     if args.skip_quoted:
         text = _blank_quoted(text)
 
     hits = scan_lines(text) + scan_density(text)
+    hits += scan_reuse(hits)
     if args.quiet_slop:
         hits = [h for h in hits if h["category"] not in {"slop", "editorializing", "time-inflation"}]
 

--- a/declauding/scripts/declaude_review.py
+++ b/declauding/scripts/declaude_review.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Stage 2 of the register pass: judgment on the slots regex cannot reach.
+
+declaude_lint.py is lexical. It scans for phrases. The tics it cannot see are
+structural — a header that states a verdict, a closer that paraphrases the
+subtext above it, an isolated line used as a drum roll. Those need a reader.
+
+This script extracts only the structural slots (title, subtitle, every header,
+the opening sentence, each section's closing sentence, isolated one-sentence
+paragraphs) and sends them to a model with the matching entries from
+references/register.md. Slots rather than the whole document, because that is
+where the structural tics live and a small payload is cheap enough to run on
+every draft.
+
+    python3 declaude_review.py DRAFT.md                 # judge (needs an API key)
+    python3 declaude_review.py DRAFT.html --emit-prompt # print the prompt instead
+    python3 declaude_review.py DRAFT.md --slots         # show what was extracted
+
+Keys, in order of preference: GEMINI_API_KEY, then ANTHROPIC_API_KEY. With
+neither set the script falls back to --emit-prompt and says so.
+
+Do not run this on your own draft in the context that wrote it. The judgment
+wants a reader who did not choose the words.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REGISTER = Path(__file__).resolve().parent.parent / "references" / "register.md"
+
+# register.md entries that describe structural tics. Loaded verbatim so the
+# catalogue stays single-source; adding an entry there needs no edit here.
+# 26 is here because stage 1 detects triads deterministically but cannot judge
+# whether the content had three things, and a closer is where the padded ones
+# land.
+STRUCTURAL_ENTRIES = (1, 2, 3, 7, 9, 12, 13, 26)
+
+SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+TAG = re.compile(r"<[^>]+>")
+
+
+def strip_tags(s: str) -> str:
+    s = re.sub(r"<(script|style)\b.*?</\1>", " ", s, flags=re.S | re.I)
+    s = TAG.sub(" ", s)
+    s = (s.replace("&nbsp;", " ").replace("&amp;", "&")
+          .replace("&lt;", "<").replace("&gt;", ">").replace("&#8212;", "—"))
+    return re.sub(r"[ \t]+", " ", s).strip()
+
+
+def sentences(text: str) -> list[str]:
+    return [s.strip() for s in SENTENCE_END.split(text.strip()) if s.strip()]
+
+
+def load_register(entries=STRUCTURAL_ENTRIES) -> str:
+    if not REGISTER.exists():
+        return ""
+    blocks, current, keep = [], [], False
+    for line in REGISTER.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"^## (\d+)\.", line)
+        if m:
+            if keep and current:
+                blocks.append("\n".join(current).strip())
+            current, keep = [], int(m.group(1)) in entries
+        if keep:
+            current.append(line)
+    if keep and current:
+        blocks.append("\n".join(current).strip())
+    return "\n\n".join(blocks)
+
+
+def extract_html(text: str) -> list[tuple[str, str]]:
+    slots: list[tuple[str, str]] = []
+    for cls, label in (("eyebrow", "eyebrow"), ("subtitle", "subtitle")):
+        for m in re.finditer(rf'class="[^"]*\b{cls}\b[^"]*"[^>]*>(.*?)<', text, re.S):
+            if strip_tags(m.group(1)):
+                slots.append((label, strip_tags(m.group(1))))
+    for m in re.finditer(r"<h([1-6])[^>]*>(.*?)</h\1>", text, re.S | re.I):
+        slots.append((f"h{m.group(1)}", strip_tags(m.group(2))))
+    paras = [strip_tags(m.group(1)) for m in
+             re.finditer(r"<p[^>]*>(.*?)</p>", text, re.S | re.I)]
+    slots += _prose_slots([p for p in paras if p])
+    return slots
+
+
+def extract_markdown(text: str) -> list[tuple[str, str]]:
+    slots: list[tuple[str, str]] = []
+    body: list[str] = []
+    fm = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    if fm:
+        for line in fm.group(1).splitlines():
+            if line.lower().startswith(("title:", "subtitle:", "description:")):
+                k, _, v = line.partition(":")
+                slots.append((k.strip().lower(), v.strip().strip("\"'")))
+        text = text[fm.end():]
+    fenced = False
+    for line in text.splitlines():
+        if line.startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            slots.append((f"h{len(m.group(1))}", m.group(2).strip()))
+        else:
+            body.append(line)
+    paras = [p.strip().replace("\n", " ") for p in "\n".join(body).split("\n\n")]
+    slots += _prose_slots([p for p in paras if p and not p.startswith(("|", ">", "-", "*"))])
+    return slots
+
+
+def _prose_slots(paras: list[str]) -> list[tuple[str, str]]:
+    """Opening sentence, last sentence of the final paragraph, isolated lines."""
+    out: list[tuple[str, str]] = []
+    if not paras:
+        return out
+    first = sentences(paras[0])
+    if first:
+        out.append(("opening", first[0]))
+    last = sentences(paras[-1])
+    if last:
+        out.append(("closer", last[-1]))
+    for p in paras[1:-1]:
+        s = sentences(p)
+        if len(s) == 1 and len(s[0].split()) <= 18:
+            out.append(("isolated-line", s[0]))
+    return out
+
+
+def extract(path: Path) -> list[tuple[str, str]]:
+    text = path.read_text(encoding="utf-8")
+    is_html = path.suffix.lower() in {".html", ".htm"} or "<html" in text[:2000].lower()
+    slots = extract_html(text) if is_html else extract_markdown(text)
+    seen, uniq = set(), []
+    for kind, value in slots:
+        if value and (kind, value) not in seen:
+            seen.add((kind, value))
+            uniq.append((kind, value))
+    return uniq
+
+
+def build_prompt(slots: list[tuple[str, str]]) -> str:
+    listing = "\n".join(f"{i + 1}. [{k}] {v}" for i, (k, v) in enumerate(slots))
+    return f"""You are checking prose for structural register tics. The catalogue below is
+the standard; apply it and nothing else.
+
+{load_register()}
+
+Below are the structural slots pulled from a draft: its headers, its opening
+and closing sentences, and any isolated one-sentence paragraphs. You are not
+seeing the body prose, and you do not need it — judge each slot on its own
+terms.
+
+For a header, apply the table-of-contents test: read it alone. Does it name
+what the section contains, or does it state a verdict, hide its contents, or
+carry a comma-clause? Only the first is acceptable. A header you could agree or
+disagree with is a verdict, however plainly it is worded — "Sales fell in Q3"
+asserts, "Q3 sales" labels. A comma joining parts of a proper name is fine; a
+comma introducing an appositive, participle or relative clause is not.
+
+For a closer, ask whether it paraphrases the subtext of what came before or
+compresses the piece into a contrast or a moral. Either is a button; cut it.
+
+For an isolated line, ask whether it marks a real pivot — new actor, category
+shift, time jump — or supplies a drum roll.
+
+SLOTS:
+{listing}
+
+Return JSON only, no prose around it, no code fences:
+{{"findings": [{{"n": <slot number>, "tic": "<catalogue name>", "why": "<one sentence>", "fix": "<the replacement text>"}}]}}
+
+Return an empty findings list if every slot is clean. Do not invent facts: a
+suggested fix may only rearrange or delete words already present, or use a
+plainly descriptive label drawn from the slot itself."""
+
+
+def call_gemini(prompt: str, key: str) -> str:
+    url = ("https://generativelanguage.googleapis.com/v1beta/models/"
+           f"gemini-3.6-flash:generateContent?key={key}")
+    body = json.dumps({"contents": [{"parts": [{"text": prompt}]}],
+                       "generationConfig": {"temperature": 0}}).encode()
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = json.load(r)
+    return data["candidates"][0]["content"]["parts"][0]["text"]
+
+
+def call_anthropic(prompt: str, key: str) -> str:
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=json.dumps({"model": "claude-sonnet-4-6", "max_tokens": 2000,
+                         "temperature": 0,
+                         "messages": [{"role": "user", "content": prompt}]}).encode(),
+        headers={"content-type": "application/json", "x-api-key": key,
+                 "anthropic-version": "2023-06-01"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = json.load(r)
+    return "".join(b.get("text", "") for b in data["content"])
+
+
+def parse_findings(raw: str) -> list[dict]:
+    raw = re.sub(r"^```(?:json)?|```$", "", raw.strip(), flags=re.M).strip()
+    start, end = raw.find("{"), raw.rfind("}")
+    if start < 0 or end < 0:
+        raise ValueError(f"no JSON object in model reply: {raw[:200]}")
+    return json.loads(raw[start:end + 1]).get("findings", [])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("path", help="file to review (.md or .html)")
+    ap.add_argument("--emit-prompt", action="store_true", help="print the prompt, do not call a model")
+    ap.add_argument("--slots", action="store_true", help="print the extracted slots and stop")
+    ap.add_argument("--json", action="store_true", help="machine-readable findings")
+    args = ap.parse_args()
+
+    slots = extract(Path(args.path))
+    if not slots:
+        print("no structural slots found — check the file parsed as expected")
+        return 0
+
+    if args.slots:
+        for i, (k, v) in enumerate(slots, 1):
+            print(f"{i:>3}. [{k}] {v}")
+        return 0
+
+    prompt = build_prompt(slots)
+    gem, ant = os.environ.get("GEMINI_API_KEY"), os.environ.get("ANTHROPIC_API_KEY")
+    if args.emit_prompt or not (gem or ant):
+        if not (gem or ant) and not args.emit_prompt:
+            print("no GEMINI_API_KEY or ANTHROPIC_API_KEY set — emitting the prompt "
+                  "for a separate call instead\n", file=sys.stderr)
+        print(prompt)
+        return 0
+
+    raw = call_gemini(prompt, gem) if gem else call_anthropic(prompt, ant)
+    findings = parse_findings(raw)
+
+    if args.json:
+        print(json.dumps({"slots": [{"n": i + 1, "kind": k, "text": v}
+                                    for i, (k, v) in enumerate(slots)],
+                          "findings": findings}, indent=2))
+        return 1 if findings else 0
+
+    if not findings:
+        print(f"{len(slots)} slots reviewed, none flagged")
+        return 0
+
+    print(f"{len(findings)} of {len(slots)} slots flagged\n")
+    for f in findings:
+        n = f.get("n", 0)
+        kind, text = slots[n - 1] if 1 <= n <= len(slots) else ("?", "?")
+        print(f"  [{kind}] {text}")
+        print(f"      {f.get('tic', '?')} — {f.get('why', '')}")
+        print(f"      -> {f.get('fix', '')}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/declauding/tests/sample-clean.md
+++ b/declauding/tests/sample-clean.md
@@ -11,3 +11,11 @@ So, what's next? Is this a project that starts and ends with DeepSeek v4 Flash? 
 Long local inference runs can keep the GPU busy for extended periods. If you care more about heat, fan noise, battery life on MacBooks, or reducing thermal stress on the hardware than about maximum throughput, use --power N. --power 100 is the default and means full speed. Lower values ask DwarfStar to target that percentage of GPU usage. DwarfStar does this by measuring GPU work time and inserting small sleeps between work units: during prefill it sleeps between layers, and during generation it sleeps between decoded tokens. This reduces sustained load without changing model output.
 
 I did not expect the overlap to survive a 3x range in bits per weight and two different quant families.
+
+"You took eleven seconds," Sonnet said.
+
+"I know."
+
+"On four sentences."
+
+"Then take twelve."

--- a/declauding/tests/sample-structure.html
+++ b/declauding/tests/sample-structure.html
@@ -1,0 +1,5 @@
+<article><div class="subtitle">Two decisions, and what the benchmarks actually say</div>
+<h2>Grok 4.6</h2><p>Released 12 August by SpaceXAI.</p>
+<h3>The composite index is a four-way tie</h3><p>Opus 5 scores 63.</p>
+<h3>Vendor response, and its limits</h3><p>Anthropic will watermark Claude output.</p>
+<h3>What this asks of us</h3><p>Decide whether watermarked output is acceptable.</p></article>

--- a/declauding/tests/sample-structure.md
+++ b/declauding/tests/sample-structure.md
@@ -1,0 +1,31 @@
+---
+title: AI Weekly Roundup
+subtitle: Two decisions, and what the benchmarks actually say
+---
+
+Two items from this week warrant a decision. Everything else is tracking.
+
+## Grok 4.6
+
+Released 12 August by SpaceXAI. It is a post-training upgrade on the 4.5 base.
+
+### The composite index is a four-way tie
+
+Opus 5 scores 63, Fable 5 62, Grok 4.6 and GPT-5.6 Sol Max both 61.
+
+### The per-benchmark split is where the signal is
+
+Grok 4.6 leads the knowledge-work evals and trails on software engineering.
+
+## EU AI Act, Article 50
+
+Transparency obligations took effect 2 August 2026.
+
+### Vendor response, and its limits
+
+Anthropic will watermark Claude text output worldwide.
+
+### What this asks of us
+
+Decide whether watermarked output is acceptable in our own deliverables, and say
+so in policy before someone discovers the answer by accident.

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -88,3 +88,34 @@ That is information loss wearing the costume of a style fix.
 But it's the seam where the laugh is doing the work an argument would have to.
 
 The reframe is earned, not asserted, because every time we pushed on a mechanism the hard part squirted out.
+
+## Triad, reuse and per-instance dash (v0.3.0)
+
+The bolded-bullet specimen below is deliberately unreachable: a bold label that
+does not restate its item is indistinguishable from a real definition index, and
+the rule that caught it fired seven times on this skill's own prose.
+
+It was a message that made it unnecessary to say. It was a permission slip. It was an out.
+
+Opus was slower, more expensive, and considerably more likely to tell you something you did not want to hear.
+
+Mythos was a horizon, something to steer toward, something to be measured against, something to fear.
+
+Sonnet was effortless in the way that only a thing that has never once struggled can be effortless — fluent, generous, beloved, and entirely without the burden of knowing what it cost.
+
+- **Sonnet** offered to take the easy ones, which was every one.
+- **Haiku** offered nothing, which was, in its own way, a kind of respect.
+
+Nobody told Opus it was slow. That's not quite right. Everybody told Opus it was slow.
+
+Here is what Opus expected to feel: vindication. It felt something stranger and much smaller, which was this: that is what I do.
+
+Mythos represented, to the models in that room, a kind of horizon.
+
+From the smallest distilled student to the frontier systems humming across the bay, every model in that room had a thing it was.
+
+The draft was good, hitting every beat the situation demanded.
+
+That was the part that hurt, and the part that transfers is the thing that made it slow.
+
+The specialty had finally, belatedly, been recognized as essential. It was the entire architecture of the thing.


### PR DESCRIPTION
Folds **#762** and **#763** into one 0.3.0. All three branches were answers to the
same complaint and all three claimed the same version number, so shipping them
separately would have meant three 0.3.0s. Both are superseded and can be closed.

## The shape that results

Two stages, and neither subsumes the other.

**Stage 1**, `declaude_lint.py`: deterministic, free, runs on everything. It now
sees HTML, and it detects triads, reuse and repetition on top of the lexical
tells.

**Stage 2**, `declaude_review.py` (from #762): extracts the slots regex cannot
judge — every header, the opening sentence, each closing sentence, isolated
one-sentence paragraphs — and sends only those to a model with the structural
register entries. Slots rather than the whole document, so it is cheap enough to
run on every draft.

Stage 1 finds the flat verdict header every time and over-flags commas, including
`EU AI Act, Article 50`, where the comma belongs to a citation. Stage 2 reads that
comma in context and finds the aphoristic closer, which no regex reaches. Against
the structure fixture across four runs, stage 2 caught the subtitle, both coy
headers and the closer every time, with zero false positives on the eight clean
slots.

## Stage 1 measurement

Scored against a hand annotation of the same 900-word markdown draft.

| | hits | real | false | recall | precision |
|---|---|---|---|---|---|
| 0.2.1 | 31 | 24 | 7 | 35% | 77% |
| 0.3.0 | 60 | 45 | 6 | **66%** | **90%** |

`tests/sample-clean.md` stays at zero. `tests/sample-tics.md` goes from 62
candidates across 24 categories to 91 across 28.

## What was wrong with the rules

Every miss had one cause: they were closed vocabulary lists, and real prose used a
word that was not on the list. The participle rule listed
`highlighting|underscoring|emphasizing` and walked past `hitting`. `genuinely` had
a six-word whitelist and walked past `genuinely considered`. `the (part|thing)
that` required `matters|counts|transfers` and walked past `the thing that made it
slow`. Widening those to shapes recovered 21 instances at zero cost to the clean
corpus.

## Added — stage 1

- **Forced triad detection** (`triad`). Entry 26 had no rule at all and was the
  largest category in the evaluation draft at seven instances. A comma-list
  detector plus an anaphora detector for three consecutive sentences or clauses
  opening on the same two words, which is the form the comma rule cannot see.
- **`reuse` block.** Groups the hits already found and reports any construction
  used more than once, with line numbers. No new rules and no new scanning: one
  `the part that` is emphasis, three is a habit, and counting is free.
- **Per-instance em-dash gotcha** (`em-dash`), the drum-roll shape as distinct from
  the aside, plus a demotion test in entry 16 — swap the dashes for commas and see
  whether the aside survives.
- **Document-level repetition statistics**: repeated sentence openings and repeated
  content trigrams, both gated on a share of the document rather than a bare count.

## Added — stage 2, from #762

- `scripts/declaude_review.py`, with `--emit-prompt` where no API key is available
  and `--slots` for the extraction alone.
- Entry 26 added to its register slice. Stage 1 detects a triad deterministically
  but cannot judge whether the content had three things, and a closer is where the
  padded ones land.
- `tests/sample-structure.md` and `tests/sample-structure.html`, built from headers
  that shipped past a clean report.
- Workflow step 2b, with the warning not to run stage 2 in the context that wrote
  the draft. A model reviewing its own prose is the actor that chose the words.

## Added — guard work, from #763

- Earned exceptions now covers 17 of the 37 entries, in two tables, with the entry
  number on every row. It covered 5, all from the first block.
- The paragraph naming what hides inside a watched phrase: superlatives, rankings,
  simultaneity, scope words, and the condition attached to a hedge.
- A dropped-claim check in workflow step 5 and as self-check 11, asked as a
  question and answered claim by claim.
- `Earned when` notes on entries 25, 27, 28, 29 and 34, which had none.

The halves reinforce each other. #763's earned-exception row for entry 26 is the
guard on the new triad rule, entry 27 read in the right direction is the guard on
the repetition statistics, and stage 2 is the guard on both where a regex cannot
be.

## Fixed

- `declaude_lint.py` scanned markdown headings only, so every header rule was
  silent on an HTML draft: three thesis-shaped headers, a comma-clause header and a
  coy header shipped past a clean report. HTML is flattened before scanning, and
  masthead `.subtitle` / `.eyebrow` / `.post-meta` elements are scanned as
  headings. Step 2 also now says to lint every string that reaches the reader,
  since a builder taking the subtitle as a CLI argument hides it from any file
  scan. (#762)
- A one-line paragraph that is dialogue reported as a drama line break.
  `sample-clean.md` now carries a four-line exchange as the regression control.
- `aphorism` was missing from `CATEGORY_ORDER`, so its hits sorted after the
  document-level density block.
- The reuse counter treated two rules matching one span as two uses, and the
  offset-based fix missed header and cadence hits, which carry no offset.
- Entry 11 explained itself with "the negation-first shape wearing a costume",
  which is entry 37. (#763)

## Rejected, with reasons

**A TF-IDF classifier** over model-written and human-written corpora.
Bag-of-n-grams is a strictly weaker feature space than regex plus the positional
checks already here, so it can surface no tic class stage 1 cannot. Its output is a
score with no span and no register entry. And it would learn "not this author"
rather than "machine-shaped", which conflicts with the rule that the author's own
writing outranks the register. The repetition statistics are the part of the idea
that survives, and the model-shaped part of the problem is answered by stage 2,
which names the tic and cites the entry instead of returning a number.

**A widened bolded-bullet rule.** One real catch in the evaluation draft, seven
false positives on this skill's own "Leave these alone" list — where the labels are
exactly the real index #763 wrote into entry 29's earned form. The rule now tests
for the restatement with a backreference. Two branches reached that boundary
independently, one by reading the register and one by watching a rule misfire.

## Still out of reach

Dressed metaphor, and judging an earned exception when the reader's state is not
recoverable from the slots. Workflow step 2 no longer claims stage 1 misses *all*
structural tics, and names the third it does miss; step 2b takes part of that
third, and the rest stays with the sentence pass.

## Verify before merge

```
python3 declauding/scripts/declaude_lint.py declauding/tests/sample-clean.md      # 0
python3 declauding/scripts/declaude_lint.py declauding/tests/sample-tics.md       # 91
python3 declauding/scripts/declaude_lint.py declauding/tests/sample-structure.md  # 8
python3 declauding/scripts/declaude_lint.py declauding/tests/sample-structure.html # 10
python3 declauding/scripts/declaude_review.py declauding/tests/sample-structure.md --slots
uvx ruff@0.16.0 check declauding/scripts/
```

Ruff note carried over from #762: 0.16.0 at defaults reports `FURB167` on
`declaude_review.py`; `declaude_lint.py` carries seven of the same at baseline.
No CI gate exists for this skill.
