### PR TITLE
declauding 0.4.0: entry 38, announce-then-deliver

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0] - 2026-08-21
+
+### Added
+
+- **Entry 38, announce-then-deliver.** A counted noun-phrase label standing in
+  front of the content it names: "One factual note, not fixed:", "Two things I
+  did not do.", "One judgment call left alone." The label carries nothing the
+  content does not, and the fix is usually to delete it and start with the
+  thing. Four `announce` rules in `declaude_lint.py` reach the regular forms;
+  the bare "One note:" shape is left alone because a pattern for it over-fires
+  on legitimate list intros.
+
+  Found by an author flagging it in this skill's own output — an annotated
+  register pass whose frame prose used the shape nine times, twice as a section
+  header, in a document whose central finding was bad headers. None of the
+  existing entries covered it: entry 5 is a placeholder *in* the subject slot,
+  entry 17 narrates the writer's procedure rather than labelling the content,
+  entry 29 is the bulleted cousin, and the `staging` rule at
+  "announces a list before giving it" targets demonstratives (`Here is what X:`)
+  rather than counted labels.
+
+  Fired before trusting: 6 of 6 specimens caught, 6 of 6 negatives silent
+  (including luria's "One decision, one thing." and the corrected form "One note
+  I did not fix:"). Dropping the qualifier requirement from the first rule
+  over-fires on the aphorism, which is what holds the precision. Zero new hits
+  across all four existing test corpora.
+
+### Fixed
+
+- Register entry 37, *Dressed metaphor*, was written `# 37.` where every other
+  entry is `## N.`, so it rendered as an H1 and fell out of any `^## [0-9]`
+  count. Unrelated to the above; picked up while editing the file.
+
 ## [0.3.0] - 2026-08-17
 
 ### Other

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -2,7 +2,7 @@
 name: declauding
 description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.3.0
+  version: 0.4.0
 ---
 
 # Declauding
@@ -54,8 +54,8 @@ performing having had the thought?* Say the thing.
 Entries 24 to 36 are a second family — the flatter encyclopedic and chatbot
 patterns, where nothing is being staged and the writing is just running on
 defaults. Copula avoidance, participle tails, forced triads, chatbot residue.
-Different mechanism, same pass. Entry 37 is back in the staging family and sits
-last only because it arrived last.
+Different mechanism, same pass. Entries 37 and 38 are back in the staging family
+and sit last only because they arrived last.
 
 ## The author's own writing outranks this skill
 

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -631,7 +631,7 @@ both positions is a cluster member.
 
 ---
 
-# 37. Dressed metaphor
+## 37. Dressed metaphor
 
 Back in the staging family, not the encyclopedic one, and numbered last because
 it arrived last.
@@ -661,6 +661,43 @@ noun fits. Delete the ones doing significance work, not the ones doing work.
 list for it would be three entries long and obsolete by the next draft. It is
 caught on the sentence pass or not at all. Both specimens above shipped past a
 clean lint report.
+
+---
+
+## 38. Announce-then-deliver
+
+**Tell:** a counted noun-phrase label with a clipped qualifier, standing before
+the content it names — "One factual note, not fixed:", "Two things I did not
+do.", "One judgment call left alone.", "The exception, worth restating:", "and
+worth saying why it works:".
+
+**Why:** the label carries nothing the content does not. It buys the writer a
+beat to compose in and costs the reader a clause before the subject arrives. A
+person either writes the label the way they would say it — "One note I did not
+fix" — or, more often, just states the thing.
+
+Distinct from entry 5, where a placeholder sits *in* the subject slot; here a
+whole announcement sits *in front of* the sentence and the real subject is fine.
+Distinct from entry 17, which narrates the writer's procedure rather than
+labelling the content. Entry 29 is the bulleted cousin: same restating label,
+rendered as a bold lead-in instead of a standalone phrase.
+
+**Fix:** delete the announcement and start with the content. Where a label is
+genuinely needed, write it as speech, not as a caption.
+
+> was: *One factual note, not fixed: X and Y both assert what people generally
+> do. Nothing in the repo supports either.*
+> now: *Two sentences assert what people generally do, and nothing in the repo
+> supports either: X and Y.*
+
+**Earned when** the count is real navigation over a list the reader will scan —
+"Three shapes, and the fix differs for each:" ahead of an actual three-item
+list. The test is whether deleting the label loses anything.
+
+**Watch the reuse.** Measured nine times in one 40 KB document, including twice
+as a section header, in a piece whose own subject was bad headers. A writer who
+reaches for this once reaches for it throughout; the linter's `reuse` block is
+the cheapest way to see it.
 
 ---
 

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -49,6 +49,16 @@ RULES: list[tuple[str, str, str]] = [
     ("deferred-noun", r"\bThe\s+(?:second|third|fourth|fifth|sixth|seventh|other|last)\s+(?:is|isn't|is not|does|doesn't)\b\s*[.,]", "pointer instead of name"),
     ("deferred-noun", r"\bThere\s+(?:was|is)\s+(?:just\s+)?one\s+(?:problem|catch|issue|wrinkle)\b", "there was just one problem"),
 
+    # --- announce-then-deliver (entry 38) -------------------------------------
+    # A counted label standing in front of the content it names. Partially
+    # reachable: the appositive-qualifier form is regular, the bare "One note:"
+    # form is not without over-firing on legitimate list intros.
+    ("announce", r"^(?:One|Two|Three|Four|A single|The one)\s+[a-z][\w -]{2,30},\s+(?:not|un\w+|left|stated|worth|flagged|still|so far)\b[^.:;]{0,25}[:.]", "counted label announcing the content it precedes"),
+    ("announce", r"\b(?:One|Two|Three|Four)\s+things?\s+(?:I|we)\s+(?:did|didn'?t|have|haven'?t|will|won'?t)\b[^.:;]{0,20}[:.]", "announcing a list of what you did before doing it"),
+    ("announce", r"\band\s+worth\s+(?:saying|noting|restating|repeating|mentioning|a\s+look)\b[^.]{0,25}:", "'and worth saying why' — say why"),
+    ("announce", r"^(?:One|Two|Three|Four)\s+[a-z][\w -]{2,25}\s+(?:left\s+(?:alone|aside|open|unfixed)|unresolved|unfixed|untouched|not\s+fixed)\s*[.:]", "counted label with a participle qualifier, no comma"),
+    ("announce", r"^The\s+\w+,\s+(?:worth|stated|noted|flagged|measured|left)\s+\w+[^.:;]{0,45}:", "appositive caption before the content"),
+
     # --- structural-metaphor locator ----------------------------------------
     ("locator", r"\bthe\s+(?:seam|hinge|joint|fault[- ]line|crux|linchpin|leg|place)\s+where\b", "structural-metaphor locator"),
     ("locator", r"\bload[- ]bearing\b", "load-bearing as metaphor"),
@@ -240,7 +250,7 @@ EMOJI_RE = re.compile(
 )
 
 CATEGORY_ORDER = [
-    "negation-first", "significance", "agency", "deferred-noun", "locator",
+    "negation-first", "significance", "agency", "deferred-noun", "announce", "locator",
     "staging", "triad", "em-dash", "aphorism", "rhetorical-q", "self-grading", "humility", "throat-clearing",
     "rtfm", "dev-cliche", "slop", "editorializing", "time-inflation",
     "copula", "participle", "false-range", "list-shape", "chatbot", "filler",

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -119,3 +119,29 @@ The draft was good, hitting every beat the situation demanded.
 That was the part that hurt, and the part that transfers is the thing that made it slow.
 
 The specialty had finally, belatedly, been recognized as essential. It was the entire architecture of the thing.
+
+## Announce-then-deliver (entry 38)
+
+One factual note, not fixed: both sentences assert what people generally do, and
+nothing in the source supports either.
+
+Two things I did not do. The em-dash rate runs high in every file, so I left it.
+
+One judgment call left alone. The triad reads as deliberate enumeration.
+
+The exception, worth restating because it cuts against the rule: a principle's
+title is a claim.
+
+Flagged by neither rule, and worth saying why it works: it tells you the size of
+the commitment.
+
+One caveat, unresolved: the alias map recovers nothing.
+
+Negatives that must stay silent — a real list intro, an aphorism, and the
+corrected form of the tic itself:
+
+Three shapes, and the fix differs for each:
+
+One decision, one thing.
+
+One note I did not fix: the count is off by two.


### PR DESCRIPTION
A counted noun-phrase label standing in front of the content it names:

```
One factual note, not fixed: both sentences assert what people generally do.
Two things I did not do.
One judgment call left alone.
The exception, worth restating because it cuts against the rule:
```

The label carries nothing the content does not. It buys the writer a beat to compose in and costs the reader a clause before the subject arrives.

## How it was found

Oskar flagged it in this skill's own output. An annotated register pass over `dmarx/luria` used the shape **nine times**, twice as a section header, in a document whose central finding was that a third of the edits were bad headers. His diagnosis:

> a normal *person* would write something like "One note that I did not fix:" — or would just actually state the note rather than announcing it

The second half is the operative one. Most instances do not want a better label; they want the announcement deleted so the sentence can start with the thing.

## Why it needed a new entry

No existing entry reaches it, and I checked all four candidates before adding a fifth:

| entry | why it does not cover this |
|---|---|
| 5, deferred noun | a placeholder sits *in* the subject slot; here the subject is fine and a whole announcement sits in front of it |
| 17, process narration | narrates the writer's procedure ("Let me explain"), not the content |
| 29, inline-header list | the bulleted cousin — same restating label, rendered as a bold lead-in |
| `staging` rule, "announces a list before giving it" | targets demonstratives (`Here is what X:`), not counted labels |

Entry 38 cross-references all three register entries so a reader landing on one finds the others.

## The rules

Four `announce` patterns in `declaude_lint.py`, reaching the regular forms. The bare `One note:` shape is deliberately unmatched: a pattern for it over-fires on legitimate list intros, and a false fire teaches the reader to skim past the block, which is the failure the linter exists to prevent.

Fired before trusting:

- **6 of 6** specimens caught.
- **6 of 6** negatives silent, including luria's own `One decision, one thing.` (a legitimate aphorism), `Three shapes, and the fix differs for each:` (a real list intro), and the corrected form `One note I did not fix:`.
- **Sabotage:** dropping the qualifier requirement from the first rule over-fires on the aphorism. The qualifier list is what holds the precision.
- **Zero** new hits across all four existing test corpora.

Specimens and negatives are appended to `tests/sample-tics.md`, so the entry keeps a fixture rather than living only in a commit message.

## Also fixed

Register entry 37, *Dressed metaphor*, was written `# 37.` where every other entry is `## N.` — it rendered as an H1 and fell out of any `^## [0-9]` count, which is why `SKILL.md` and the file disagreed about how many entries exist. Unrelated to the above; picked up while editing the file.

`SKILL.md`'s family paragraph now says entries 37 *and 38*, and the version is bumped to 0.4.0 so `skill-release.yml` sees a delta.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5qQZEWSniFMBzcET1cJy9)_