### PR TITLE
declauding 0.6.0: entries 43-47, the register the pass produces

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0] - 2026-08-28
+
+### Added
+
+- Entries 43 to 47, a fourth group: the flat-certainty register this skill's own
+  output lands in. 43 flat-certainty adverb ("provably safe", "quietly dropped"),
+  44 juridical register (a linter that *rules*, a default that is a *carve-out*),
+  45 verification-provenance compound ("byte-identical", "mutation-checked", the
+  `re-` prefix claiming a second pass), 46 privative coinage ("unguarded",
+  "unwired", "vacuous"), 47 exhaustive negation ("nothing in it does X",
+  "nowhere else for it to be"). Each has an earned column; none is a blocklist.
+- `references/corpus.md` — the measurement behind them, the method, and what the
+  numbers do not support.
+- Lint categories `flat-certainty`, `juridical`, `verification`, `privative`,
+  `exhaustive`, and a `corpus-register` density line reporting the draft's rate
+  of the cluster's top-150 vocabulary.
+- Earned-exception rows in `SKILL.md` for entries 43 to 47, and specimens plus
+  four must-stay-silent negatives in `tests/sample-tics.md`.
+- Entry 47 added to `STRUCTURAL_ENTRIES` in `declaude_review.py`: an exhaustive
+  negative is earned when its scope is named, and only the surrounding sentences
+  say whether it is. 43 to 46 are lexical and stage 1 reaches them.
+
+### Fixed
+
+- `load_register` in `declaude_review.py` ended an entry only at the next
+  *numbered* heading, so selecting the file's last entry pulled the trailing
+  "Quick self-check" section into the prompt with it. Any `#`/`##` heading now
+  closes the block. Latent until 47 became the last entry.
+
+### Provenance
+
+Louis Abraham's [load-bearing](https://github.com/louisabraham/load-bearing)
+clusters GitHub pull request descriptions by vocabulary — 461,121 descriptions,
+85 whole weeks, 2025-01-06 to 2026-08-17, ten clusters, no time parameter in the
+fit. One cluster is 0.70% of the first eight weeks and 39.5% of the last four,
+rising 1.24 points a week. Its highest-lift words are `load-bearing` 39x,
+`plainly` 34x, `quietly` 30x, `refusal` 28x, `re-derived` 27x, `asserted` 25x,
+`nobody` 25x, `genuinely` 24x, `outright` 23x, `byte-identical` 23x.
+
+That is not the slop vocabulary of entry 20. It is the register this skill aims
+at, and it is now the fastest-growing way of writing a pull request description
+there is. A pass that removes 42 staging tics and lands here has traded one
+detectable shape for another.
+
+### False-positive budget
+
+`tests/sample-clean.md` still reports zero. On 115,920 words of Python stdlib
+docstrings the five new categories fire 18 times (0.16 per 1,000 words), ten of
+them on `silently`. `is simply` was cut from the adverb rule for scoring two of
+those and not appearing in the corpus list at all. `unsatisfiable` was cut from
+the privative rule as a SAT term.
+
+The `corpus-register` line is a register locator and not an authorship detector.
+load-bearing's own human-written README scores 1.51 per 100 words of body prose,
+above this skill's `SKILL.md` at 1.47, on `nothing` x9, `carries` x3, `alone` x2,
+`never` x2 and `half` x2. Human stdlib docstrings run 0.08 median and 0.32 at
+worst over 46 chunks of 2,500 words. The note on the line says this, because a
+reader who takes it for a detector will cut `nothing` and `measured` out of
+correct sentences.
+
+`tests/sample-tics.md` now reports 136 candidates across 35 categories,
+`SKILL.md --skip-quoted` 12 and `README.md --skip-quoted` 15 — the README's three
+new `locator` hits are the repository's name, which entry 19 lists as a metaphor
+and `--skip-quoted` cannot tell from a proper noun.
+
 ## [0.5.1] - 2026-08-23
 
 ### Other

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -4,18 +4,22 @@ Removes LLM prose tics from a draft and returns plain human technical prose. The
 input is text; the output is either the rewritten text or an annotated HTML diff
 showing every edit with its original and its reason.
 
-The register has three groups. Entries 1 to 23, 37 and 38 are one move: **the
+The register has four groups. Entries 1 to 23, 37 and 38 are one move: **the
 sentence is built to make the reader feel a finding arrive, instead of stating
 the finding.** The fix is always the same: put a real subject in the subject
 slot, say the thing, stop. Entries 24 to 36 are the flatter slop patterns, where
 nothing is being staged and the prose is running on defaults. Entries 39 to 42
 are the register of reference prose — schema formality, and maxims welded onto
-facts. Numbering is chronological within the file, so a group is not a
-contiguous range.
+facts. Entries 43 to 47 are this skill's own output: the flat, verdict-shaped
+register a clean pass lands in, which is now the fastest-growing cluster of
+GitHub pull request descriptions there is. Numbering is chronological within the
+file, so a group is not a contiguous range.
 
 See [`SKILL.md`](SKILL.md) for the workflow, the overcorrection guard and the
 earned-exception table. See [`references/register.md`](references/register.md)
-for the catalogue. See [`CHANGELOG.md`](CHANGELOG.md) for version history.
+for the catalogue and [`references/corpus.md`](references/corpus.md) for the
+measurement behind entries 43 to 47. See [`CHANGELOG.md`](CHANGELOG.md) for
+version history.
 
 ## Two output modes
 
@@ -108,6 +112,15 @@ whose label restates the item, per-instance em-dash drum rolls, em-dash density,
 repeated sentence openings and phrases, curly-quote and emoji counts, and
 sentence-length monotony.
 
+One line is not a tell at all. `corpus-register density` reports how much of the
+draft is the top-150 vocabulary of the load-bearing corpus cluster, which locates
+the register and says nothing about the author: human stdlib docstrings run 0.08
+median and 0.32 at worst, this skill's own files run 1.5 to 3.2, and the
+human-written README of the repository the list came from scores 1.51, above this
+skill's `SKILL.md`. Above roughly 1.0 the
+cue is to read entries 43 to 47, never to cut `nothing` or `measured` on sight.
+[`references/corpus.md`](references/corpus.md) has the figures and the limits.
+
 The `reuse` block groups the hits the scan already produced and reports any
 construction used more than once. It adds no rules and costs nothing, and reuse
 is the strongest available evidence that a construction is a habit rather than a
@@ -140,22 +153,27 @@ as a pre-commit hook.
 ## False positives
 
 `tests/sample-clean.md` is human-written prose and must lint to zero.
-`tests/sample-tics.md` is a corpus of real specimens and currently reports 114
-candidates across 30 categories.
+`tests/sample-tics.md` is a corpus of real specimens and currently reports 136
+candidates across 35 categories.
 
 ```sh
-python3 scripts/declaude_lint.py tests/sample-tics.md    # 114 candidates
+python3 scripts/declaude_lint.py tests/sample-tics.md    # 136 candidates
 python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
-python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 8, all checked
-python3 scripts/declaude_lint.py README.md --skip-quoted # 6, all checked
+python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 12, all checked
+python3 scripts/declaude_lint.py README.md --skip-quoted # 15, all checked
 python3 scripts/declaude_lint.py tests/sample-structure.html   # 10, HTML path
 python3 scripts/declaude_review.py tests/sample-structure.md --slots
 ```
 
-One of the eight on `SKILL.md` is the `reuse` detector catching three parallel
+One of the twelve on `SKILL.md` is the `reuse` detector catching four parallel
 table labels ("Staging shapes, entries…", "Encyclopedic shapes, entries…",
-"Reference-prose shapes, entries…"). Three labels in a table series is the
-deliberate repetition entry 27 protects, so it stays.
+"Reference-prose shapes, entries…", "Flat-certainty shapes, entries…"). Four
+labels in a table series is the deliberate repetition entry 27 protects, so it
+stays.
+
+Three of the fifteen on this README are `load-bearing`, which entry 19 does list
+as a metaphor and which here is the name of a repository. A proper name is the
+carve-out `SKILL.md` states and `--skip-quoted` cannot see.
 
 Several rules are deliberately tuned down to hold that zero, so the linter misses
 some real coy headers and some real inline-header bullets. A linter that fires on
@@ -179,7 +197,7 @@ rather than left to judgment:
 
 Every entry fires on a shape, and a shape sometimes carries a claim. Cutting it
 then removes content while looking like it removed only style. `SKILL.md`
-tabulates the earned form of 20 of the 42 entries, and names what hides inside a
+tabulates the earned form of 25 of the 47 entries, and names what hides inside a
 watched phrase: superlatives, rankings, simultaneity, scope words, and the
 condition attached to a hedge. *X rather than Y* is legitimate when the reader
 was genuinely holding Y; it is staged when you supplied Y so you could reject
@@ -237,6 +255,18 @@ specimens produced 2 candidates from this linter, neither for the right reason.
 It now produces 33 across 13 categories. The no-fabrication rule, the
 voice-sample precedence, the embedded invocation mode and the "leave these alone"
 list are also from that skill.
+
+Entries 43 to 47 came from a count instead of a draft. Louis Abraham's
+[load-bearing](https://github.com/louisabraham/load-bearing) clusters GitHub pull
+request descriptions by vocabulary — 461,121 of them across 85 whole weeks — and
+one of its ten clusters went from 0.70% of early 2025 to 39.5% of August 2026.
+Its highest-lift words are `load-bearing`, `plainly`, `quietly`, `refusal`,
+`re-derived`, `asserted`, `nobody`, `genuinely`, `outright`, `byte-identical`:
+not the slop vocabulary of entry 20, but the flat verdict-shaped register this
+skill aims at. The five entries and the `corpus-register` line came out of that,
+along with the measurement in
+[`references/corpus.md`](references/corpus.md) of what the rate can and cannot
+claim.
 
 Entries 39 to 42 came from a `create_session` reference artifact (2026-08-23)
 that had already been through a 0.4.0 pass and reported clean. Two of its section

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: declauding
-description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, plus the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
+description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging), and the flat-certainty patterns of the register the pass itself produces (bare adverbs, juridical vocabulary, verification compounds, privative coinages, exhaustive negation) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.5.1
+  version: 0.6.0
 ---
 
 # Declauding
@@ -57,6 +57,19 @@ defaults. Copula avoidance, participle tails, forced triads, chatbot residue.
 Different mechanism, same pass. Entries 37 and 38 are back in the staging family
 and sit last only because they arrived last.
 
+Entries 43 to 47 are a third family, and they are this skill's own output. The
+register a clean pass lands in — flat, concrete, verdict-shaped — is the
+fastest-growing cluster of GitHub pull request descriptions there is: 0.70% of
+early 2025, 39.5% of August 2026, with `plainly`, `quietly`, `refusal`,
+`re-derived` and `byte-identical` among its highest-lift words.
+`references/corpus.md` has the measurement. Flat certainty has tics of its own,
+and the test is the same one register over: *am I stating the finding, or
+performing having settled it?*
+
+The response to that is not to put the staging back. It is to check that an
+adverb, a hyphenated compound or an absolute negative is carrying evidence
+rather than standing in for it.
+
 ## The author's own writing outranks this skill
 
 If the user supplies a sample of their writing, read it before editing and match
@@ -108,6 +121,12 @@ treated as a heading too, because a subtitle is a header by every test that
 matters. Force with `--html`, disable with `--no-html`. Reported line numbers
 refer to the flattened view.
 
+The `corpus-register` density line locates a register. It does not detect an
+author. Above roughly 1.0 per 100 words the draft sits in the cluster's register,
+and a person who chooses that register scores there too, so the line is a cue to
+read entries 43 to 47 and never a licence to cut `nothing` or `measured` on
+sight. `references/corpus.md` has the figures.
+
 Lint every string that reaches the reader, not only the body file. Page titles,
 subtitles and deck headers are prose, and a builder that takes them as CLI
 arguments rather than from the file will hide them from this scan.
@@ -140,7 +159,9 @@ markers, drift across the piece, imposter test — use the `challenging` skill's
 thorough one.
 
 **3. Sentence pass.** For every sentence, in order: stating or staging? Load
-`references/register.md` for the catalogue of tells and their fixes.
+`references/register.md` for the catalogue of tells and their fixes. On a draft
+this skill or another model already cleaned, read entries 43 to 47 first — a
+second pass over already-flat prose is where they live.
 
 **4. Structure pass.** Headers (are they labels or verdicts?), paragraph breaks
 (is an isolated line a real pivot or a drum roll?), fragment runs, rhetorical
@@ -256,6 +277,16 @@ Reference-prose shapes, entries 39 to 42:
 | Diff-anchored (34) | The doc narrates the change that produced it | The document is version-scoped by design: changelogs, release notes, migration guides |
 | Subjectless fragment (35) | The actor is known and matters | The register is clipped throughout — release notes, a feature table, a CLI help string |
 | Predicate hyphenation (36) | Every pair is hyphenated in both positions | House style or a quoted source sets it |
+
+Flat-certainty shapes, entries 43 to 47:
+
+| Shape | Banned when | Earned when |
+|---|---|---|
+| Flat-certainty adverb (43) | It asserts the reader's reaction — "provably safe", "quietly dropped" | It names a contrast the reader can check: "silently" against a version that logs |
+| Juridical vocabulary (44) | A program state described as an adjudication | It is the system's own documented word — a policy engine whose API says `deny` |
+| Verification compound (45) | The method is compressed into an adjective and never shown | The number is beside it: "byte-identical" next to the diff, "mutation-checked" next to 14 of 15 |
+| Privative coinage (46) | A minted adjective replaces the measurement | The field's term ("unsatisfiable"), or the absence is the finding and stated once |
+| Exhaustive negation (47) | A universal negative stands in for the search | The scope is bounded and named: "none of the 46 chunks exceeds 0.57%" |
 
 **Modifiers inside a watched phrase carry content.** "The single most important
 new build" ranks that item against every other item; "the important new build"

--- a/declauding/references/corpus.md
+++ b/declauding/references/corpus.md
@@ -1,0 +1,113 @@
+# Where entries 43 to 47 come from
+
+Entries 1 to 42 were promoted from drafts, one specimen at a time, under the
+rule in `SKILL.md`: a phrase earns an entry after it shows up twice. Entries 43
+to 47 came the other way round, from a corpus that had already counted the
+phrases. This file records what was measured, so a later reader can check the
+entries against the evidence instead of taking them on trust.
+
+## The source
+
+Louis Abraham's [load-bearing](https://github.com/louisabraham/load-bearing)
+samples GitHub pull request descriptions — ten five-minute windows a day drawn
+by a date-seeded RNG, bodies fetched through the search API, bot logins and
+mass-posters filtered out — and clusters them by the words they are written
+with. Ten clusters, hard assignment, KL k-means with no time parameter anywhere
+in the fit, so a cluster's weekly share is attribution after the fact rather
+than a trend the model was free to draw.
+
+The numbers below are from `analysis.js` generated 2026-08-28: 595 days in 85
+whole weeks, 2025-01-06 to 2026-08-17, 461,121 descriptions, 51,079,244 word
+appearances, 19,798 words past the 50-distinct-authors floor. `k=10`, `SEED=6`,
+8 fits, cheapest published.
+
+One of the ten clusters was **0.70% of the first eight weeks and 39.5% of the
+last four**. The least-squares line over the last twelve weeks is +1.24 points a
+week. Its highest-lift words, by the ratio of inside-frequency to
+outside-frequency:
+
+```
+load-bearing 39x   plainly 34x   quietly 30x   refusal 28x   survived 28x
+re-derived 27x     halves 27x    asserted 25x  nobody 25x    genuinely 24x
+deliberately 24x   premise 23x   refuses 23x   outright 23x  byte-identical 23x
+ruling 22x         genuine 22x   handed 22x    carries 21x   died 20x
+```
+
+## The register this skill produces
+
+That is not the slop vocabulary of entry 20. There is no *delve*, no *tapestry*,
+no *robust*. It is flat, concrete, verdict-shaped technical prose: the register
+this skill's Overcorrection section describes as the target, where the writing is
+plain-and-sure, facts are short, and failures are stated dryly.
+
+**The register this skill produces is the fastest-growing cluster in the
+corpus.** Entries 43 to 47 exist because a subtractive pass that removes 42
+staging tics and lands the draft in a register 39% of GitHub now writes has
+traded one detectable shape for another.
+
+Putting the staging back would be worse. What the entries ask instead is that
+flat certainty be checked the way staging is, by the same generative test one
+register over: am I stating the finding, or performing having settled it? An
+author reaches for these shapes when a sentence has to sound settled.
+
+## The measured rates and their limits
+
+Rate of the cluster's top-150 vocabulary as a percentage of body-prose word
+tokens, measured the way `declaude_lint.py` measures it — headings, tables, code
+fences and, where marked, quoted specimens excluded:
+
+| text | rate |
+|---|---|
+| Python stdlib docstrings, 116k words, 46 chunks of 2,500 | median 0.08, p90 0.17, max 0.32 |
+| `tests/sample-clean.md`, this skill's human control | 0.34 |
+| load-bearing's own `README.md`, written by a person | 1.51 |
+| this skill's `SKILL.md` | 1.47 |
+| this skill's `README.md` | 1.71 |
+| `tests/sample-tics.md` | 2.87 |
+| this file | 2.65 |
+| this skill's `references/register.md` | 3.17 |
+
+The stdlib figure is a floor rather than a fair control. API reference prose is a
+different genre, so some of the separation is genre and not authorship.
+
+The third row is the one that settles what the rule can claim. Louis Abraham's
+README scores 1.51, above this skill's `SKILL.md`, on `nothing` x9, `carries` x3,
+`alone` x2, `never` x2 and `half` x2. Quoted specimens are already excluded, so
+they do not account for it. He writes this way, and writes it well.
+
+So the rate is a **register locator, not an authorship detector**. It answers one
+question: is this draft written in the cluster's register. The
+`corpus-register` density line in `declaude_lint.py` says so in its note. That
+wording carries weight. A reader who takes the line for a detector will start
+cutting `nothing` and `measured` out of correct sentences, which is entry 23's
+failure mode with a number attached to it.
+
+That is also why there is no blocklist here. Every word in the list is a word a
+person writes. Entries 43 to 47 fire on the shape each family builds, and each
+one carries an earned column because each family carries claims.
+
+## Reproducing it
+
+```bash
+git clone --depth 1 https://github.com/louisabraham/load-bearing
+python3 - <<'EOF'
+import json, re
+s = open('load-bearing/analysis.js').read()
+d = json.loads(s[s.index('{'):s.rindex('}') + 1])
+lead = set(d['components'][0]['word_list'][:150])
+words = re.findall(r"[A-Za-z0-9/_-]*[A-Za-z][A-Za-z0-9/_-]*", open('DRAFT.md').read().lower())
+print(100 * sum(w in lead for w in words) / len(words))
+EOF
+```
+
+The list ships in `declaude_lint.py` as `CORPUS_LEAD`, so re-running that against
+a fresh `analysis.js` is also how the list gets updated. The cluster is one fit's
+answer, and load-bearing's own §5 says the seed moves the headline, so treat a
+shifted list as a shifted sample and not a correction to this one.
+
+## The top of the table
+
+The two highest rows are this skill's own files: `references/register.md` at
+3.17, this one at 2.65. Both are documents whose subject is the vocabulary, so
+the result is expected, and it is also the demonstration. A rate reports where
+the prose sits. Authorship and quality are outside what it measures.

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -809,6 +809,169 @@ need one.
 
 ---
 
+# Flat-certainty patterns
+
+Entries 43 to 47 are the register this skill produces, once the staging is gone.
+They come from a count rather than from a draft: the cluster of GitHub pull
+request descriptions that went from 0.70% of early 2025 to 39.5% of August 2026,
+whose highest-lift words are `load-bearing`, `plainly`, `quietly`, `refusal`,
+`re-derived`, `asserted`, `nobody`, `genuinely`, `outright`, `byte-identical`.
+`references/corpus.md` carries the method, the numbers and the limits.
+
+Nothing here is staging a reveal. These sentences are trying to sound *settled* —
+adjudicated, verified, exhaustively negated — and the same test applies one
+register over: **am I stating the finding, or performing having settled it?**
+
+Every family below is also a family a careful writer uses correctly, which is why
+each entry has an earned column. Do not treat any of these words as a blocklist;
+`references/corpus.md` explains what the measurement does and does not support.
+
+---
+
+## 43. Flat-certainty adverb
+
+**Tell:** a bare adverb doing the work of the evidence — "plainly", "quietly",
+"outright", "merely", "genuinely", "deliberately", "provably", "empirically",
+"demonstrably", "structurally", "legitimately", "precisely", "honestly",
+"vacuously", "adversarially", "silently", "loudly", "routinely", "identically".
+
+**Why:** `plainly` and `quietly` are the second and third highest-lift words in
+the corpus cluster. The adverb asserts the reader's reaction — that this is
+obvious, that it happened without noise, that the check was real — where the
+sentence has not shown it. "Provably correct" without the proof is "correct" with
+a costume on. It is entry 23 in the flat register: the modifier pre-loads the
+verdict.
+
+**Fix:** delete it, or replace it with what makes it true.
+
+> was: *The retry is provably safe.*
+> now: *The retry is idempotent: the handler keys on the request id.*
+
+> was: *The flag was quietly dropped in 4.2.*
+> now: *The flag was dropped in 4.2. The changelog does not mention it.*
+
+**Earned:** the adverb names a real contrast the reader can check — "silently"
+against a version that logs, "identically" against a version that differs. One
+adverb carrying a comparison is information; three in a paragraph is a register.
+
+---
+
+## 44. Juridical register
+
+**Tell:** code, tests and processes described as a court — "refusal", "refuses",
+"declines", "admits", "ruling", "verdict", "precedent", "carve-out", "standing",
+"grounds", "obligation", "owed", "remedy", "ratified", "sanctioned", "honoured",
+"answerable", "cites".
+
+**Why:** `refusal` is the fourth highest-lift word in the cluster and `ruling` the
+seventeenth. The register borrows finality from a domain that has procedures for
+producing it. A linter does not *rule*; it exits non-zero. A default is not a
+*carve-out* unless something granted it. The vocabulary makes an implementation
+detail sound adjudicated, and it stacks with entry 4 — the thing doing the ruling
+is usually an abstraction with no hands.
+
+**Fix:** name the mechanism and its exit condition.
+
+> was: *The guard refuses any caller without standing.*
+> now: *The guard returns 403 when the token has no `write` scope.*
+
+> was: *That is the carve-out the header check honors.*
+> now: *The header check skips one-word titles.*
+
+**Earned:** the system's own documented vocabulary. A policy engine whose API
+says `deny` denies; an RFC that says MUST is an obligation. Use the word the
+system uses, not the word that sounds like it.
+
+---
+
+## 45. Verification-provenance compound
+
+**Tell:** a hyphenated compound asserting how thoroughly something was checked —
+"byte-identical", "bit-identical", "byte-for-byte", "byte-exact",
+"mutation-checked", "mutation-verified", "mutation-tested", "live-verified",
+"cross-checked", "root-caused", "hand-verified", "re-derived", "re-verified",
+"re-measured", "re-checked", "re-confirmed".
+
+**Why:** eleven of the cluster's top hundred words are this shape, and it is the
+newest family in the register — it arrived with agents that report on their own
+work. The compound is a claim about method compressed to an adjective, which puts
+it past the place a reader would ask for the method. "Byte-identical" is
+checkable and often true; "mutation-checked" usually means a mutation run
+happened, not that this line survived one. The `re-` prefix is the same move in a
+verb: it claims a second pass without saying what the second pass did
+differently.
+
+**Fix:** state what was run and what came back.
+
+> was: *The rewrite is byte-identical and mutation-checked.*
+> now: *`diff` reports no change. The mutation run killed 14 of 15; the survivor
+> is in `parse_header`.*
+
+> was: *I re-derived the threshold.*
+> now: *I recomputed the threshold from the 46 chunks and got 0.20 again.*
+
+**Earned:** the compound is the precise term and the number is beside it.
+"Byte-identical" against a stated diff is exact and shorter than the alternative.
+A `re-` verb earns its prefix when the first pass is on the page and the second
+disagreed with it.
+
+---
+
+## 46. Privative coinage
+
+**Tell:** a thing named by what was not done to it — "ungated", "unguarded",
+"unwired", "uncapped", "unbuilt", "unparseable", "unverifiable", "unmeasured",
+"unresolvable", "unsatisfiable", "unrecognised", "vacuous", "inert".
+
+**Why:** the coinage sounds like a diagnosis and carries no measurement. "The
+hook is unwired" and "the hook is not in settings.json" say the same thing, but
+the first sounds like a category the writer already knew and the second can be
+checked. Several of these are not words outside this register, which is the tell:
+the writer minted an adjective rather than describe a state.
+
+**Fix:** say what is missing, and where.
+
+> was: *Three of the paths are unguarded.*
+> now: *Three of the paths have no length check before the index.*
+
+> was: *The assertion is vacuous.*
+> now: *The assertion passes on an empty list, which is what the test supplies.*
+
+**Earned:** the term is the field's ("unsatisfiable" in SAT, "unbuilt" of a build
+target), or the absence is the finding and the entry names it once before the
+detail.
+
+---
+
+## 47. Exhaustive negation
+
+**Tell:** an absolute quantifier standing in for the argument — "nothing in it
+does X", "nowhere else for it to be", "no path reaches", "never", "neither",
+"nobody". Often in a closer, often as the whole of the evidence.
+
+**Why:** `nobody`, `nowhere` and `nothing` are all in the cluster's top
+twenty-five. A universal negative is the strongest available claim and the most
+expensive to establish, so it is the cheapest to assert. "Nothing else could
+cause it" is a claim about the search, and the search is what the reader wants.
+Entry 2 covers the negation that sets up a reveal and entry 3 the unfalsifiable
+"nobody noticed"; this is the flat form, where the negation *is* the finding.
+
+**Fix:** state the scope you actually checked.
+
+> was: *Nothing in the fit varies with time.*
+> now: *The fit has one parameter per cluster and none per week.*
+
+> was: *There is nowhere else for the rise to be.*
+> now: *The weekly shares are counted after assignment, so a rise is in the
+> assignments.*
+
+**Earned:** the scope is bounded and named. "None of the 46 chunks exceeds 0.57%"
+is a universal over a set the reader can see. So is a negative that follows an
+exhaustive mechanism — "the enum has three members and the switch covers all
+three".
+
+---
+
 ## Quick self-check before shipping an edit
 
 1. Does any sentence exist to make a finding feel bigger than it is?
@@ -830,3 +993,6 @@ need one.
     paragraph by paragraph. Superlatives, rankings, simultaneity, scope words and
     the condition attached to a hedge all sit inside phrasings this register
     cuts, and the paragraph looks intact after they go.
+14. Does an adverb, a hyphenated compound or an absolute negative carry a claim
+    the sentence never shows? Flat certainty has tics of its own; entries 43 to
+    47 and `references/corpus.md`.

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -209,6 +209,32 @@ RULES: list[tuple[str, str, str]] = [
 
     # --- predicate-position hyphenation --------------------------------------
     ("hyphenation", r"\b(?:is|are|was|were|feels?|seems?)\s+(?:high-quality|cross-functional|data-driven|end-to-end|real-time|long-term|well-known|client-facing|decision-making|third-party|open-source)\b", "drop the hyphen after the noun"),
+
+    # --- flat certainty (entries 43-47) ---------------------------------------
+    # Corpus-derived; references/corpus.md. Each fires on a shape, never on a
+    # word alone: an adverb needs a verb to modify, a privative needs a copula.
+    ("flat-certainty", r"\b(?:plainly|quietly|outright|merely|provably|demonstrably|empirically|vacuously|adversarially|legitimately|structurally)\s+(?=\w)", "flat-certainty adverb — say what makes it true, or cut it"),
+    ("flat-certainty", r"\b(?:is|are|was|were|reads?|remains?|stays?)\s+(?:plainly|quietly|merely|genuinely|outright)\b", "adverb asserting the reader's reaction"),
+    ("flat-certainty", r"\b(?:deliberately|genuinely|honestly|routinely|silently|identically|precisely)\s+\w+(?:ed|ing|s)\b", "flat-certainty adverb on a verb — check it names a contrast the reader can check"),
+
+    ("juridical", r"\b(?:the\s+)?\w+\s+(?:refuses|declines|admits|rules|ratifies|sanctions|honou?rs|forbids|governs|decides|settles)\s+(?:the|a|an|any|no|that|it)\b", "juridical verb — name the mechanism and its exit condition"),
+    ("juridical", r"\b(?:a|the|its|this|that|one)\s+(?:refusal|ruling|verdict|precedent|carve-out|remedy|obligation|standing|grounds)\b", "juridical noun for a program state"),
+    ("juridical", r"\b(?:has|have|had|lacks?|without|no)\s+standing\b", "standing — say what the caller is missing"),
+
+    ("verification", r"\b(?:byte|bit)-(?:identical|exact|identity|for-byte)\b", "verification compound — put the diff or the number beside it"),
+    ("verification", r"\bbyte-for-byte\b", "verification compound — put the diff beside it"),
+    ("verification", r"\bmutation-(?:checked|verified|tested|proof)\b", "mutation compound — say what the run killed and what survived"),
+    ("verification", r"\b(?:live|hand|cross|independently|adversarially)-(?:verified|checked|tested|confirmed|audited)\b", "verification compound — state what was run and what came back"),
+    ("verification", r"\bre-(?:derived?|derives|deriving|verified|verifies|measured|measures|checked|confirmed|read|reads)\b", "re- prefix claims a second pass — say what the second pass did differently"),
+    ("verification", r"\broot-caused\b", "root-caused — name the cause"),
+
+    ("privative", r"\b(?:is|are|was|were|remains?|stays?|left|leaves?)\s+(?:ungated|unguarded|unwired|uncapped|unbuilt|unparseable|unverifiable|unmeasured|unresolvable|vacuous|inert)\b", "privative coinage — say what is missing, and where"),
+    ("privative", r"\b(?:an?|the|three|two|several|most|all)\s+(?:ungated|unguarded|unwired|uncapped|unbuilt|unmeasured|unverifiable)\s+\w+", "privative coinage naming a thing by what was not done to it"),
+
+    ("exhaustive", r"\bnothing\s+(?:in|else|about|here|there)\b[^.]{0,60}\b(?:does|is|can|could|would|varies|reaches|touches|explains)\b", "exhaustive negation — state the scope you checked"),
+    ("exhaustive", r"\bnowhere\s+(?:else|in|for|to)\b", "nowhere — a universal over an unnamed search"),
+    ("exhaustive", r"\b(?:no|not\s+a\s+single)\s+(?:path|caller|branch|test|case|line|file)\s+\w+s\b", "universal negative — bound it to a set the reader can see"),
+    ("exhaustive", r"\bcan\s+never\b|\bwill\s+never\b|\bnever\s+(?:fires|happens|reaches|runs|returns)\b", "never — an absolute is the most expensive claim and the cheapest to assert"),
 ]
 
 HTML_HEADING_RE = re.compile(r"<h([1-6])\b[^>]*>(.*?)</h\1>", re.S | re.I)
@@ -282,11 +308,42 @@ CATEGORY_ORDER = [
     "rtfm", "dev-cliche", "slop", "editorializing", "time-inflation",
     "copula", "participle", "false-range", "list-shape", "chatbot", "filler",
     "gap-fill", "diff-anchored", "subjectless", "hyphenation", "spec-ese",
+    "flat-certainty", "juridical", "verification", "privative", "exhaustive",
     "header", "typography", "cadence", "reuse", "density",
 ]
 
 # A one-line paragraph that is a line of dialogue is a line of dialogue.
 DIALOGUE_RE = re.compile("^[\"\u201c\u2018']|[\"\u201d'](\\s*,)?\\s*(\\w+\\s+)?(said|asked|replied|answered)\\b")
+
+# The 150 highest-lift words of the fastest-growing cluster in Louis Abraham's
+# load-bearing corpus of GitHub pull request descriptions (analysis.js generated
+# 2026-08-28: 461,121 descriptions, 85 whole weeks, the cluster 0.70% of the
+# first eight weeks and 39.5% of the last four). Used ONLY for the rate in
+# scan_density — never as a blocklist. Every word here is a word a person
+# writes, and load-bearing's own human-written README scores above this skill's
+# SKILL.md on it. references/corpus.md carries the method and the limits, and
+# how to regenerate this list from a fresh analysis.js.
+CORPUS_LEAD = frozenset("""
+admits alone argued armed arms asserted asserts asymmetry backstop bit-identical
+bites byte-for-byte byte-identical carried carries carrying carve-out ceiling
+cheap chokepoint cited cites contradicted contradicting decides declines defect
+defects degrades deliberate deliberately died disagree disagreed disagreement
+drains drifted eleven empirically escalates ever faithful falsified filed folded
+folds forever genuine genuinely half halves handed held holds honest honestly
+honoured indistinguishable inert judged landed lands legitimately lever
+load-bearing loses loud loudly machinery mattered measured merely minted mints
+mutation-checked mutation-tested mutation-verified never nine nobody nothing
+nowhere obligation opposite outright owed parked plainly pre-fix precedent
+precisely predates premise probed provably proven proves quietly re-derived
+re-derives re-measured re-read re-verified reaches reaped reds refusal refusals
+refused refuses refusing refuted remedy reproduces restated rests retires rides
+ruling rung says seam self-heals settles short-circuits sitting spellings stamped
+stamps standing stranded structurally survived survives surviving sweep symptom
+thirteen throwaway told ungated unguarded vacuous vacuously walked wedge wedged
+whoever whose worse
+""".split())
+
+CORPUS_WORD_RE = re.compile(r"[a-z0-9/_-]*[a-z][a-z0-9/_-]*")
 
 STOPWORDS = frozenset(
     "the a an and or but if of to in for on at by is are was were be been it its "
@@ -529,6 +586,20 @@ def scan_density(text: str) -> list[dict]:
                     "note": f"repeated phrases: {worst} — check each is the deliberate "
                             "repetition entry 27 protects and not a cadence",
                     "match": "phrase repetition"})
+
+    toks_all = CORPUS_WORD_RE.findall(body.lower())
+    if len(toks_all) >= 400:
+        lead = sum(1 for w in toks_all if w in CORPUS_LEAD)
+        per100 = lead / len(toks_all) * 100
+        if per100 >= 1.0:
+            out.append({"line": 0, "category": "density",
+                        "note": f"{lead} of {len(toks_all)} words are top-150 vocabulary of the "
+                                f"load-bearing corpus cluster ({per100:.2f} per 100; 46 chunks of human "
+                                "stdlib docstrings run 0.08 median, 0.32 at worst) — this locates "
+                                "the register, it does not "
+                                "detect a machine. Read entries 43 to 47, and do not cut these "
+                                "words on sight: references/corpus.md",
+                        "match": "corpus-register density"})
 
     lens = [len(s.split()) for s in sentences]
     if len(lens) > 20:

--- a/declauding/scripts/declaude_review.py
+++ b/declauding/scripts/declaude_review.py
@@ -38,8 +38,10 @@ REGISTER = Path(__file__).resolve().parent.parent / "references" / "register.md"
 # catalogue stays single-source; adding an entry there needs no edit here.
 # 26 is here because stage 1 detects triads deterministically but cannot judge
 # whether the content had three things, and a closer is where the padded ones
-# land.
-STRUCTURAL_ENTRIES = (1, 2, 3, 7, 9, 12, 13, 26)
+# land. 47 is here for the same reason: an exhaustive negative is earned when its
+# scope is named, and only reading the surrounding sentences says whether it is.
+# 43 to 46 are lexical and stage 1 reaches them.
+STRUCTURAL_ENTRIES = (1, 2, 3, 7, 9, 12, 13, 26, 47)
 
 SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
 TAG = re.compile(r"<[^>]+>")
@@ -62,11 +64,14 @@ def load_register(entries=STRUCTURAL_ENTRIES) -> str:
         return ""
     blocks, current, keep = [], [], False
     for line in REGISTER.read_text(encoding="utf-8").splitlines():
-        m = re.match(r"^## (\d+)\.", line)
-        if m:
+        # Any h1/h2 ends the current entry. Matching only numbered headings let
+        # the file's trailing "Quick self-check" section ride along with the
+        # last entry whenever that entry was selected.
+        if line.startswith(("## ", "# ")):
+            m = re.match(r"^## (\d+)\.", line)
             if keep and current:
                 blocks.append("\n".join(current).strip())
-            current, keep = [], int(m.group(1)) in entries
+            current, keep = [], bool(m) and int(m.group(1)) in entries
         if keep:
             current.append(line)
     if keep and current:

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -159,3 +159,31 @@ Omit it and the child idles awaiting input.
 Entries the caller does not itself hold are dropped, so a child never carries a grant its parent lacks.
 
 ## GitHub authorship in a sourced child
+
+## Entries 43-47 specimens
+
+The retry is provably safe and the flag was quietly dropped in 4.2.
+
+Three of the paths are unguarded, and the assertion is vacuous.
+
+The guard refuses any caller without standing. That is the carve-out the header
+check honors, and the linter's ruling stands.
+
+The rewrite is byte-identical and mutation-checked. I re-derived the threshold
+and cross-checked it against the previous run, then root-caused the difference.
+
+Nothing in the fit varies with time, and there is nowhere else for the rise to
+be. No caller reaches it, so the branch can never fire.
+
+The hook is unwired, the budget uncapped, and the header unparseable.
+
+Negatives that must stay silent — a bounded universal, a field term, a compound
+with its number beside it, and an adverb carrying a real contrast:
+
+None of the 46 chunks exceeds 0.57 per cent.
+
+The clause set is unresolvable only in the SAT sense, and the solver says so.
+
+`diff` reports no change; the mutation run killed 14 of 15.
+
+The handler logs the drop, where 4.1 dropped it silently.


### PR DESCRIPTION
Louis Abraham's [load-bearing](https://github.com/louisabraham/load-bearing) clusters 461,121 GitHub pull request descriptions by the words they are written with — ten clusters, hard assignment, KL k-means with no time parameter anywhere in the fit, so a cluster's weekly share is attribution after the fact and not a trend the model was free to draw.

One of the ten went from 0.70% of the first eight weeks of 2025 to 39.5% of the last four weeks of August 2026. Its highest-lift words:

```
load-bearing 39x   plainly 34x   quietly 30x   refusal 28x   survived 28x
re-derived 27x     halves 27x    asserted 25x  nobody 25x    genuinely 24x
deliberately 24x   premise 23x   refuses 23x   outright 23x  byte-identical 23x
```

That is not entry 20's slop vocabulary. There is no *delve*, no *tapestry*, no *robust*. It is the flat, concrete, verdict-shaped register this skill's Overcorrection section names as the target — and it is now the fastest-growing way of writing a pull request description there is. A pass that removes 42 staging tics and lands there has traded one detectable shape for another.

## What is in the diff

Five register entries, a fourth group in `references/register.md`:

| # | family | example |
|---|---|---|
| 43 | flat-certainty adverb | "provably safe", "quietly dropped" |
| 44 | juridical register | a linter that *rules*, a default that is a *carve-out* |
| 45 | verification-provenance compound | "byte-identical", "mutation-checked", the `re-` prefix |
| 46 | privative coinage | "unguarded", "unwired", "vacuous" |
| 47 | exhaustive negation | "nothing in it does X", "nowhere else for it to be" |

Each carries an earned column, because each family is one a careful writer uses correctly. None is a blocklist.

Also: five lint categories, a `corpus-register` density line, earned-exception rows in `SKILL.md`, specimens and four must-stay-silent negatives in `tests/sample-tics.md`, and `references/corpus.md` with the method, the figures and the limits.

Entry 47 goes into `STRUCTURAL_ENTRIES` for stage 2 — an exhaustive negative is earned when its scope is named, and only the surrounding sentences say whether it is. 43 to 46 are lexical and stage 1 reaches them.

## The density line is not a detector

| text | rate per 100 words of body prose |
|---|---|
| Python stdlib docstrings, 116k words, 46 chunks of 2,500 | median 0.08, p90 0.17, max 0.32 |
| `tests/sample-clean.md`, the human control | 0.34 |
| load-bearing's own `README.md`, written by a person | 1.51 |
| this skill's `SKILL.md` | 1.47 |
| this skill's `references/register.md` | 3.17 |

Louis Abraham's README scores above this skill's `SKILL.md`, on `nothing` x9, `carries` x3, `alone` x2, `never` x2, `half` x2. Quoted specimens are already excluded. He writes this way, and writes it well.

So the line locates a register and says nothing about the author, and its note says so. A reader who takes it for a detector will start cutting `nothing` and `measured` out of correct sentences, which is entry 23's failure mode with a number attached to it. The two highest rows in the table are this skill's own files.

## False-positive budget

`tests/sample-clean.md` still reports zero. On 115,920 words of Python stdlib docstrings the five new categories fire 18 times, 0.16 per 1,000 words, ten of them on `silently`. `is simply` was cut from the adverb rule for scoring two of those while not appearing in the corpus list at all; `unsatisfiable` was cut from the privative rule as a SAT term.

`sample-tics.md` now reports 136 candidates across 35 categories, `SKILL.md --skip-quoted` 12, `README.md --skip-quoted` 15. Three of the README's are `load-bearing`, which entry 19 lists as a metaphor and which here is a repository's name.

## Incidental fix

`load_register` in `declaude_review.py` ended an entry only at the next *numbered* heading, so selecting the file's last entry pulled the trailing "Quick self-check" section into the model prompt with it. Latent until 47 became the last entry. Any `#`/`##` heading now closes the block.

## Checks run

```
python3 scripts/validate_skills.py --all --warn-only     # declauding: ok
python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
python3 -m py_compile scripts/*.py
python3 scripts/declaude_review.py tests/sample-structure.md --emit-prompt
```

Every prose file in the diff was run through the linter and the remaining hits checked one at a time; the surviving ones are proper nouns, quoted specimens, and the two documents whose subject is the vocabulary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnXKT992QPbzSnQUCAGFDH)_