### PR TITLE
featuring: fix source=None crash on cache hit, add --orient

### DIFF
--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -90,13 +90,30 @@ $PYTHON $TREESIT /tmp/$REPO 'refs:Config'
 
 ### 3. Feature synthesis
 
+**Pick the mode from your DELIVERABLE, before you run it.**
+
+| Your deliverable | Command | Size |
+|---|---|---|
+| Your own understanding — a review, an orientation read, answering a question | `--orient` | ~115 lines |
+| A written `_FEATURES.md` that must cite every symbol | full output | thousands of lines |
+
 ```bash
-$PYTHON $GATHER /tmp/$REPO \
-  --skip tests,.github,node_modules --source-budget 8000
+# Default. Complexity assessment, decomposition ranking, directory tree, entry points.
+$PYTHON $GATHER /tmp/$REPO --skip tests,.github,node_modules --orient
+
+# Only when you are about to WRITE the inventory into a file:
+$PYTHON $GATHER /tmp/$REPO --skip tests,.github,node_modules --source-budget 8000
 ```
 
 Output includes a "Candidate areas for sub-files (by symbol density)"
 list near the top — that's your drill-target picker, ranked.
+
+**Never pipe the full output through `head`.** If you are about to truncate it,
+`--orient` was the correct mode and you have paid for thousands of lines you
+will not read. Diagnosed 2026-08-22 on a FreeToken review: a 5,697-line gather
+was cut at line 120, and every finding in that review came from `treesit`
+drilling and targeted reads instead. `--orient` returns the 115 lines that were
+actually used. The full mode's symbol inventory exists to be CITED, not read.
 
 ### 4. Reason about the combined output
 

--- a/featuring/CHANGELOG.md
+++ b/featuring/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.4.0 (2026-08-22)
+
+### Fixed: gather.py crashed on the second run against a repo
+tree-sitting's `/tmp/treesit-cache` persists symbols and imports but not file
+source, so every cache HIT returned `entry.source = None`. `identify_key_files`
+(`len(entry.source)`) and the Key Source Excerpts emitter
+(`entry.source.decode(...)`) both used it unguarded. A cold run succeeded and
+wrote the cache; the next run with the same repo + skip set exited 1 with a
+TypeError, which read as flakiness. `_source_bytes()` now falls back to reading
+the file from disk. Verified cold/warm output is byte-identical.
+
+### New: `--orient`
+Emits the orientation header only — complexity assessment, decomposition
+ranking, directory tree, entry points — and stops before the symbol inventory.
+~115 lines against 5,697 for the full output on a 71k-line repo. Use it whenever
+the deliverable is your own understanding rather than a written `_FEATURES.md`.
+The full mode now prints its own line count first when the output exceeds 400
+lines, so the cost of not using `--orient` is visible before the scroll.
+
 ## 0.2.0 (2026-03-31)
 
 ### Hierarchical features support

--- a/featuring/SKILL.md
+++ b/featuring/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   or needs to understand a codebase's purpose before modifying it. Complements
   tree-sitting (structural) with semantic (why/what-for) layer.
 metadata:
-  version: 0.3.0
+  version: 0.4.0
 ---
 
 # Featuring
@@ -33,6 +33,13 @@ uv venv /home/claude/.venv 2>/dev/null
 uv pip install tree-sitter-language-pack --python /home/claude/.venv/bin/python
 ```
 
+tree-sitting caches its scan to `/tmp/treesit-cache`, keyed by repo path plus
+skip set. That cache persists symbols and imports but NOT file source, so a
+cache HIT returns `source=None`. `gather.py` re-reads those files from disk;
+do not assume `entry.source` is populated if you write against the engine
+directly. (Before this was handled, gather crashed on its second run against a
+repo while the first succeeded — diagnosed 2026-08-22.)
+
 For quick structural orientation before running gather.py, use tree-sitting's CLI:
 
 ```bash
@@ -53,6 +60,17 @@ after all features are understood — not first.
 /home/claude/.venv/bin/python /mnt/skills/user/featuring/scripts/gather.py /path/to/repo \
   --skip tests,.github,node_modules --source-budget 8000
 ```
+
+**`--orient` when you are not writing the file.** The full output is a complete
+symbol inventory — 5,697 lines on a 71k-line repo — and it exists so a
+`_FEATURES.md` can cite every symbol. When the deliverable is your own
+understanding (a review, an orientation read), pass `--orient`: complexity
+assessment, decomposition ranking, directory tree and entry points, and nothing
+else. ~115 lines. Reaching for `head` on the full output means `--orient` was
+the right mode.
+
+Pass 1 of THIS skill is the case that wants the full output — you are about to
+write the inventory down.
 
 Read the gather output. Before writing anything, form a hypothesis:
 

--- a/featuring/scripts/gather.py
+++ b/featuring/scripts/gather.py
@@ -97,7 +97,26 @@ def classify_symbols(cache, area_prefix=None) -> dict:
     return categories
 
 
-def identify_key_files(cache, source_budget: int, area_prefix=None) -> list:
+def _source_bytes(repo_path, relpath, entry) -> bytes:
+    """Raw bytes of one scanned file.
+
+    ``entry.source`` is populated only on a COLD scan: tree-sitting's on-disk
+    cache (/tmp/treesit-cache) persists lang/symbols/imports and deliberately
+    drops source, so every cache HIT hands back ``source=None``. Both call sites
+    here used it unguarded, which made gather.py crash on its SECOND run against
+    the same repo+skip set while the first succeeded -- diagnosed 2026-08-22,
+    reproduced A/B/C: cold rc=0 (5697 lines), warm rc=1 (TypeError).
+    Re-read from disk on the miss; return b"" if the file is gone.
+    """
+    if entry is not None and entry.source is not None:
+        return entry.source
+    try:
+        return (Path(repo_path) / relpath).read_bytes()
+    except OSError:
+        return b""
+
+
+def identify_key_files(cache, source_budget: int, area_prefix=None, repo_path=None) -> list:
     """Pick files worth reading source from, within a token budget."""
     file_scores = []
     for relpath, entry in cache.files.items():
@@ -119,7 +138,7 @@ def identify_key_files(cache, source_budget: int, area_prefix=None) -> list:
                 score += 1
 
         if score > 0:
-            source_len = len(entry.source)
+            source_len = len(_source_bytes(repo_path, relpath, entry))
             file_scores.append((relpath, score, source_len))
 
     file_scores.sort(key=lambda x: x[1], reverse=True)
@@ -196,7 +215,7 @@ def format_symbol_brief(sym, indent=0) -> str:
 
 
 def gather(repo_path: str, skip: set = None, source_budget: int = 8000,
-           area: str = None) -> str:
+           area: str = None, orient: bool = False) -> str:
     """Scan a codebase and produce structured output for feature synthesis.
 
     Args:
@@ -204,6 +223,11 @@ def gather(repo_path: str, skip: set = None, source_budget: int = 8000,
         skip: Directory names to skip
         source_budget: Approximate char budget for source excerpts
         area: Optional subdirectory to focus on (for sub-feature generation)
+        orient: Stop after the orientation header (complexity assessment,
+            decomposition ranking, directory tree, entry points) and omit the
+            full symbol inventory. ~115 lines instead of thousands. Use when the
+            deliverable is your own understanding; use the full output only when
+            you are writing a _FEATURES.md that must cite every symbol.
     """
     cache = setup_engine()
 
@@ -217,7 +241,7 @@ def gather(repo_path: str, skip: set = None, source_budget: int = 8000,
         area_prefix = None
 
     categories = classify_symbols(cache, area_prefix)
-    key_files = identify_key_files(cache, source_budget, area_prefix)
+    key_files = identify_key_files(cache, source_budget, area_prefix, repo_path)
     complexity = compute_complexity(cache, area_prefix)
 
     lines = []
@@ -260,6 +284,15 @@ def gather(repo_path: str, skip: set = None, source_budget: int = 8000,
             lines.append(format_symbol_brief(sym))
         lines.append("")
 
+    # Everything above is the orientation header: what this repo is, where it is
+    # dense, and where execution starts. Everything below is the full symbol
+    # inventory, which exists to be CITED in a _FEATURES.md -- not read end to end.
+    if orient:
+        lines.append(f"_Orientation only ({len(categories['public_api'])} public symbols and "
+                     f"{len(categories['types'])} types withheld). Re-run without --orient "
+                     f"to emit the full inventory._")
+        return "\n".join(lines)
+
     # ── Public API (grouped by file)
     if categories['public_api']:
         lines.append("## Public API")
@@ -295,7 +328,7 @@ def gather(repo_path: str, skip: set = None, source_budget: int = 8000,
             entry = cache.files.get(filepath)
             if not entry:
                 continue
-            source_text = entry.source.decode('utf-8', errors='replace')
+            source_text = _source_bytes(repo_path, filepath, entry).decode('utf-8', errors='replace')
             source_lines = source_text.split('\n')
             if len(source_lines) > 150:
                 excerpt = '\n'.join(source_lines[:150])
@@ -340,10 +373,22 @@ def main():
                         help='Focus on a specific subdirectory (for sub-feature generation)')
     parser.add_argument('--source-budget', type=int, default=8000,
                         help='Approximate char budget for source excerpts (default: 8000)')
+    parser.add_argument('--orient', action='store_true',
+                        help='Orientation header only (~115 lines): complexity, decomposition '
+                             'ranking, directory tree, entry points. Omits the symbol inventory. '
+                             'Use this unless you are writing a _FEATURES.md.')
     args = parser.parse_args()
 
     skip = set(args.skip.split(',')) if args.skip else None
-    print(gather(args.repo, skip=skip, source_budget=args.source_budget, area=args.area))
+    out = gather(args.repo, skip=skip, source_budget=args.source_budget,
+                 area=args.area, orient=args.orient)
+    if not args.orient and out.count("\n") > 400:
+        # Diagnosed 2026-08-22 (FreeToken review): a 5,697-line gather was piped
+        # through `head -120` and the rest paid for and discarded. Say the size up
+        # front so the cost of NOT using --orient is visible before the scroll.
+        print(f"<!-- {out.count(chr(10)) + 1} lines. Reading only the top? "
+              f"Re-run with --orient. -->")
+    print(out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`gather.py` exits 1 on its second run against the same repo. The first run
succeeds, so this presents as flakiness rather than as the deterministic bug
it is.

tree-sitting caches its scan to `/tmp/treesit-cache`, keyed by repo path plus
skip set. The cache persists `lang`, `symbols` and `imports`. It does not
persist file source. So a cache hit hands back `entry.source = None`, and two
call sites dereference it unguarded: `identify_key_files` at
`len(entry.source)`, and the Key Source Excerpts emitter at
`entry.source.decode(...)`. The cold run populates source in memory, works, and
writes the cache that breaks the next run.

Reproduced on FreeToken (349 files), all three cases:

| run | cache | result |
|---|---|---|
| A | cold | rc=0, 5,697 lines; writes the cache |
| B | warm, same skip set | rc=1, TypeError |
| C | cold (different skip set, so a different fingerprint) | rc=0, 5,697 lines |

`_source_bytes()` re-reads the file from disk when the cache did not carry it.
Cold and warm output are byte-identical on both FreeToken and claude-workspace,
and `--area` now survives a warm cache too.

## `--orient`

The full output is a symbol inventory: 643 functions and 453 types, 5,697 lines
on a 71k-line repo. It exists so a `_FEATURES.md` can cite every symbol, and it
is not built to be read end to end.

`--orient` stops after the orientation header (complexity assessment,
decomposition ranking, directory tree, entry points). That is 115 lines on the
same repo, 57 on claude-workspace.

`exploring-codebases` step 3 now routes on the deliverable. `--orient` when the
output is your own understanding, the full inventory when you are writing it
into a file. The full mode also prints its own line count first when it exceeds
400 lines.

This came out of a review where I ran the full gather and piped it through
`head -120`, then took every finding from `treesit` drilling and targeted reads
instead. `--orient` returns the 115 lines that run actually used.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKfotvzuTp5nubWpKF1Cb9)_