### PR TITLE
declauding 0.7.0: entries 48-52 from the llm-cliche-highlighter update

### DIFF
--- a/declauding/CHANGELOG.md
+++ b/declauding/CHANGELOG.md
@@ -2,6 +2,85 @@
 
 All notable changes to the `declauding` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.7.0] - 2026-08-29
+
+### Added
+
+- Entries 48 to 52, a fourth group: the confiding-essayist register. 48
+  performative candour ("let's be honest", sentence-initial "Honestly,", "you
+  don't have to take my word for it"), 49 stranded auxiliary reversal ("The tool
+  died; the data didn't."), 50 retroactive significance ("that's why X
+  mattered"), 51 totalizing designation ("that's the whole point", "the only
+  release notes I trust"), 52 obituary headline ("X is dead", "long live X").
+  Each has an earned column.
+- Lint categories `candour`, `reversal`, `retroactive`, `totalizing`,
+  `obituary`, and an obituary check on header text. "X is dead" is left alone
+  inline — a dead process is a dead process — and flagged only in a header.
+- `_echo_runs`, entry 26's third shape: two consecutive sentences sharing a
+  five-word run that covers at least half the shorter one. Anaphora keys on the
+  opening words and the triad regex on the commas; neither reaches *A shopping
+  cart is an object in the system. A chat room is an object in the system.*
+- `_question_runs`, entry 10 without the fragment answer: two or more questions
+  in a row where at least one after the first is clipped.
+- Entries 50 to 52 added to `STRUCTURAL_ENTRIES` in `declaude_review.py`. A
+  retroactive grade is only visible against the passage it grades, a totalizing
+  claim is earned when the set is named nearby, and an obituary headline is a
+  header. 48 and 49 are lexical and stage 1 reaches them.
+- Specimens for all five entries plus the two detectors in
+  `tests/sample-tics.md`, with four negatives that must stay silent.
+
+### Changed
+
+- Entry 3 gained the staged variants of its gesture: "here's the twist / catch /
+  kicker / rub", "that's the part", "my favourite part of".
+- Entry 10 gained the stacked-question run.
+- Entry 18 gained bare sentence-initial "Turns out"; the rule only reached "it
+  turns out".
+- Entry 19 gained "batteries included", "zero config" and "small enough to fit
+  in your head".
+- Entry 26 is now three shapes rather than two.
+- `is the whole point` moved off the `aphorism` rule; entry 51 owns it.
+
+### Provenance
+
+Simon Willison's
+[llm-cliche-highlighter](https://github.com/simonw/tools/blob/main/llm-cliche-highlighter.html)
+added fifteen patterns and three structural detectors on 2026-08-27, in
+[simonw/tools#322](https://github.com/simonw/tools/pull/322) and
+[#323](https://github.com/simonw/tools/pull/323). Eight of the fifteen were
+already covered here in some form and extended existing entries. Five had no
+entry and became 48 to 52. Two of the three detectors are ported; the third,
+his colon-into-a-triple, is already the comma-list half of entry 26.
+
+Several ported regexes are narrower than the source, which is tuned for essays
+rather than for technical prose. His `x-is-dead` fires on any "X is dead"; here
+it fires in headers only. His echo detector needs one shared four-gram; here it
+needs five words covering half the shorter sentence. His question run needs two
+questions; here one of them after the first must be clipped, because two full
+questions in sequence is how a person changes subject.
+
+### False-positive budget
+
+`tests/sample-clean.md` still reports zero. It did not on the first cut: the
+question-run rule fired on *So, what's next? Is this a project that starts and
+ends with DeepSeek v4 Flash?*, which is antirez changing subject, and the
+clipped-question condition came out of that.
+
+On 180,929 words of Python stdlib docstrings the five new categories fire 4
+times (0.022 per 1,000 words), all four on entry 49 and all four the ordinary
+ellipsis the entry names as earned. `_echo_runs` fires 36 times (0.199 per
+1,000), between the existing anaphora detector at 0.077 and fragment cadence at
+0.298. The first cut of that detector, keyed on a shared five-gram alone, fired
+91 times on phrases like "is the same as using" inside sentences that were
+otherwise unalike; requiring the run to cover half the shorter sentence is what
+took it to 36. `_question_runs` fires 0 times.
+
+`tests/sample-tics.md` now reports 167 candidates across 42 categories,
+`SKILL.md --skip-quoted` 13 and `README.md --skip-quoted` 18. The extra hit on
+`SKILL.md` is the `reuse` detector counting a fifth parallel table label; one of
+the eighteen on the README is entry 49 on "Symmetry and antithesis are not",
+which is the earned ellipsis.
+
 ## [0.6.0] - 2026-08-28
 
 ### Other

--- a/declauding/README.md
+++ b/declauding/README.md
@@ -38,7 +38,7 @@ and nothing else.
 
 ## Tics it catches
 
-Forty-two entries. All of them except part of the 24-to-36 block are grouped by
+Fifty-two entries. All of them except part of the 24-to-36 block are grouped by
 mechanism rather than by phrase, since phrase blocklists miss the next
 paraphrase. The ones that show up in nearly every draft:
 
@@ -88,6 +88,20 @@ Entry 41 is the overcorrection from entry 7 and is written up as one. A verdict
 header rewritten into an abstraction passes entry 7's regex and still fails entry
 7's own test.
 
+Entries 43 to 47 are the flat, verdict-shaped register a clean pass lands in —
+the one this skill produces. `references/corpus.md` carries the measurement.
+
+Entries 48 to 52 are the confiding-essayist voice, where the staging is aimed at
+the reader's trust instead of at a finding:
+
+| Tic | Example |
+|---|---|
+| Announced candour | *Let's be honest: I won't pretend the first run was clean.* |
+| Stranded auxiliary | *The tool died; the data didn't.* |
+| Retroactive significance | *That's why being able to open the environment mattered.* |
+| Totalizing designation | *That's the whole point of the format.* / *the only release notes I trust* |
+| Obituary headline | *Peer code review is dead* |
+
 Each entry carries the surface tell, why it is a tic, the fix, and a
 before-and-after. The first 23 come from a real published draft; the second block
 keeps the Wikipedia specimens.
@@ -107,7 +121,8 @@ python3 scripts/declaude_lint.py DOC.md --skip-quoted # ignore quoted specimens
 
 Stdlib only. It flags the lexical tells with line numbers and categories, plus
 header shape, Title Case headings, one-line-paragraph beats, fragment runs,
-forced triads in both their comma-list and anaphora forms, inline-header bullets
+forced triads in all three of their comma-list, anaphora and echo forms, runs of
+stacked rhetorical questions, inline-header bullets
 whose label restates the item, per-instance em-dash drum rolls, em-dash density,
 repeated sentence openings and phrases, curly-quote and emoji counts, and
 sentence-length monotony.
@@ -153,27 +168,29 @@ as a pre-commit hook.
 ## False positives
 
 `tests/sample-clean.md` is human-written prose and must lint to zero.
-`tests/sample-tics.md` is a corpus of real specimens and currently reports 136
-candidates across 35 categories.
+`tests/sample-tics.md` is a corpus of real specimens and currently reports 167
+candidates across 42 categories.
 
 ```sh
-python3 scripts/declaude_lint.py tests/sample-tics.md    # 136 candidates
+python3 scripts/declaude_lint.py tests/sample-tics.md    # 167 candidates
 python3 scripts/declaude_lint.py tests/sample-clean.md   # 0
-python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 12, all checked
-python3 scripts/declaude_lint.py README.md --skip-quoted # 15, all checked
+python3 scripts/declaude_lint.py SKILL.md --skip-quoted  # 13, all checked
+python3 scripts/declaude_lint.py README.md --skip-quoted # 18, all checked
 python3 scripts/declaude_lint.py tests/sample-structure.html   # 10, HTML path
 python3 scripts/declaude_review.py tests/sample-structure.md --slots
 ```
 
-One of the twelve on `SKILL.md` is the `reuse` detector catching four parallel
+One of the thirteen on `SKILL.md` is the `reuse` detector catching five parallel
 table labels ("Staging shapes, entries…", "Encyclopedic shapes, entries…",
-"Reference-prose shapes, entries…", "Flat-certainty shapes, entries…"). Four
-labels in a table series is the deliberate repetition entry 27 protects, so it
-stays.
+"Reference-prose shapes, entries…", "Flat-certainty shapes, entries…",
+"Confiding-essayist shapes, entries…"). Five labels in a table series is the
+deliberate repetition entry 27 protects, so it stays.
 
-Three of the fifteen on this README are `load-bearing`, which entry 19 does list
+Three of the eighteen on this README are `load-bearing`, which entry 19 does list
 as a metaphor and which here is the name of a repository. A proper name is the
-carve-out `SKILL.md` states and `--skip-quoted` cannot see.
+carve-out `SKILL.md` states and `--skip-quoted` cannot see. One is entry 49
+firing on "Symmetry and antithesis are not" in the Overcorrection list, which is
+the ordinary ellipsis the entry names as earned.
 
 Several rules are deliberately tuned down to hold that zero, so the linter misses
 some real coy headers and some real inline-header bullets. A linter that fires on
@@ -267,6 +284,19 @@ skill aims at. The five entries and the `corpus-register` line came out of that,
 along with the measurement in
 [`references/corpus.md`](references/corpus.md) of what the rate can and cannot
 claim.
+
+Entries 48 to 52 came from another tool rather than another corpus. Simon
+Willison's
+[llm-cliche-highlighter](https://github.com/simonw/tools/blob/main/llm-cliche-highlighter.html)
+highlights LLM cliches in pasted text, and its 2026-08-27 update added fifteen
+patterns and three structural detectors. Eight of the fifteen were already here
+in some form and extended existing entries — "here's the twist" and "that's the
+part" under entry 3, bare "Turns out" under 18, "batteries included" and "zero
+config" under 19, stacked questions under 10, the echo run under 26. The other
+five had no entry, and the shapes are the ones an essay reaches for when it is
+addressing the reader directly. Several of the ported regexes are narrower here
+than in the source, which is tuned for essays rather than for technical prose;
+the register entries say which, and why.
 
 Entries 39 to 42 came from a `create_session` reference artifact (2026-08-23)
 that had already been through a 0.4.0 pass and reported clean. Two of its section

--- a/declauding/SKILL.md
+++ b/declauding/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: declauding
-description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging), and the flat-certainty patterns of the register the pass itself produces (bare adverbs, juridical vocabulary, verification compounds, privative coinages, exhaustive negation) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
+description: Removes LLM prose tics from drafts — staged reveals, "it's not X, it's Y", significance tags, abstraction agency, coy headers, fragment cadence, the flatter slop patterns (copula avoidance, participle tails, forced triads, chatbot residue, filler and hedging), the flat-certainty patterns the pass itself produces (bare adverbs, juridical vocabulary, verification compounds, privative coinages, exhaustive negation), and the confiding-essayist patterns (announced honesty, stranded auxiliaries, retroactive significance, totalizing claims, obituary headlines) — and returns plain human technical prose. Use when text needs editing for register, when someone says "de-claude", "de-slop", "humanize this", "this reads like AI", "make this sound human", "remove the tics/claudisms", or asks for a voice/register pass on a post, README, report, PR description or essay. Also use before publishing any draft Claude wrote. Produces either clean prose or an annotated HTML diff showing every edit with its original and reason.
 metadata:
-  version: 0.6.0
+  version: 0.7.0
 ---
 
 # Declauding
@@ -69,6 +69,13 @@ performing having settled it?*
 The response to that is not to put the staging back. It is to check that an
 adverb, a hyphenated compound or an absolute negative is carrying evidence
 rather than standing in for it.
+
+Entries 48 to 52 are a fourth family and come from outside: Simon Willison's
+[llm-cliche-highlighter](https://github.com/simonw/tools/blob/main/llm-cliche-highlighter.html),
+updated 2026-08-27. They are the confiding-essayist voice — announced honesty, a
+reversal landed on a bare auxiliary, a grade applied to a passage the reader has
+already read, a part claimed as a whole, an obituary headline. Staging again, but
+aimed at the reader's trust rather than at a finding.
 
 ## The author's own writing outranks this skill
 
@@ -161,7 +168,9 @@ thorough one.
 **3. Sentence pass.** For every sentence, in order: stating or staging? Load
 `references/register.md` for the catalogue of tells and their fixes. On a draft
 this skill or another model already cleaned, read entries 43 to 47 first — a
-second pass over already-flat prose is where they live.
+second pass over already-flat prose is where they live. On a personal essay, a
+launch post, or anything addressed to the reader as a confidant, read 48 to 52
+first instead.
 
 **4. Structure pass.** Headers (are they labels or verdicts?), paragraph breaks
 (is an isolated line a real pivot or a drum roll?), fragment runs, rhetorical
@@ -287,6 +296,16 @@ Flat-certainty shapes, entries 43 to 47:
 | Verification compound (45) | The method is compressed into an adjective and never shown | The number is beside it: "byte-identical" next to the diff, "mutation-checked" next to 14 of 15 |
 | Privative coinage (46) | A minted adjective replaces the measurement | The field's term ("unsatisfiable"), or the absence is the finding and stated once |
 | Exhaustive negation (47) | A universal negative stands in for the search | The scope is bounded and named: "none of the 46 chunks exceeds 0.57%" |
+
+Confiding-essayist shapes, entries 48 to 52:
+
+| Shape | Banned when | Earned when |
+|---|---|---|
+| Announced candour (48) | Sincerity claimed for a sentence that could have carried it | Reported speech, or one "to be clear" correcting a misreading the draft caused |
+| Stranded auxiliary (49) | The verb is elided so the clause lands as a beat | Both halves are measured — "reads passed on all 12 shards, writes on none" |
+| Retroactive significance (50) | It grades a passage the reader has already read | A "which is why" introducing a consequence the reader has not seen |
+| Totalizing designation (51) | A part is claimed as the whole, or a superlative ranks an unnamed set | A real count of one over a named set — "the only one of the six runs that finished" |
+| Obituary headline (52) | A verdict borrowed from a form built to overstate | The phrase belongs to something quoted or named |
 
 **Modifiers inside a watched phrase carry content.** "The single most important
 new build" ranks that item against every other item; "the important new build"

--- a/declauding/references/register.md
+++ b/declauding/references/register.md
@@ -46,7 +46,10 @@ negation does work.
 **Tell:** "the real X", "the actual question", "the part that matters", "the part
 that transfers", "the useful question", "the detail that makes the point", "the
 most interesting number", "the one thing nobody said", "here's the thing", "and
-that's the interesting part", "and it has a name here".
+that's the interesting part", "and it has a name here". Also the staged variants
+of the same gesture: "here's the twist / the catch / the kicker / the rub",
+"that's the part", "the part that makes me trust the rest", "my favourite part
+of".
 
 **Why:** it ranks your own sentences for the reader instead of writing a sentence
 worth ranking first. The reader decides what is interesting.
@@ -180,6 +183,13 @@ walking the reader through a discovery.
 
 **Fix:** one declarative. *"fit-17g fails mostly by not finishing."*
 
+**Two in a row is the same tic amplified.** *Do I know how it works? Where it
+breaks? Which corners it cut?* — the second and third are fragments riding on
+the first, and none of them is asked of anyone. The linter reports runs of
+consecutive questions separately from the single standalone one, because a run
+does not need the fragment answer to be the tic. An interview transcript and a
+FAQ are the earned cases.
+
 ---
 
 ## 11. Straw-man knockdown
@@ -286,7 +296,8 @@ procedure.
 
 ## 18. RTFM as revelation
 
-**Tell:** "It turns out that", "I finally discovered", "Hidden in the API",
+**Tell:** "It turns out that", bare sentence-initial "Turns out", "I finally
+discovered", "Hidden in the API",
 "Buried in the docs" — followed by standard documented behaviour.
 
 **Fix:** if the finding is that you missed something obvious, say that.
@@ -297,7 +308,8 @@ procedure.
 
 **Tell:** footgun, shot itself in the foot, almost killed it, fell apart, rabbit
 hole, yak shaving, belt-and-suspenders, load-bearing (as metaphor), moving the
-needle, first-class citizen, under the hood, magic, just works, sane defaults.
+needle, first-class citizen, under the hood, magic, just works, sane defaults,
+batteries included, zero config, small enough to fit in your head.
 
 **Why:** the writer reached for the easy phrase instead of the accurate one. The
 accurate phrase is usually shorter.
@@ -421,14 +433,18 @@ three. The count is chosen by rhythm rather than by the content.
 **Earned when** there are genuinely three things, or a superlative or ranking
 rides on the phrasing.
 
-**Two shapes, one tic.** The comma list ("keynote sessions, panel discussions,
+**Three shapes, one tic.** The comma list ("keynote sessions, panel discussions,
 and networking opportunities") is the obvious one. The anaphora form carries the
 parallelism in the opening words instead: *It was a message. It was a permission
 slip. It was an out.* across sentences, or *something to steer toward, something
-to be measured against, something to fear* inside one. The linter catches both,
-and the document-level `opening repetition` count is the same tic spread thin
-enough that no single passage looks wrong. Entry 27 read in the right direction
-is the guard: repetition that is the point stays.
+to be measured against, something to fear* inside one. The echo form keys on
+neither the commas nor the opening, but on a skeleton reused whole: *A shopping
+cart is an object in the system. A chat room is an object in the system.* Two
+sentences sharing four or more words in sequence are a template being filled,
+and a reader who has read the first has read the second. The linter catches all
+three, and the document-level `opening repetition` count is the same tic spread
+thin enough that no single passage looks wrong. Entry 27 read in the right
+direction is the guard: repetition that is the point stays.
 
 ---
 
@@ -972,6 +988,124 @@ three".
 
 ---
 
+## 48. Performative candour
+
+**Tell:** "I'll be honest", "let's be honest", "to be clear", "I won't pretend",
+sentence-initial "Honestly," / "Look," / "Frankly,", and the invitation that
+follows them — "you don't have to take my word for it".
+
+**Why:** sincerity announced instead of shown. The reader had no reason to
+suspect the preceding sentences, so the announcement marks the next one as the
+true one and demotes the rest. "Don't take my word for it" is the same move
+aimed at evidence: it offers a check and hands over nothing to check with.
+
+**Fix:** delete the announcement and keep the sentence. Where the invitation to
+verify is real, link the thing.
+
+> was: *Let's be honest: the benchmark does not measure what the README claims.
+> And you don't have to take my word for it.*
+> now: *The benchmark times decode only. The README claims end to end. The
+> harness is `bench/run.py`, line 40.*
+
+**Earned:** reported speech, where a person said it. Also "to be clear"
+introducing a correction of a misreading the draft itself caused, once.
+
+---
+
+## 49. Stranded auxiliary reversal
+
+**Tell:** a clause that ends on a bare auxiliary carrying the reversal — "The
+tool died; the data didn't.", "Reading mostly passed. Writing didn't.", "Maybe
+it wouldn't have."
+
+**Why:** the auxiliary does the work and the verb is elided, so the clause lands
+as a beat rather than as a fact. Entry 2 stages a reveal by negating first; this
+stages one by negating last, with the content left out of the half that is
+supposed to carry it.
+
+**Fix:** say what the second clause is claiming.
+
+> was: *The tool died; the data didn't.*
+> now: *The tool stopped writing checkpoints on 12 August. The rows already
+> written are still in the bucket.*
+
+**Earned:** ordinary ellipsis, where the elided verb is the one just used and
+the contrast rides in the same breath rather than in a beat of its own —
+"Digression and mild informality are human. Symmetry and antithesis are not."
+Also where both halves are measured and the reader can see both numbers: "reads
+passed on all 12 shards, writes on none". The tic is the reversal given its own
+sentence as a drop, with the verb withheld.
+
+---
+
+## 50. Retroactive significance
+
+**Tell:** "that's why X mattered", "this is why keeping every transcript
+counted", "which is why the open environment mattered".
+
+**Why:** entry 3 tells the reader which sentence matters before they read it;
+this tells them which one did. The retroactive form is the worse of the two,
+because the passage being graded has already had its chance with the reader and
+the grade is an admission it did not take.
+
+**Fix:** cut it. If the earlier passage did not carry the point, the earlier
+passage is the problem.
+
+> was: *That's why being able to open the environment mattered.*
+> now: *Opening the environment recovered 40 GB of checkpoints. Without it the
+> run restarts at step 0.*
+
+**Earned:** a "which is why" that introduces a consequence the reader has not
+seen yet. New information, not a grade on old information.
+
+---
+
+## 51. Totalizing designation
+
+**Tell:** "that's the whole point", "the entire business model is X", "here's
+the whole trick", "the only marketing I trust", "the only thing that matters".
+
+**Why:** entry 3 with the scope widened to everything. "The whole point" claims
+the rest of the paragraph is decoration. "The only X I trust" ranks a field
+whose other members are never named, so there is nothing to disagree with.
+Neither can be checked, and both ask the reader to accept a total where a part
+was demonstrated.
+
+**Fix:** state the part, and let it be a part.
+
+> was: *That's the whole point of the format.*
+> now: *The format keeps the offsets in the header, so a reader can seek without
+> decompressing.*
+
+> was: *Changelogs are the only release notes I trust.*
+> now: *I check release notes against the diff, which per-entry links make
+> possible.*
+
+**Earned:** a real count of one over a named set — "the only one of the six runs
+that finished".
+
+---
+
+## 52. Obituary headline
+
+**Tell:** "X is dead", "long live X", "the death of X", "RIP X" — usually a
+header or a first line.
+
+**Why:** a headline built to be argued with rather than read. It states a
+verdict, which entry 7 already bars in headers, and it borrows a form whose
+function is to overstate. The body then spends its opening paragraph walking the
+claim back, which is the tell that the header was never the finding.
+
+**Fix:** name what changed.
+
+> was: *Peer code review is dead*
+> now: *Three of our four teams dropped the second-approval requirement in July*
+
+**Earned:** the phrase belongs to something quoted or named — a post you are
+citing, a product whose vendor announced end of life.
+
+---
+
 ## Quick self-check before shipping an edit
 
 1. Does any sentence exist to make a finding feel bigger than it is?
@@ -996,3 +1130,6 @@ three".
 14. Does an adverb, a hyphenated compound or an absolute negative carry a claim
     the sentence never shows? Flat certainty has tics of its own; entries 43 to
     47 and `references/corpus.md`.
+15. Does any sentence announce its own honesty, grade an earlier passage, claim
+    a whole where a part was shown, or land a reversal on a bare auxiliary?
+    Entries 48 to 52.

--- a/declauding/scripts/declaude_lint.py
+++ b/declauding/scripts/declaude_lint.py
@@ -32,6 +32,9 @@ RULES: list[tuple[str, str, str]] = [
     ("significance", r"\bthe\s+(?:part|thing|bit|piece|detail)\s+(?:that|which)\b", "the part that — designation; the reader decides what matters"),
     ("significance", r"\bthe\s+(?:one|leg|row|line|number|question)\s+that\s+(?:matters|counts|transfers|makes the point|does the work|answers|explains)\b", "the X that matters"),
     ("significance", r"\b(?:here'?s|this is)\s+(?:the thing|where it gets interesting|what)\b", "here's the thing"),
+    ("significance", r"\bhere(?:'?s|\s+is)\s+(?:the|a|my|one)\s+(?:twist|catch|kicker|rub|surprising|interesting|best|worst)\b", "staged reveal — 'here's the twist/catch/kicker'"),
+    ("significance", r"\b(?:that|this|it)(?:'?s|\s+(?:is|was))\s+the\s+part\b", "that's the part — the reader decides which part"),
+    ("significance", r"\bmy\s+favou?rite\s+part\s+of\b", "gesturing at a favoured detail instead of stating it"),
     ("significance", r"\band\s+(?:that'?s|it has)\s+(?:the interesting part|a name here)\b", "manufactured reveal"),
     ("significance", r"\bthe\s+(?:one|only)\s+thing\s+(?:nobody|no one)\b", "the one thing nobody"),
     ("significance", r"\b(?:most|more)\s+(?:interesting|telling|revealing|surprising)\s+(?:part|thing|number|finding)\b", "significance tag"),
@@ -98,9 +101,11 @@ RULES: list[tuple[str, str, str]] = [
 
     # --- RTFM ----------------------------------------------------------------
     ("rtfm", r"\b(?:it turns out|I finally (?:discovered|realized|found)|hidden in the|buried in the (?:docs|api))\b", "RTFM as revelation"),
+    ("rtfm", r"(?:^|[.!?\u2013\u2014]\s+)Turns\s+out\b", "bare 'Turns out' opener — a casual reveal bolted to a tidy conclusion"),
 
     # --- dev cliché ----------------------------------------------------------
-    ("dev-cliche", r"\b(?:footgun|shot itself in the foot|rabbit hole|yak[- ]shav\w*|belt[- ]and[- ]suspenders|moving the needle|first[- ]class citizen|under the hood|just works|sane defaults|almost killed it)\b", "generic developer vocabulary"),
+    ("dev-cliche", r"\b(?:footgun|shot itself in the foot|rabbit hole|yak[- ]shav\w*|belt[- ]and[- ]suspenders|moving the needle|first[- ]class citizen|under the hood|just works|sane defaults|almost killed it|batteries[- ]included|zero[- ]config(?:uration)?)\b", "generic developer vocabulary"),
+    ("dev-cliche", r"\b(?:hold|holds|held|fit|fits)\s+(?:it\s+)?in\s+your\s+head\b", "dev-blog boilerplate for simplicity — say how big it is"),
 
     # --- slop ----------------------------------------------------------------
     ("slop", r"\b(?:delve|tapestry|testament to|navigate the complexities|in today'?s fast[- ]paced|realm of|robust|seamless|leverage|utilize|crucial|pivotal|myriad|plethora|elevate|unlock the|harness the|embark|dive deep|at the end of the day)\b", "slop vocabulary"),
@@ -114,7 +119,7 @@ RULES: list[tuple[str, str, str]] = [
     # --- aphoristic closer ---------------------------------------------------
     ("aphorism", r"\bthe\s+kind\s+of\s+\w+\s+that\b[^.]{0,60}\band\s+is\s+not\b", "X that looks like Y and is not"),
     ("aphorism", r"\bthe\s+\w+\s+that\s+looks\s+like\s+\w+", "X that looks like Y"),
-    ("aphorism", r"\b(?:by\s+a\s+wide\s+margin|was\s+the\s+move|is\s+the\s+whole\s+(?:point|bug|story))\b", "quotable closer"),
+    ("aphorism", r"\b(?:by\s+a\s+wide\s+margin|was\s+the\s+move)\b", "quotable closer"),
     ("aphorism", r"\bthe\s+(?:entire|whole)\s+\w+\s+of\s+the\s+thing\b", "quotable closer"),
 
     # --- staging (more) ------------------------------------------------------
@@ -235,6 +240,31 @@ RULES: list[tuple[str, str, str]] = [
     ("exhaustive", r"\bnowhere\s+(?:else|in|for|to)\b", "nowhere — a universal over an unnamed search"),
     ("exhaustive", r"\b(?:no|not\s+a\s+single)\s+(?:path|caller|branch|test|case|line|file)\s+\w+s\b", "universal negative — bound it to a set the reader can see"),
     ("exhaustive", r"\bcan\s+never\b|\bwill\s+never\b|\bnever\s+(?:fires|happens|reaches|runs|returns)\b", "never — an absolute is the most expensive claim and the cheapest to assert"),
+
+    # ===== entries 48-52: the confiding-essayist register ====================
+    # Ported from Simon Willison's llm-cliche-highlighter, 2026-08-27. The
+    # shapes there are tuned for essays; several are narrowed here to keep the
+    # false-positive budget on technical prose. references/register.md says
+    # which, and why.
+
+    ("candour", r"\bI\s+(?:will\s+not|won'?t)\s+pretend\b", "announced sincerity — show it instead"),
+    ("candour", r"\b(?:I'?ll|let'?s|to)\s+be\s+(?:honest|clear|blunt|real)\b", "announced sincerity — the sentence after this is the one you meant to write"),
+    ("candour", r"(?:^|[.!?\u2013\u2014]\s+)(?:honestly|look|truthfully|frankly)\s*,", "confiding opener — delete it and keep the sentence"),
+    ("candour", r"\b(?:you\s+)?(?:do\s+not|don'?t)\s+(?:have\s+to\s+)?take\s+my\s+word\s+for\b", "invitation to verify with nothing to verify against — link the thing"),
+
+    ("reversal", r"[;:,]\s+[^.;:!?\n]{2,50}\s(?:did|does|do|was|were|is|are|has|have|had|can|could|would|will)(?:n'?t|\s+not)\s*[.;]", "clause landing on a bare auxiliary — say what the second half claims"),
+    ("reversal", r"[.!?]\s+[A-Z][^.;:!?\n]{2,40}\s(?:did|does|was|were|is|are|has|have|had|can|could|would|will)(?:n'?t|\s+not)\s*\.", "sentence landing on a bare auxiliary — the verb is elided and the beat is doing the work"),
+    ("reversal", r"\b(?:maybe|perhaps)\s+\w+[^.!?\n]{0,40}\s(?:would|could|might|should|did|had|was|is)(?:n'?t)\s+(?:have\s*)?\.", "speculative reversal on a stranded auxiliary"),
+
+    ("retroactive", r"\b(?:that|this|which)(?:'?s|\s+(?:is|was))\s+why\b[^.!?\n]{0,80}?\b(?:matter(?:s|ed)|count(?:s|ed))\b", "grading a passage the reader has already read"),
+
+    ("totalizing", r"(?<!here)(?:\b(?:is|was|are|were)|'?s)\s+the\s+(?:whole|entire)\s+(?:point|game|thing|trick|pitch|idea|story|premise|argument|bug|business\s+model)\b", "the whole point — claims a total where a part was shown"),
+    ("totalizing", r"\bthe\s+(?:whole|entire)\s+(?:point|game|trick|pitch|premise|argument|business\s+model)\s+(?:is|was)\b", "the whole point is — the flipped twin"),
+    ("totalizing", r"\bhere(?:'?s|\s+is)\s+the\s+(?:whole|entire)\s+\w+", "here's the whole X — a total announced, not shown"),
+    ("totalizing", r"\bthe\s+only\s+[\w'-]+(?:\s+[\w'-]+){0,2}?\s+(?:I|you|we|they)\s+(?:trust|need|needs|want|wants|use|uses|care|believe)\b", "narrowing superlative over an unnamed set"),
+    ("totalizing", r"\bthe\s+only\s+[\w'-]+\s+that\s+(?:matters|counts|works|survives)\b", "narrowing superlative — name the set or drop the only"),
+
+    ("obituary", r"\blong\s+live\s+\w+", "obituary headline — name what changed"),
 ]
 
 HTML_HEADING_RE = re.compile(r"<h([1-6])\b[^>]*>(.*?)</h\1>", re.S | re.I)
@@ -292,6 +322,10 @@ NOMINAL_HEADER_RE = re.compile(
     r"|\w+\s+\w+" + _NOM + r"\s*$)", re.I)
 GERUND_HEADER_RE = re.compile(r"^\w+ing\s+(?:a|an|the)\b", re.I)
 
+# Entry 52. Inline "X is dead" is left alone — a dead process is a dead process.
+# In a header the phrase is only ever the obituary shape.
+OBITUARY_HEADER_RE = re.compile(r"\b(?:is|are)\s+dead\b|\blong\s+live\b|^(?:the\s+)?death\s+of\b", re.I)
+
 TITLE_CASE_SKIP = {
     "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "into",
     "nor", "of", "on", "onto", "or", "over", "the", "to", "up", "via", "with",
@@ -309,6 +343,7 @@ CATEGORY_ORDER = [
     "copula", "participle", "false-range", "list-shape", "chatbot", "filler",
     "gap-fill", "diff-anchored", "subjectless", "hyphenation", "spec-ese",
     "flat-certainty", "juridical", "verification", "privative", "exhaustive",
+    "candour", "reversal", "retroactive", "totalizing", "obituary",
     "header", "typography", "cadence", "reuse", "density",
 ]
 
@@ -391,7 +426,11 @@ def scan_lines(text: str) -> list[dict]:
                 hits.append({"line": i, "category": "header",
                              "note": "comma-clause header — no real person puts sentence clauses in a headline",
                              "match": title[:90]})
-            if COY_HEADER_RE.match(title):
+            if OBITUARY_HEADER_RE.search(title):
+                hits.append({"line": i, "category": "obituary",
+                             "note": "obituary headline — a verdict in a form built to overstate; name what changed",
+                             "match": title[:90]})
+            elif COY_HEADER_RE.match(title):
                 hits.append({"line": i, "category": "header",
                              "note": "coy header — could top three different sections; name the content",
                              "match": title[:90]})
@@ -427,6 +466,8 @@ def scan_lines(text: str) -> list[dict]:
 
     hits.extend(_fragment_runs(text))
     hits.extend(_anaphora_runs(text))
+    hits.extend(_echo_runs(text))
+    hits.extend(_question_runs(text))
     return hits
 
 
@@ -464,6 +505,101 @@ def _anaphora_runs(text: str) -> list[dict]:
                             "match": f"{keys[i]!r} x3: {units[i][:60]}",
                         })
                         break
+        line_no += n + 1
+    return out
+
+
+ECHO_WORD = re.compile(r"[a-z0-9\u2019'-]+")
+
+
+def _echo_runs(text: str, min_gram: int = 5, min_share: float = 0.5) -> list[dict]:
+    """Consecutive sentences built on the same skeleton.
+
+    The third shape of entry 26. Anaphora keys on the opening words and the
+    triad regex on the commas; this keys on a run of words reused anywhere in
+    the sentence — `A shopping cart is an object in the system. A chat room is
+    an object in the system.` A reader who has read the first has read the
+    second.
+
+    Two thresholds, both needed. `min_gram` is 5 rather than the 4 the source
+    tool uses, and the run must also cover `min_share` of the shorter sentence.
+    A shared five-word run alone is an idiom, not a template: on 181,000 words
+    of Python stdlib docstrings the gram test alone fires 91 times, on phrases
+    like "is the same as using" inside sentences that are otherwise unalike.
+    Requiring half the shorter sentence takes that to single figures and still
+    catches the filled template, where the shared run is most of both.
+    """
+    out = []
+    line_no = 1
+
+    def longest_run(a: list[str], b: list[str]) -> tuple[int, int]:
+        """Longest common contiguous run, and where it starts in `a`."""
+        best, best_i = 0, 0
+        prev = [0] * (len(b) + 1)
+        for i in range(1, len(a) + 1):
+            cur = [0] * (len(b) + 1)
+            for j in range(1, len(b) + 1):
+                if a[i - 1] == b[j - 1]:
+                    cur[j] = prev[j - 1] + 1
+                    if cur[j] > best:
+                        best, best_i = cur[j], i - cur[j]
+            prev = cur
+        return best, best_i
+
+    for para in re.split(r"\n\s*\n", text):
+        n = para.count("\n") + 1
+        if not para.strip().startswith(("#", "-", "*", ">", "|", "`")):
+            sents = [s.strip() for s in re.split(r"(?<=[.!?])\s+", para.strip()) if s.strip()]
+            words = [ECHO_WORD.findall(s.lower()) for s in sents]
+            for i in range(1, len(sents)):
+                a, b = words[i - 1], words[i]
+                shorter = min(len(a), len(b))
+                if shorter < 6:
+                    continue
+                run, at = longest_run(a, b)
+                if run >= min_gram and run >= min_share * shorter:
+                    out.append({
+                        "line": line_no, "category": "triad",
+                        "note": f"two consecutive sentences sharing a {run}-word run that is "
+                                f"{run / shorter:.0%} of the shorter one — echoing skeleton, "
+                                "entry 26's third shape",
+                        "match": f"{' '.join(a[at:at + run])!r}: {sents[i][:60]}",
+                    })
+                    break
+        line_no += n + 1
+    return out
+
+
+def _question_runs(text: str, min_run: int = 2, tail_words: int = 6) -> list[dict]:
+    """Two or more questions in a row where the later ones are fragments.
+
+    Entry 10 without the fragment answer. `Do I know how it works? Where it
+    breaks? Which corners it cut?` — the second and third have no verb of their
+    own and ride on the first.
+
+    The run alone is not enough. Two full questions in sequence is how a person
+    changes subject: *So, what's next? Is this a project that starts and ends
+    with DeepSeek v4 Flash?* is in `tests/sample-clean.md` and must stay silent.
+    What makes the run a tic is a clipped question after the first, so the rule
+    requires one.
+    """
+    out = []
+    line_no = 1
+    for para in re.split(r"\n\s*\n", text):
+        n = para.count("\n") + 1
+        if not para.strip().startswith(("#", "-", "*", ">", "|", "`")):
+            sents = [s.strip() for s in re.split(r"(?<=[.!?])\s+", para.strip()) if s.strip()]
+            run: list[str] = []
+            for s in sents:
+                run = run + [s] if s.endswith("?") else []
+                if (len(run) >= min_run
+                        and any(len(q.split()) <= tail_words for q in run[1:])):
+                    out.append({"line": line_no, "category": "rhetorical-q",
+                                "note": f"{len(run)} questions in a row, at least one of them clipped — "
+                                        "stacked rhetorical questions; an interview or a FAQ is the "
+                                        "earned case",
+                                "match": s[:90]})
+                    break
         line_no += n + 1
     return out
 

--- a/declauding/scripts/declaude_review.py
+++ b/declauding/scripts/declaude_review.py
@@ -41,7 +41,11 @@ REGISTER = Path(__file__).resolve().parent.parent / "references" / "register.md"
 # land. 47 is here for the same reason: an exhaustive negative is earned when its
 # scope is named, and only reading the surrounding sentences says whether it is.
 # 43 to 46 are lexical and stage 1 reaches them.
-STRUCTURAL_ENTRIES = (1, 2, 3, 7, 9, 12, 13, 26, 47)
+STRUCTURAL_ENTRIES = (1, 2, 3, 7, 9, 12, 13, 26, 47, 50, 51, 52)
+# 50 to 52 need the slots this script extracts and stage 1 cannot judge: a
+# retroactive grade is only visible against the passage it grades, a totalizing
+# claim is earned when the set is named nearby, and an obituary headline is a
+# header. 48 and 49 are lexical and stage 1 reaches them.
 
 SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
 TAG = re.compile(r"<[^>]+>")

--- a/declauding/tests/sample-tics.md
+++ b/declauding/tests/sample-tics.md
@@ -187,3 +187,42 @@ The clause set is unresolvable only in the SAT sense, and the solver says so.
 `diff` reports no change; the mutation run killed 14 of 15.
 
 The handler logs the drop, where 4.1 dropped it silently.
+
+## Entries 48-52 specimens
+
+Let's be honest: I won't pretend the first run was clean. Honestly, the harness
+was wrong. You don't have to take my word for it.
+
+The tool died; the data didn't. Reading mostly passed. Writing didn't.
+Maybe it wouldn't have.
+
+That's why being able to open the environment mattered. This is why keeping
+every transcript counted.
+
+That's the whole point of the format, and the entire business model is the
+index. Here's the whole trick. Changelogs are the only release notes I trust,
+and the only thing that matters is the diff.
+
+## Peer code review is dead
+
+Long live the pre-merge check.
+
+Here's the twist: that's the part I keep coming back to.
+My favourite part of the thing is the cache. Turns out the header was there.
+Batteries included, zero config, small enough to fit in your head.
+
+Do I know how it works? Where it breaks? Which corners it cut?
+
+A shopping cart is an object in the system. A chat room is an object in the
+system.
+
+Negatives that must stay silent — a bounded count of one, a quoted obituary, a
+subject change across two full questions, and two sentences that share an idiom
+without sharing a skeleton:
+
+It is the only one of the six runs that finished.
+
+So, what's next? Is this a project that starts and ends with the current model?
+
+The result is the same as using the plus operation with a zero operand. For
+round-floor, the sign of the intermediate result decides the rounding.


### PR DESCRIPTION
Simon Willison's [llm-cliche-highlighter](https://github.com/simonw/tools/blob/main/llm-cliche-highlighter.html) added fifteen patterns and three structural detectors on 2026-08-27, in [simonw/tools#322](https://github.com/simonw/tools/pull/322) and [#323](https://github.com/simonw/tools/pull/323). Eight of the fifteen were already covered here in some form. Five had no entry.

## New entries

| # | Entry | Tell |
|---|---|---|
| 48 | Performative candour | "let's be honest", sentence-initial "Honestly,", "you don't have to take my word for it" |
| 49 | Stranded auxiliary reversal | *The tool died; the data didn't.* |
| 50 | Retroactive significance | *That's why being able to open the environment mattered.* |
| 51 | Totalizing designation | *That's the whole point of the format.* / *the only release notes I trust* |
| 52 | Obituary headline | *Peer code review is dead* / *long live X* |

Each carries a tell, a why, a fix, a before-and-after, and an earned column, plus a row in `SKILL.md`'s earned-exception tables. They are a fourth group: the confiding-essayist voice, where the staging is aimed at the reader's trust rather than at a finding.

## Extended entries

Entry 3 gained "here's the twist / catch / kicker / rub", "that's the part", "my favourite part of". Entry 10 gained the stacked-question run. Entry 18 gained bare "Turns out" — the rule only reached "it turns out". Entry 19 gained "batteries included", "zero config", "small enough to fit in your head". Entry 26 is now three shapes rather than two. `is the whole point` moved off the `aphorism` rule; entry 51 owns it.

## Detectors

`_echo_runs` is entry 26's third shape: two consecutive sentences sharing a five-word run that covers at least half the shorter one. Anaphora keys on the opening words and the triad regex on the commas; neither reaches *A shopping cart is an object in the system. A chat room is an object in the system.*

`_question_runs` is entry 10 without the fragment answer: two or more questions in a row where at least one after the first is clipped.

The third detector in the source, colon-into-a-triple, is already the comma-list half of entry 26.

## Narrowing

Several ported regexes are narrower than the source, which is tuned for essays rather than for technical prose. His `x-is-dead` fires on any "X is dead"; here it fires in headers only, because a dead process is a dead process. His echo detector needs one shared four-gram; here it needs five words covering half the shorter sentence. His question run needs two questions; here one after the first must be clipped.

## False-positive budget

`tests/sample-clean.md` still reports zero. It did not on the first cut: the question-run rule fired on *So, what's next? Is this a project that starts and ends with DeepSeek v4 Flash?*, which is antirez changing subject, and the clipped-question condition came out of that.

On 180,929 words of Python stdlib docstrings the five new categories fire 4 times (0.022 per 1,000 words), all four on entry 49 and all four the ordinary ellipsis the entry names as earned. `_echo_runs` fires 36 times (0.199 per 1,000), between the existing anaphora detector at 0.077 and fragment cadence at 0.298. Its first cut, keyed on a shared five-gram alone, fired 91 times on phrases like "is the same as using" inside sentences that were otherwise unalike. `_question_runs` fires 0 times.

`tests/sample-tics.md` now reports 167 candidates across 42 categories, `SKILL.md --skip-quoted` 13 and `README.md --skip-quoted` 18. Specimens for all five entries and both detectors are in `sample-tics.md`, with four negatives that must stay silent.

`scripts/validate_skills.py --all` passes for declauding; the one failure in the repo is `controlling-spotify` and predates this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBueZS76cWb6XVbwd4mH2A)_