### PR TITLE
CI: gate PRs on the skill frontmatter spec

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,47 @@
+name: Validate Skills
+
+# Gate: a PR may not ADD a frontmatter violation. Pre-existing ones are
+# baseline — see scripts/validate_skills.py for why the gate is diff-scoped
+# rather than whole-tree. The full-catalogue audit runs alongside as a
+# non-blocking report, and on demand via workflow_dispatch.
+
+on:
+  pull_request:
+    paths:
+      - '*/SKILL.md'
+      - 'scripts/validate_skills.py'
+      - 'scripts/vendor/**'
+      - '.github/workflows/validate-skills.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # validate_skills.py diffs against the merge base, so history has to
+          # be in the clone. A shallow checkout leaves `git diff ref...HEAD`
+          # with no common ancestor and every skill reads as changed.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate skills changed by this PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          python3 scripts/validate_skills.py --changed-vs "origin/${{ github.base_ref }}"
+
+      - name: Audit the whole catalogue (informational)
+        run: python3 scripts/validate_skills.py --all --warn-only

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Run the skill spec check over this repo, scoped to what a branch changed.
+
+    validate_skills.py --changed-vs origin/main     # gate: only what this PR touched
+    validate_skills.py --all                        # audit: whole catalogue
+    validate_skills.py exploring-codebases flowing  # named skills
+
+Exits 1 if any selected skill fails. The check itself is Anthropic's
+`quick_validate.py`, vendored under scripts/vendor/ so CI runs the same rules
+that gate an actual upload: YAML parseability, the allowed-property whitelist,
+kebab-case names, the 64/1024 length caps, no angle brackets anywhere, and
+exactly one SKILL.md per skill directory.
+
+WHY DIFF-SCOPED BY DEFAULT
+
+A whole-tree gate on a catalogue with pre-existing violations is red on arrival,
+and a check that is always red gets ignored. `controlling-spotify` carries
+`credentials` and `domains` keys outside the allowed set; whether those keys have
+a live consumer is not something CI should decide. So the PR gate asks only "did
+this branch add a violation", and `--all` stays available for the audit. Same
+split as `muninn_utils.ruff_gate` in claude-workspace, for the same reason.
+
+Diagnosed 2026-08-24 and 2026-08-25: an unquoted ": " inside a long description
+ends the YAML scalar, and an angle bracket is rejected outright. Either way the
+skill stops loading, silently, while a regex-based reader still ranks it happily.
+Four such violations were live in this repo before anyone ran the check.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent / "vendor"))
+from quick_validate import validate_skill  # noqa: E402
+
+
+def all_skills() -> list[Path]:
+    return sorted(p.parent for p in REPO.glob("*/SKILL.md"))
+
+
+def changed_skills(ref: str) -> list[Path]:
+    """Skill dirs whose SKILL.md differs from `ref`.
+
+    Uses `ref...HEAD` so the comparison is against the merge base, not the tip
+    of the base branch — otherwise every unrelated commit landing on main while
+    a PR is open reads as this branch's change. A deleted skill has nothing to
+    validate, so filter to dirs that still exist rather than failing on a rename.
+
+    This compares COMMITS. An uncommitted edit in the working tree is invisible
+    here, which is right for CI (a PR branch always has its changes committed)
+    and a trap locally: `--changed-vs` on a dirty tree reports "nothing to
+    validate". Commit first, or name the skill directly.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{ref}...HEAD"],
+            cwd=REPO, capture_output=True, text=True, check=True).stdout
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(f"git diff against {ref!r} failed: {e.stderr.strip()}") from e
+    dirs = {REPO / line.split("/")[0] for line in out.splitlines()
+            if line.endswith("/SKILL.md") and line.count("/") == 1}
+    return sorted(d for d in dirs if (d / "SKILL.md").exists())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("skills", nargs="*", help="skill directory names")
+    ap.add_argument("--all", action="store_true", help="validate every skill")
+    ap.add_argument("--changed-vs", metavar="REF",
+                    help="validate only skills this branch changed vs REF")
+    ap.add_argument("--warn-only", action="store_true",
+                    help="report failures but exit 0 (for informational audits)")
+    args = ap.parse_args()
+
+    if args.all:
+        targets = all_skills()
+        scope = f"all {len(targets)} skills"
+    elif args.changed_vs:
+        targets = changed_skills(args.changed_vs)
+        scope = f"{len(targets)} skill(s) changed vs {args.changed_vs}"
+    elif args.skills:
+        targets = [REPO / s for s in args.skills]
+        scope = f"{len(targets)} named skill(s)"
+    else:
+        ap.error("pass --all, --changed-vs REF, or one or more skill names")
+
+    if not targets:
+        print(f"No SKILL.md changed vs {args.changed_vs} — nothing to validate.")
+        return
+
+    print(f"Validating {scope}\n")
+    bad = []
+    for d in targets:
+        if not (d / "SKILL.md").exists():
+            bad.append((d.name, "SKILL.md not found"))
+            print(f"  FAIL  {d.name}: SKILL.md not found")
+            continue
+        ok, msg = validate_skill(d)
+        if ok:
+            print(f"  ok    {d.name}")
+        else:
+            bad.append((d.name, msg))
+            print(f"  FAIL  {d.name}: {msg}")
+
+    print()
+    if not bad:
+        print(f"All {len(targets)} valid.")
+        return
+    print(f"{len(bad)} of {len(targets)} invalid:")
+    for name, msg in bad:
+        print(f"  {name}: {msg.splitlines()[0]}")
+    if args.warn_only:
+        print("\n(--warn-only: not failing the build)")
+        return
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vendor/quick_validate.py
+++ b/scripts/vendor/quick_validate.py
@@ -1,0 +1,155 @@
+# Vendored from Anthropic's `skill-creator` skill, Apache License 2.0.
+# Upstream: /mnt/skills/examples/skill-creator/scripts/quick_validate.py
+# (also synced to ~/.claude/skills/synced/skill-creator/). Full licence text
+# ships with that skill as LICENSE.txt.
+#
+# DO NOT EDIT. This is a verbatim copy so CI can run the same spec check the
+# skill-creator runs in-session; a local fix here would silently diverge from
+# what actually gates uploads. If upstream changes, re-vendor and note the
+# date. Vendored 2026-08-25.
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+
+# Directories whose contents are not packaged as part of the skill, so any
+# SKILL.md inside them shouldn't count toward the single-SKILL.md check below.
+# Mirrors package_skill.py: __pycache__ and node_modules are excluded at any
+# depth, while evals is only excluded at the skill root.
+EXCLUDED_DIR_PARTS = {'__pycache__', 'node_modules'}
+ROOT_EXCLUDED_DIR_PARTS = {'evals'}
+
+
+def _counts_as_skill_md(rel_path):
+    """True if a SKILL.md at rel_path (relative to the skill root) would be packaged."""
+    dir_parts = rel_path.parts[:-1]
+    if any(part in EXCLUDED_DIR_PARTS for part in dir_parts):
+        return False
+    if dir_parts and dir_parts[0] in ROOT_EXCLUDED_DIR_PARTS:
+        return False
+    return True
+
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # A skill must contain exactly one SKILL.md, at <folder>/SKILL.md. Extra
+    # (nested) SKILL.md files are rejected on upload: the Skills API and claude.ai
+    # accept exactly one per skill — only Claude Code's filesystem loads nested
+    # ones. package_skill produces an upload-bound .skill, so block here rather
+    # than ship an artifact that's guaranteed to fail on upload.
+    skill_md_files = [
+        p for p in skill_path.rglob('SKILL.md')
+        if _counts_as_skill_md(p.relative_to(skill_path))
+    ]
+    if len(skill_md_files) > 1:
+        extras = sorted(
+            str(p.relative_to(skill_path)) for p in skill_md_files
+            if p.resolve() != skill_md.resolve()
+        )
+        return False, (
+            f"Found {len(skill_md_files)} SKILL.md files, but a skill must contain "
+            f"exactly one at <folder>/SKILL.md. The Skills API and claude.ai reject "
+            f"multiple on upload (only Claude Code's filesystem loads nested skills). "
+            f"Extra: {', '.join(extras)}.\n"
+            "  - Separate skills: package each on its own, or build a plugin "
+            "(skills/<name>/SKILL.md).\n"
+            "  - Supporting docs: rename to non-SKILL.md files (e.g. references/<topic>.md).\n"
+            "  - Swept in by mistake: package only the one skill directory."
+        )
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)


### PR DESCRIPTION
Step 1 of the plan agreed after the catalogue audit: make the cheap check permanent instead of a one-time pass.

## Why a gate rather than another sweep

Four frontmatter violations were live in this repo before anyone ran a check, and one of them was shipped by #774 — the PR that added a hand-rolled version of the check. The class recurs because nothing validates frontmatter at read time. An unquoted `: ` ends the YAML scalar; an angle bracket is rejected on upload. Either way the skill silently stops loading, and a regex-based reader still ranks it perfectly happily, so the failure is invisible from the retrieval side.

## What lands

- `scripts/vendor/quick_validate.py` — Anthropic's validator from the bundled `skill-creator`, vendored verbatim under Apache 2.0 with attribution in the file header. Vendored rather than reimplemented so CI runs the same rules that gate a real upload; a local approximation would drift from the thing that actually rejects the file. Marked do-not-edit, re-vendor instead.
- `scripts/validate_skills.py` — driver with three modes: `--changed-vs REF`, `--all`, or named skills.
- `.github/workflows/validate-skills.yml` — runs on PRs touching `*/SKILL.md`, plus `workflow_dispatch`.

## The gate is diff-scoped on purpose

A whole-tree gate on a catalogue that already has a violation is red on arrival, and a check that is always red gets ignored. `controlling-spotify` carries `credentials` and `domains` keys outside the allowed set, and whether those have a live consumer is not CI's call.

So the PR gate asks only whether *this branch added* a violation. The full-catalogue audit runs in the same job with `--warn-only`, so the pre-existing one stays visible without blocking. Same split as `muninn_utils.ruff_gate` in claude-workspace, for the same reason.

`fetch-depth: 0` is required — the driver diffs `ref...HEAD` against the merge base, and a shallow checkout leaves no common ancestor, so every skill would read as changed.

## Verification

Reproduced the failure before trusting the fix. Broke `hello-demo`'s description with `<tag>` and a `broken: scalar`, committed it, and ran the gate:

```
Validating 1 skill(s) changed vs origin/main

  FAIL  hello-demo: Invalid YAML in frontmatter: mapping values are not allowed here
     ... e. Now with a <tag> and a broken: scalar.
                                         ^
rc=1
```

Red on exactly the one changed skill, silent on the other 91. Then reverted and confirmed clean.

Current catalogue state: 91 of 92 valid, the exception being `controlling-spotify` above.

One gotcha documented in the docstring: `--changed-vs` compares commits, so an uncommitted working-tree edit is invisible to it. Correct for CI, a trap locally — commit first or name the skill directly.

Next: negative cases in `skill_confusability.py` before any more bulk description edits, then the ranked pass over the top ~20 by use.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoDaifHB1jjqNNFUU27rHE)_