### PR TITLE
declauding 0.5.1: bring the README current, scope the header check

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.1] - 2026-08-23
+
+### Changed
+
+- README brought current. It described 37 entries and two register halves, which
+  was already stale by one before this release — 0.4.0 added entry 38 without
+  updating it. Now three groups, 42 entries, a table for 39 to 42, refreshed
+  corpus counts, and the provenance of the new block.
+- Nominalized-header check scoped to a prepositional tail ("Authorship in a
+  sourced child") or a two-word modifier plus abstraction ("Spawn availability").
+  A bare one-word nominalization is a legitimate label for a term the document
+  defines, and the first cut fired on this skill's own `## Overcorrection` and
+  `## Calibration`.
+
+### Added
+
+- Earned-exception rows in `SKILL.md` for entries 39 to 41, including the
+  one-word-label carve-out the header check now honors.
+
 ## [0.5.0] - 2026-08-23
 
 ### Other

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -4,12 +4,14 @@ Removes LLM prose tics from a draft and returns plain human technical prose. The
 input is text; the output is either the rewritten text or an annotated HTML diff
 showing every edit with its original and its reason.
 
-The register has two halves. Entries 1 to 23 are one move: **the sentence is
-built to make the reader feel a finding arrive, instead of stating the finding.**
-The fix is always the same: put a real subject in the subject slot, say the
-thing, stop. Entries 24 to 36 are the flatter slop patterns, where nothing is
-being staged and the prose is running on defaults. Entry 37 returns to the first
-half and sits last because it arrived last.
+The register has three groups. Entries 1 to 23, 37 and 38 are one move: **the
+sentence is built to make the reader feel a finding arrive, instead of stating
+the finding.** The fix is always the same: put a real subject in the subject
+slot, say the thing, stop. Entries 24 to 36 are the flatter slop patterns, where
+nothing is being staged and the prose is running on defaults. Entries 39 to 42
+are the register of reference prose — schema formality, and maxims welded onto
+facts. Numbering is chronological within the file, so a group is not a
+contiguous range.
 
 See [`SKILL.md`](SKILL.md) for the workflow, the overcorrection guard and the
 earned-exception table. See [`references/register.md`](references/register.md)
@@ -32,9 +34,9 @@ and nothing else.
 
 ## Tics it catches
 
-Thirty-seven entries. The first 23, and entry 37, are grouped by mechanism rather
-than by phrase, since phrase blocklists miss the next paraphrase. The ones that
-show up in nearly every draft:
+Forty-two entries. All of them except part of the 24-to-36 block are grouped by
+mechanism rather than by phrase, since phrase blocklists miss the next
+paraphrase. The ones that show up in nearly every draft:
 
 | Tic | Example |
 |---|---|
@@ -66,6 +68,21 @@ README boilerplate and pasted chat:
 | Speculative gap-filling | *…not publicly available, suggesting she maintains a low profile.* |
 | Diff-anchored documentation | *This function was added to replace the previous approach…* |
 | Subjectless fragment | *No configuration file needed. The results are preserved automatically.* |
+
+Entries 39 to 42 came from a reference document — an API page, where the prose is
+describing a system rather than making an argument. The staging entries mostly do
+not fire on that kind of writing, and these four do:
+
+| Tic | Example |
+|---|---|
+| Welded epigram | *…are dropped, so a child never carries a grant its parent lacks.* |
+| Spec-ese | *That child holds no repository and waits for input.* |
+| Nominalized header | *GitHub authorship in a sourced child* |
+| Contents-list standfirst | *The parameter surface, plus the behavior the schema leaves out.* |
+
+Entry 41 is the overcorrection from entry 7 and is written up as one. A verdict
+header rewritten into an abstraction passes entry 7's regex and still fails entry
+7's own test.
 
 Each entry carries the surface tell, why it is a tic, the fix, and a
 before-and-after. The first 23 come from a real published draft; the second block
@@ -123,16 +140,22 @@ as a pre-commit hook.
 ## False positives
 
 `tests/sample-clean.md` is human-written prose and must lint to zero.
-`tests/sample-tics.md` is a corpus of real specimens and currently reports 91
-candidates across 28 categories.
+`tests/sample-tics.md` is a corpus of real specimens and currently reports 114
+candidates across 30 categories.
 
 ```sh
-python3 scripts/declaude_lint.py tests/sample-tics.md    # 91 candidates
+python3 scripts/declaude_lint.py tests/sample-tics.md    # 114 candidates
 python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
-python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 7, all checked
+python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 8, all checked
+python3 scripts/declaude_lint.py README.md --skip-quoted # 6, all checked
 python3 scripts/declaude_lint.py tests/sample-structure.html   # 10, HTML path
 python3 scripts/declaude_review.py tests/sample-structure.md --slots
 ```
+
+One of the eight on `SKILL.md` is the `reuse` detector catching three parallel
+table labels ("Staging shapes, entries…", "Encyclopedic shapes, entries…",
+"Reference-prose shapes, entries…"). Three labels in a table series is the
+deliberate repetition entry 27 protects, so it stays.
 
 Several rules are deliberately tuned down to hold that zero, so the linter misses
 some real coy headers and some real inline-header bullets. A linter that fires on
@@ -156,7 +179,7 @@ rather than left to judgment:
 
 Every entry fires on a shape, and a shape sometimes carries a claim. Cutting it
 then removes content while looking like it removed only style. `SKILL.md`
-tabulates the earned form of 17 of the 37 entries, and names what hides inside a
+tabulates the earned form of 20 of the 42 entries, and names what hides inside a
 watched phrase: superlatives, rankings, simultaneity, scope words, and the
 condition attached to a hedge. *X rather than Y* is legitimate when the reader
 was genuinely holding Y; it is staged when you supplied Y so you could reject
@@ -214,6 +237,12 @@ specimens produced 2 candidates from this linter, neither for the right reason.
 It now produces 33 across 13 categories. The no-fabrication rule, the
 voice-sample precedence, the embedded invocation mode and the "leave these alone"
 list are also from that skill.
+
+Entries 39 to 42 came from a `create_session` reference artifact (2026-08-23)
+that had already been through a 0.4.0 pass and reported clean. Two of its section
+headers were flagged as verdict-shaped, all four were rewritten into
+nominalizations, and the linter then passed the result — which is entry 41, and
+the reason the entry names itself as an overcorrection.
 
 The two skills cover different halves of the problem and both remain worth
 reading. Humanizer is broader on encyclopedic and promotional slop and ships as a

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -2,7 +2,7 @@
 name: declauding
 description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.5.0
+  version: 0.5.1
 ---
 
 # Declauding
@@ -244,6 +244,14 @@ Encyclopedic shapes, entries 24 to 36:
 | False range (28) | X and Y are not endpoints of any scale | A real range with real endpoints |
 | Inline-header list (29) | The label restates the item | The label is a real index: a term being defined, an option name, a case name |
 | Typographic tells (30) | Bold, emoji or Title Case scattered mechanically | Bold on a term at first use; the document already uses emoji; a house style requires Title Case |
+
+Reference-prose shapes, entries 39 to 42:
+
+| Shape | Banned when | Earned when |
+|---|---|---|
+| Welded epigram (39) | The second clause restates the first as a maxim | Both clauses carry distinct facts a reader can act on |
+| Latinate state verb (40) | Register formality for a program doing nothing | The word is the system's own documented state — a queue whose states are `waiting` and `held` |
+| Nominalized header (41) | It names a topic area instead of the content | The noun is a term this document defines, standing alone as its label — "Overcorrection", "Provenance" |
 | Filler and hedging (32) | Hedges stack and none names a condition | One hedge names a real condition: "on the two runs that finished" |
 | Diff-anchored (34) | The doc narrates the change that produced it | The document is version-scoped by design: changelogs, release notes, migration guides |
 | Subjectless fragment (35) | The actor is known and matters | The register is clipped throughout — release notes, a feature table, a CLI help string |

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -256,9 +256,14 @@ HEADER_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 COY_HEADER_RE = re.compile(r"^(?:what|why|how)\b(?!.*\?$)", re.I)
 VERDICT_HEADER_RE = re.compile(r"\b(?:is|are|isn'?t|aren'?t|was|wasn'?t|does|doesn'?t|actually|really|wrong|right|matters|counts)\b", re.I)
 
+_NOM = r"(?:ship|tion|sion|ment|ance|ence|ity|ness)"
+# Fires on a nominalization with a prepositional tail ("Authorship in a sourced
+# child") or a two-word modifier+abstraction label ("Spawn availability"). A bare
+# one-word nominalization is a legitimate label for a term the document defines
+# — "Overcorrection", "Calibration", "Provenance" — and must not fire.
 NOMINAL_HEADER_RE = re.compile(
-    r"^(?:[A-Z]\w*\s+){0,2}\w+(?:ship|tion|sion|ment|ance|ence|ity|ness)\b"
-    r"(?:\s+(?:in|of|for|between|across|under)\b|\s*$)", re.I)
+    r"^(?:(?:\w+\s+){0,2}\w+" + _NOM + r"\s+(?:in|of|for|between|across|under)\b"
+    r"|\w+\s+\w+" + _NOM + r"\s*$)", re.I)
 GERUND_HEADER_RE = re.compile(r"^\w+ing\s+(?:a|an|the)\b", re.I)
 
 TITLE_CASE_SKIP = {


### PR DESCRIPTION
Follow-up to #771, which shipped entries 39-42 and left the README describing the skill as it was two releases ago.

## README

It said "Thirty-seven entries" and "the register has two halves". Both were already wrong before #771 — 0.4.0 added entry 38 and did not touch the README. Now:

- Three groups, not two. Entries 39 to 42 are the register of reference prose, and the numbering is chronological rather than grouped, which the text now says outright.
- Forty-two entries, with a table of the four new tics and their specimens.
- Corpus counts remeasured: `sample-tics.md` 114 across 30 categories, `SKILL.md --skip-quoted` 8, and `README.md --skip-quoted` 6, which was not tracked before.
- Earned-form count corrected to 20 of 42.
- Provenance for the new block.

## Header check

The nominalized-header rule from #771 fired on this skill's own `## Overcorrection` and `## Calibration`. Both are correct — a one-word noun labelling a term the document defines is what entry 7 asks for, and turning it into anything longer would make it worse. The check now needs a prepositional tail ("Authorship in a sourced child") or a two-word modifier plus abstraction ("Spawn availability"), so a bare noun no longer fires.

`SKILL.md` gains earned-exception rows for entries 39 to 41, including that carve-out, so the table and the linter agree on it.

## Counts

`sample-clean.md` still reports zero. All 14 specimen hits still fire. `SKILL.md` sits at 8 rather than the 7 the README used to quote — the extra one is the `reuse` detector on the three parallel table labels I added ("Staging shapes…", "Encyclopedic shapes…", "Reference-prose shapes…"), which is the deliberate repetition entry 27 protects. The README says so rather than rounding it down.

One thing I left alone: the release workflow prepends its own generated `## [0.5.0]` block above the hand-written one, so the changelog now has two. The same duplication exists at 0.4.0, so it predates this branch and editing it would only be undone at the next release.

Version 0.5.1, which is what triggers the release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu8z8WcJd1eQgG3LJNj3Wb)_