### PR TITLE
Use Anthropic's quick_validate.py; fix four frontmatter violations it found

### DIFF
--- a/container-layer/SKILL.md
+++ b/container-layer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: container-layer
-description: Build and cache a personalized container environment from a Dockerfile-like spec. Supports both single-layer (one Containerfile -> one cached tarball) and multi-layer composition (compose [base, scientific, mojo, ...] into one container with each layer cached independently). Use when the user mentions "container layer", "Containerfile", "custom container", "environment setup", "cache my installs", "uv shim", "composable layers", or wants to persist package installations, skills, or environment config across ephemeral sessions. Also triggers when the user asks to snapshot, restore, or rebuild their environment, or wants to capture ad-hoc package installs into a reproducible spec.
+description: Build and cache a personalized container environment from a Dockerfile-like spec. Supports both single-layer (one Containerfile to one cached tarball) and multi-layer composition (compose [base, scientific, mojo, ...] into one container with each layer cached independently). Use when the user mentions "container layer", "Containerfile", "custom container", "environment setup", "cache my installs", "uv shim", "composable layers", or wants to persist package installations, skills, or environment config across ephemeral sessions. Also triggers when the user asks to snapshot, restore, or rebuild their environment, or wants to capture ad-hoc package installs into a reproducible spec.
 metadata:
-  version: 0.2.2
+  version: 0.2.3
 ---
 
 # Container Layer

--- a/creating-skill/SKILL.md
+++ b/creating-skill/SKILL.md
@@ -87,7 +87,8 @@ description: What it does. Use when [trigger patterns].
 - Third person voice: "Processes files" not "I process files"
 - WHAT it does + WHEN to use it (trigger patterns)
 - Specify: file types, keywords, task types that should activate this skill
-- No XML tags
+- No angle brackets at all — the rule is stricter than "no XML tags". A `->` arrow
+  or a `>200MB` threshold is rejected on upload just as a `<tag>` is.
 
 **Good examples:**
 - "Creates PowerPoint presentations. Use when users mention slides, .pptx files, or presentations."
@@ -141,35 +142,44 @@ measures its own phrasing and nothing else. Any neighbour above ~0.65 cosine
 needs an explicit boundary in both descriptions, or the two skills need
 merging.
 
-### Parse the frontmatter before shipping it
+### Validate the frontmatter with Anthropic's validator, not by eye
 
-A description rich enough to be findable is long enough to break YAML. An
-unquoted `: ` inside the value ends the scalar, and the whole file stops
-parsing — the skill then does not load at all, silently, because nothing
-validates frontmatter at read time.
+A description rich enough to be findable is long enough to break the spec. An
+unquoted `: ` ends the YAML scalar and the file stops parsing; an angle bracket
+is rejected outright. Either way the skill does not load, silently, because
+nothing validates frontmatter at read time.
+
+Do not hand-roll this check. `skill-creator` ships one, and it is stricter than
+anything worth rewriting:
 
 ```bash
-python3 - <<'EOF'
-import yaml, pathlib
-for p in sorted(pathlib.Path('.').glob('*/SKILL.md')):
-    t = p.read_text()
-    if not t.startswith('---'):
-        print(f'{p.parent.name}: no frontmatter'); continue
-    try:
-        d = yaml.safe_load(t.split('---', 2)[1])
-        assert d.get('name') == p.parent.name, 'name != directory'
-        assert len(d['description']) <= 1024, f'description {len(d["description"])} chars'
-    except Exception as e:
-        print(f'{p.parent.name}: {e}')
-EOF
+python3 /mnt/skills/examples/skill-creator/scripts/quick_validate.py <skill-dir>
 ```
 
-Silence means clean. Diagnosed 2026-08-24: two skills revised in the same pass
-shipped `Primitives: depends_on...` and `makes skills work: a concrete...`
-inside unquoted descriptions. Both files became unparseable. A regex-based
-reader — including `skill_confusability.py` — accepts them happily, so the
-retrieval check passes while the skill is dead. Quote the string or use `>-`
-if a colon is unavoidable.
+It enforces YAML parseability, the allowed-property whitelist
+(`name`, `description`, `license`, `allowed-tools`, `metadata`,
+`compatibility`), kebab-case names under 64 chars, descriptions under 1024
+chars with no angle brackets, and exactly one SKILL.md per directory — the
+Skills API and claude.ai reject multiple on upload even though Claude Code's
+filesystem loads them.
+
+Run it over the whole catalogue before a batch edit:
+
+```bash
+for d in */; do
+  printf '%-24s ' "${d%/}"
+  python3 /mnt/skills/examples/skill-creator/scripts/quick_validate.py "$d" 2>&1 | tail -1
+done
+```
+
+Diagnosed 2026-08-24, twice in one pass. First: two skills shipped
+`Primitives: depends_on...` and `makes skills work: a concrete...` inside
+unquoted descriptions, and both files became unparseable. Second, the next day:
+a description carrying the literal `"review what's new in <repo>"` violated the
+no-angle-brackets rule. A regex reader — including `skill_confusability.py` —
+accepts all three happily, so the retrieval check passes while the skill is
+dead. `quick_validate.py` catches every one in about a second, and it was on
+disk the whole time.
 
 ## Writing Effective SKILL.md
 
@@ -446,7 +456,7 @@ Before providing skill to user:
 - [ ] Description routes away from its nearest siblings by name
 - [ ] `skill_confusability.py` run: skill takes top-1 on 5 task-shaped queries
 - [ ] No neighbour above ~0.65 cosine without an explicit boundary in both
-- [ ] **Frontmatter parses as YAML** — run the check below, do not eyeball it
+- [ ] `quick_validate.py` passes (YAML, allowed keys, name, length, no angle brackets)
 - [ ] `metadata.version` bumped (releases gate on the delta; unchanged = silent no-op)
 
 **Structure:**

--- a/exploring-codebases/SKILL.md
+++ b/exploring-codebases/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   yields an account of what the repo contains and how it is arranged,
   optionally written out as _FEATURES.md. Use for "I just cloned this",
   "what is this repo", "what does this do", "explore this repo", "give me an
-  orientation", "what are the main features", "review what's new in <repo>",
+  orientation", "what are the main features", "review what's new in this repo",
   or before starting work in a codebase you have not seen. This is the
   divergent what's-here skill. Route elsewhere for: a named symbol, a file's
   structure or a line range (tree-sitting); all callers of a Python symbol
@@ -15,7 +15,7 @@ description: >-
   (orienting-codebases); fetching or cloning a repo without analysing it
   (accessing-github-repos, cloning-project).
 metadata:
-  version: 2.5.0
+  version: 2.5.1
 ---
 
 # Exploring Codebases

--- a/exploring-data/SKILL.md
+++ b/exploring-data/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: exploring-data
-description: Exploratory data analysis. Use when users upload .csv/.xlsx/.json/.parquet files or request "explore data", "analyze dataset", "EDA", "profile data". Small files get ydata-profiling HTML/JSON reports; large files (>200MB or >5M rows) get fixed-memory DuckDB/sketch profiling. Also covers near-duplicate row detection, cross-file key overlap ("can these join?"), dataset drift vs a stored baseline, and time-series profiling.
+description: Exploratory data analysis. Use when users upload .csv/.xlsx/.json/.parquet files or request "explore data", "analyze dataset", "EDA", "profile data". Small files get ydata-profiling HTML/JSON reports; large files (over 200MB or 5M rows) get fixed-memory DuckDB/sketch profiling. Also covers near-duplicate row detection, cross-file key overlap ("can these join?"), dataset drift vs a stored baseline, and time-series profiling.
 metadata:
-  version: 0.1.1
+  version: 0.1.2
 ---
 
 # Exploring Data


### PR DESCRIPTION
Follow-up to #774, which merged this morning. Comparing our `creating-skill` against the bundled `skill-creator` turned up a validator that was on disk the whole time.

## The validator we already had

`/mnt/skills/examples/skill-creator/scripts/quick_validate.py` is stricter than the YAML check #774 added by hand:

- YAML parseability and dict shape
- allowed-property whitelist — `name`, `description`, `license`, `allowed-tools`, `metadata`, `compatibility`
- kebab-case name, no leading/trailing/double hyphens, ≤64 chars
- description ≤1024 chars, **no angle brackets in any position**
- exactly one SKILL.md per directory, because the Skills API and claude.ai reject multiples on upload even though Claude Code's filesystem loads nested ones

`creating-skill` now calls it instead of the hand-rolled heredoc, with a catalogue-wide loop.

## Four violations, one of them from #774

| Skill | Problem |
|---|---|
| `exploring-codebases` | `"review what's new in <repo>"` — angle brackets, introduced in #774. 2.5.0 → 2.5.1 |
| `container-layer` | `(one Containerfile -> one cached tarball)` — the `>` in the arrow |
| `exploring-data` | `large files (>200MB or >5M rows)` — the `>` in the thresholds |
| `controlling-spotify` | `credentials` and `domains` keys outside the allowed set — **not fixed here** |

The last one is left alone deliberately. Something may read those keys, and stripping frontmatter blind is not a safe unilateral edit. Flagging it rather than guessing.

Our frontmatter guidance said "No XML tags". The actual rule is no angle brackets at all, which is what caught `container-layer` and `exploring-data` — neither is markup. Corrected.

## Verification

91 of 92 skills validate; the remaining one is `controlling-spotify` above.

```
for d in */; do
  printf '%-24s ' "${d%/}"
  python3 /mnt/skills/examples/skill-creator/scripts/quick_validate.py "$d" 2>&1 | tail -1
done
```

Patch-bumped `metadata.version` on all three edited skills.

Note: #774's branch was deleted on merge, so this is a fresh branch off current `main` rather than a continuation. The stale `claude/skill-quality-fixes-from-agent-skills-paper` branch got recreated by a push before I noticed the merge — it holds no unmerged work and can be deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoDaifHB1jjqNNFUU27rHE)_