### PR TITLE
declauding 0.5.0: entries 39-42

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0] - 2026-08-23
+
+### Added
+
+- Entry 39, welded epigram — a maxim joined to a fact with "and" or "so", inside
+  one sentence. Entry 12 only catches the paragraph-final form.
+- Entry 40, spec-ese — demonstrative subjects, reflexive emphatics, and latinate
+  state verbs ("idles", "holds no", "awaiting input") for a program doing nothing.
+- Entry 41, nominalized header — the standard overcorrection from entry 7.
+  Fleeing a verdict header into an abstraction passes entry 7's regex and fails
+  its table-of-contents test.
+- Entry 42, contents-list standfirst — "X, plus the Y the docs leave out".
+- `spec-ese` lint category, three new `aphorism` and two new `announce` patterns,
+  and a nominalized/gerund header check.
+- Two self-check questions covering the welded epigram and the read-aloud test.
+
+Diagnosed on a create_session reference artifact whose four section headers were
+all rewritten from verdict-shaped into nominalized by a single declauding pass,
+after which the linter reported the document clean.
+
 ## [0.4.0] - 2026-08-21
 
 ### Other

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -2,7 +2,7 @@
 name: declauding
 description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.4.0
+  version: 0.5.0
 ---
 
 # Declauding

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -701,12 +701,121 @@ the cheapest way to see it.
 
 ---
 
+## 39. Welded epigram
+
+**Tell:** a factual clause joined by `and` or `so` to a second clause that
+restates it as a general truth — ", so a child never carries a grant its parent
+lacks", ", and the failure it prevents is silent", ", and nothing errors". The
+second clause typically contains no concrete noun and would read as true of any
+system, not this one.
+
+**Why:** the first clause says what happens; the second says what it means, in a
+shape built to be quoted. It also loses precision, because a maxim has to drop
+the conditions that made the mechanism specific. *A child never carries a grant
+its parent lacks* is vaguer than the rule it paraphrases, and a reader cannot
+act on it.
+
+**Fix:** keep the clause that says what happens. Delete the one that says what it
+means.
+
+> was: *Entries the caller does not itself hold are dropped, so a child never
+> carries a grant its parent lacks.*
+> now: *List a tool you do not have yourself and it is dropped.*
+
+> was: *The rest of the surface depends on this parameter, and the failure it
+> prevents is silent.*
+> now: *Leave it out and nothing errors — the child just comes up bare.*
+
+Distinct from entry 12, which is a whole sentence at the end of a paragraph.
+This one hides inside a single sentence, mid-paragraph, and survives a pass that
+is only checking closers.
+
+---
+
+## 40. Spec-ese
+
+**Tell:** the register of a standards document rather than of a person
+explaining something. Demonstrative subject where "it" would do ("That child
+holds no repository"); reflexive emphatics ("does not itself hold"); latinate
+state verbs for a program doing nothing ("idles", "holds", "carries", "awaits");
+participle tails on those verbs ("awaiting input"); passive with the actor
+displaced into a subordinate clause.
+
+**Why:** it reads as translated from a schema. The formality signals precision
+without adding any — every specimen below says less than its plain rewrite,
+because the plain rewrite names who does the thing.
+
+**Fix:** use "it". Use the verb you would say aloud. Name the reader as the actor
+where the reader is the actor.
+
+> was: *That child holds no repository and waits for input.*
+> now: *It comes up with no repo and does nothing until you send it a message.*
+
+> was: *Omit it and the child idles awaiting input.*
+> now: *Leave it out and the session just sits there.*
+
+**Earned when** the term is the system's own — a queue whose documented states
+are `waiting` and `held`, a flag literally named `AWAIT`. Then it is a
+quotation, not a register choice.
+
+---
+
+## 41. Nominalized header
+
+**Tell:** a header whose head noun is an abstraction — "GitHub authorship in a
+sourced child", "Spawn availability", "Channels between siblings", "Detecting a
+parked child". Shapes to scan for: `<-ship/-tion/-ment/-ance/-ity noun> in|of|for
+<thing>`, and a bare gerund standing in for the sentence the section actually
+makes.
+
+**Why:** it names a topic area instead of the content, so it fails entry 7's
+table-of-contents test while passing entry 7's regex. A reader scanning
+"Spawn availability" learns that the section is about spawning, which they knew.
+
+**Fix:** name the concrete thing, or ask the reader's question.
+
+> was: *GitHub authorship in a sourced child* → now: *Who the delegate posts as*
+> was: *Spawn availability* → now: *When create_session fails*
+
+**This is the standard overcorrection from entry 7.** Diagnosed 2026-08-23: a
+draft's four verdict-shaped section headers ("A sourced child signs GitHub
+writes as the token owner", "There is no reply channel between siblings") were
+all rewritten into nominalizations in a single pass, and the linter then
+reported the document clean. Fleeing a verdict into an abstraction is not a fix.
+The target is a concrete label, and both failures miss it in opposite
+directions.
+
+---
+
+## 42. Contents-list standfirst
+
+**Tell:** a subtitle or opening line built as `<noun phrase>, plus <noun
+phrase>` — "The create_session parameter surface, plus the behavior the schema
+leaves out". Variants: "…, and what it means for X", "…, and the N things you
+need to know". The second half is usually a coy reduced relative that claims
+value without naming any ("the behavior the schema leaves out", "the part the
+docs skip").
+
+**Why:** it is a table of contents wearing a sentence, and the second half is a
+significance tag (entry 3) in disguise — it tells the reader the withheld
+material is worth having rather than saying what it is.
+
+**Fix:** say what the page contains, or drop the subtitle. A reference does not
+need one.
+
+> was: *The create_session parameter surface, plus the behavior the schema
+> leaves out.*
+> now: *Every parameter, and four behaviors that only show up in practice.*
+
+---
+
 ## Quick self-check before shipping an edit
 
 1. Does any sentence exist to make a finding feel bigger than it is?
 2. Does any sentence tell the reader which sentence matters?
 3. Is anything in a subject slot that cannot act?
-4. Does any header state a verdict, hide its contents, or contain a comma?
+4. Does any header state a verdict, hide its contents, contain a comma, or
+   name an abstraction instead of the content?
 5. Is any noun deferred that was available?
 6. Does the last paragraph paraphrase the subtext of the piece?
 7. Did the edit remove content, change a claim, or add hedging?
@@ -715,7 +824,9 @@ the cheapest way to see it.
 10. Does the rewrite contain a fact, name, number, date or citation that is not
     in the source? A fabrication is a defect even when it sounds more human than
     the vague original.
-11. Does the rewrite drop a claim the source made? Check claim by claim, not
+11. Does any sentence weld a maxim onto a fact with "and" or "so"?
+12. Would you say it aloud in those words, or is it schema prose?
+13. Does the rewrite drop a claim the source made? Check claim by claim, not
     paragraph by paragraph. Superlatives, rankings, simultaneity, scope words and
     the condition attached to a hedge all sit inside phrasings this register
     cuts, and the paragraph looks intact after they go.

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -196,7 +196,7 @@ RULES: list[tuple[str, str, str]] = [
     ("aphorism", r",\s*(?:so|and)\s+nothing\s+\w+s\b[^.]{0,40}\.", "welded epigram — 'and nothing X's' closer"),
 
     # --- spec-ese (entry 40) --------------------------------------------------
-    ("spec-ese", r"\bThat\s+(?:child|session|process|container|job|worker|request|instance|delegate)\b", "demonstrative subject for a thing already named — use 'it'"),
+    ("spec-ese", r"(?:^|[.!?]\s+)That\s+(?:child|session|process|container|job|worker|request|instance|delegate)\b(?!'s)", "demonstrative subject for a thing already named — use 'it'"),
     ("spec-ese", r"\bdoes\s+not\s+itself\b", "reflexive-emphatic formality"),
     ("spec-ese", r"\b(?:idles?|sits?|waits?)\s+awaiting\b", "latinate state verb plus participle tail"),
     ("spec-ese", r"\bawaiting\s+(?:input|instructions|a\s+\w+|the\s+\w+)\b", "awaiting — say what the reader has to do"),

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -190,6 +190,23 @@ RULES: list[tuple[str, str, str]] = [
     ("subjectless", r"\bNo\s+\w+(?:\s+\w+){0,2}\s+(?:needed|required)\s*[.!]", "subjectless claim — name the actor"),
     ("subjectless", r"\b(?:is|are)\s+\w+ed\s+automatically\b", "subjectless claim — who does it?"),
 
+    # --- welded epigram (entry 39) -------------------------------------------
+    ("aphorism", r",\s*so\s+(?:a|an|the|it|they|you)\s+[^.]{0,50}\bnever\b[^.]{0,40}\.", "welded epigram — second clause restates the first as a maxim"),
+    ("aphorism", r",\s*and\s+(?:the|its)\s+(?:failure|error|cost|risk|difference|effect|result|damage|loss)\s+[^.]{0,40}\bis\b[^.]{0,30}\.", "welded epigram — second clause generalizes the first"),
+    ("aphorism", r",\s*(?:so|and)\s+nothing\s+\w+s\b[^.]{0,40}\.", "welded epigram — 'and nothing X's' closer"),
+
+    # --- spec-ese (entry 40) --------------------------------------------------
+    ("spec-ese", r"\bThat\s+(?:child|session|process|container|job|worker|request|instance|delegate)\b", "demonstrative subject for a thing already named — use 'it'"),
+    ("spec-ese", r"\bdoes\s+not\s+itself\b", "reflexive-emphatic formality"),
+    ("spec-ese", r"\b(?:idles?|sits?|waits?)\s+awaiting\b", "latinate state verb plus participle tail"),
+    ("spec-ese", r"\bawaiting\s+(?:input|instructions|a\s+\w+|the\s+\w+)\b", "awaiting — say what the reader has to do"),
+    ("spec-ese", r"\b(?:holds|carries|comprises|obtains)\s+no\s+\w+", "latinate state verb — say what is not there"),
+    ("spec-ese", r"\bnever\s+carries\s+a\b", "latinate state verb for a permission or flag"),
+
+    # --- contents-list standfirst (entry 42) ----------------------------------
+    ("announce", r"^[^.\n]{10,90},\s*plus\s+the\s+\w+", "'X, plus Y' standfirst — a contents list shaped as a sentence"),
+    ("announce", r",\s*(?:plus|and)\s+the\s+\w+\s+(?:the|that|which)\s+\w+\s+(?:leaves?|skips?|misses?|omits?)\b", "coy reduced relative — name what is in it"),
+
     # --- predicate-position hyphenation --------------------------------------
     ("hyphenation", r"\b(?:is|are|was|were|feels?|seems?)\s+(?:high-quality|cross-functional|data-driven|end-to-end|real-time|long-term|well-known|client-facing|decision-making|third-party|open-source)\b", "drop the hyphen after the noun"),
 ]
@@ -239,6 +256,11 @@ HEADER_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 COY_HEADER_RE = re.compile(r"^(?:what|why|how)\b(?!.*\?$)", re.I)
 VERDICT_HEADER_RE = re.compile(r"\b(?:is|are|isn'?t|aren'?t|was|wasn'?t|does|doesn'?t|actually|really|wrong|right|matters|counts)\b", re.I)
 
+NOMINAL_HEADER_RE = re.compile(
+    r"^(?:[A-Z]\w*\s+){0,2}\w+(?:ship|tion|sion|ment|ance|ence|ity|ness)\b"
+    r"(?:\s+(?:in|of|for|between|across|under)\b|\s*$)", re.I)
+GERUND_HEADER_RE = re.compile(r"^\w+ing\s+(?:a|an|the)\b", re.I)
+
 TITLE_CASE_SKIP = {
     "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "into",
     "nor", "of", "on", "onto", "or", "over", "the", "to", "up", "via", "with",
@@ -254,7 +276,7 @@ CATEGORY_ORDER = [
     "staging", "triad", "em-dash", "aphorism", "rhetorical-q", "self-grading", "humility", "throat-clearing",
     "rtfm", "dev-cliche", "slop", "editorializing", "time-inflation",
     "copula", "participle", "false-range", "list-shape", "chatbot", "filler",
-    "gap-fill", "diff-anchored", "subjectless", "hyphenation",
+    "gap-fill", "diff-anchored", "subjectless", "hyphenation", "spec-ese",
     "header", "typography", "cadence", "reuse", "density",
 ]
 
@@ -314,6 +336,11 @@ def scan_lines(text: str) -> list[dict]:
             elif not title.endswith("?") and VERDICT_HEADER_RE.search(title) and len(title.split()) > 3:
                 hits.append({"line": i, "category": "header",
                              "note": "thesis-shaped header — states a verdict instead of labelling",
+                             "match": title[:90]})
+            elif NOMINAL_HEADER_RE.match(title) or GERUND_HEADER_RE.match(title):
+                hits.append({"line": i, "category": "header",
+                             "note": "nominalized header — names a topic area, not the content "
+                                     "(the standard overcorrection from a verdict header)",
                              "match": title[:90]})
             words = title.split()
             minor = [w for w in words[1:] if w.lower() not in TITLE_CASE_SKIP]

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -145,3 +145,17 @@ Three shapes, and the fix differs for each:
 One decision, one thing.
 
 One note I did not fix: the count is off by two.
+
+## Entries 39-42 specimens
+
+The create_session parameter surface, plus the behavior the schema leaves out.
+
+That child holds no repository and waits for input.
+
+The rest of the surface depends on this parameter, and the failure it prevents is silent.
+
+Omit it and the child idles awaiting input.
+
+Entries the caller does not itself hold are dropped, so a child never carries a grant its parent lacks.
+
+## GitHub authorship in a sourced child


### PR DESCRIPTION
Oskar flagged six sentences in a `create_session` reference artifact I had already run declauding over. All six passed the 0.4.0 lint. They break into four mechanisms.

## Entry 39, welded epigram

A factual clause joined by `and` or `so` to a second clause that restates it as a general truth.

> Entries the caller does not itself hold are dropped, so a child never carries a grant its parent lacks.

The maxim also drops precision — a reader cannot act on "never carries a grant its parent lacks", but they can act on "list a tool you do not have yourself and it is dropped". Entry 12 already covers the aphoristic closer, but its tell is a whole sentence ending a paragraph. This one hides inside one sentence, mid-paragraph, and survives a pass that only checks closers.

## Entry 40, spec-ese

Demonstrative subjects where "it" would do, reflexive emphatics, and latinate verbs for a program doing nothing.

> That child holds no repository and waits for input.
> Omit it and the child idles awaiting input.

Carved out for a system whose own documented states use those words — a queue with a `waiting` state, a flag named `AWAIT`.

## Entry 41, nominalized header

> GitHub authorship in a sourced child

This is the overcorrection from entry 7, and it is why the artifact came back clean. Its four section headers all started verdict-shaped ("A sourced child signs GitHub writes as the token owner"), the 0.4.0 lint flagged two of them, and my fix turned every one into an abstraction. Nominalized headers pass entry 7's regex and fail entry 7's own table-of-contents test. The entry says so directly, because a rule that pushes writers into a second tic needs to name it.

## Entry 42, contents-list standfirst

> The create_session parameter surface, plus the behavior the schema leaves out.

A table of contents wearing a sentence. The second half is usually a significance tag from entry 3 in disguise: "the behavior the schema leaves out" claims the withheld material is worth having without naming any of it.

## Changes

- `references/register.md` — four entries, plus two questions in the shipping self-check
- `scripts/declaude_lint.py` — a `spec-ese` category, three `aphorism` patterns, two `announce` patterns, and a nominalized/gerund header check alongside the existing coy and verdict ones
- `tests/sample-tics.md` — the six specimens
- version 0.5.0, changelog entry

## Testing

All six specimens fire, across four categories. `tests/sample-clean.md` still reports nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu8z8WcJd1eQgG3LJNj3Wb)_