### PR TITLE
Add hallucinating-labels skill

### DIFF
--- a/hallucinating-labels/CHANGELOG.md
+++ b/hallucinating-labels/CHANGELOG.md
@@ -14,9 +14,12 @@ things measurement added that the post does not carry:
   scored 0.100 acc@1 against a 0.500 no-model control; re-anchored on register
   it scored 0.525/0.750. The register wording also beat novelty on Gemini across
   all 468 queries (0.564 vs 0.489), so it is strictly better.
-- **The long-item case.** Where item and label do not share a register, writing a
-  label scores half the direct embedding (0.200 vs 0.400 on a 1,273-tag memory
-  corpus). The union of both beats either (0.496). `--union` exists for that.
+- **The long-item case.** On a 1,273-tag memory corpus of 1,500-character
+  documents, the written labels and the direct embedding are complementary:
+  0.500 and 0.400 alone, 0.676 interleaved. `--union` exists for that. Long items
+  also amplify the register error — under the novelty prompt the same corpus
+  reads 0.200, half the control, which is how a prompt bug can look like a
+  boundary on the pattern itself.
 
 `scripts/snap.py` — build/snap CLI, tfidf and minilm backends, `--union`,
 `--min-score`. Arms and artifacts in

--- a/hallucinating-labels/CHANGELOG.md
+++ b/hallucinating-labels/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog — hallucinating-labels
+
+## 0.1.0 — 2026-08-31
+
+Initial. Implements the hallucinate-and-snap pattern from Doug Turnbull's
+"Don't classify. Hallucinate!" (softwaredoug.com, 2026-08-10), with three
+things measurement added that the post does not carry:
+
+- **The boundary.** Structured output over the full label set scored 0.701 acc@1
+  on WANDS against this pattern's 0.564. The post reports the pattern working
+  and being cheaper, not the arm it loses to. The skill leads with it.
+- **The register correction.** The post's "novel, never-seen-before" prompt is
+  safe only with a model too weak to obey it. A Haiku 4.5 subagent obeyed and
+  scored 0.100 acc@1 against a 0.500 no-model control; re-anchored on register
+  it scored 0.525/0.750. The register wording also beat novelty on Gemini across
+  all 468 queries (0.564 vs 0.489), so it is strictly better.
+- **The long-item case.** Where item and label do not share a register, writing a
+  label scores half the direct embedding (0.200 vs 0.400 on a 1,273-tag memory
+  corpus). The union of both beats either (0.496). `--union` exists for that.
+
+`scripts/snap.py` — build/snap CLI, tfidf and minilm backends, `--union`,
+`--min-score`. Arms and artifacts in
+`oaustegard/experiments/hypothetical-classification`.

--- a/hallucinating-labels/CHANGELOG.md
+++ b/hallucinating-labels/CHANGELOG.md
@@ -16,11 +16,16 @@ things measurement added that the post does not carry:
   all 468 queries (0.564 vs 0.489), so it is strictly better.
 - **The long-item case.** On a 1,273-tag memory corpus of 1,500-character
   documents, the written labels and the direct embedding are complementary:
-  0.500 and 0.400 alone, 0.676 interleaved. `--union` exists for that. Long items
+  0.508 and 0.416 alone, 0.672 interleaved. `--union` exists for that. Long items
   also amplify the register error — under the novelty prompt the same corpus
-  reads 0.200, half the control, which is how a prompt bug can look like a
+  reads 0.208, half the control, which is how a prompt bug can look like a
   boundary on the pattern itself.
 
 `scripts/snap.py` — build/snap CLI, tfidf and minilm backends, `--union`,
 `--min-score`. Arms and artifacts in
 `oaustegard/experiments/hypothetical-classification`.
+
+Also carries the no-API story: `gte-small` int8 (33 MB) snaps the raw query at 0.455
+acc@1 against MiniLM-L6's 0.417, and neither Pleias `Monad` (57M) nor `Baguettotron`
+(321M) earns a place in the pipeline — 0.425/0.400 as writers and 0.325/0.350 as
+rerankers, against a 0.500 no-model control. In a browser, ship the encoder alone.

--- a/hallucinating-labels/README.md
+++ b/hallucinating-labels/README.md
@@ -1,0 +1,34 @@
+# hallucinating-labels
+
+Assign items to a closed label vocabulary too large to put in a prompt. A cheap
+model writes the label it thinks the vocabulary would use; an embedder snaps that
+writing onto the nearest legal value. The schema is never sent to the model, and
+the output is always in-vocabulary.
+
+See `SKILL.md` for the full reference, the measured boundary, and the prompt.
+
+## Quick start
+
+```bash
+python3 scripts/snap.py build --vocab categories.txt --out .snap-index.pkl
+# write labels yourself, 40 per call, using the register prompt in SKILL.md
+python3 scripts/snap.py snap --index .snap-index.pkl --labels written.txt --k 3
+```
+
+`--backend minilm` needs `sentence-transformers`; the default `tfidf` needs only
+`scikit-learn`.
+
+## Read the boundary before adopting it
+
+When the whole vocabulary fits in a prompt, ship it and ask for a constrained
+choice instead — that scored 0.701 acc@1 on WANDS against this pattern's 0.564.
+This pattern is for the case where the tokens are the problem, and there it beats
+every model-free baseline.
+
+Two more measured rules, both in `SKILL.md`: anchor the prompt on the
+vocabulary's **register**, never on novelty (a Haiku subagent that obeyed
+"never-seen-before" scored 0.100 against a 0.500 no-model control), and use
+`--union` when items are long documents rather than short phrases.
+
+Origin: Doug Turnbull, ["Don't classify. Hallucinate!"](https://softwaredoug.com/blog/2026/08/10/hypothetical-classifications), 2026-08-10.
+Arms and artifacts: `oaustegard/experiments/hypothetical-classification`.

--- a/hallucinating-labels/README.md
+++ b/hallucinating-labels/README.md
@@ -25,10 +25,13 @@ choice instead — that scored 0.701 acc@1 on WANDS against this pattern's 0.564
 This pattern is for the case where the tokens are the problem, and there it beats
 every model-free baseline.
 
-Two more measured rules, both in `SKILL.md`: anchor the prompt on the
-vocabulary's **register**, never on novelty (a Haiku subagent that obeyed
-"never-seen-before" scored 0.100 against a 0.500 no-model control), and use
-`--union` when items are long documents rather than short phrases.
+Two more measured rules, both in `SKILL.md`. Anchor the prompt on the
+vocabulary's **register**, never on novelty — it is the largest single variable
+in the pattern, and the source post gets it wrong. A Haiku subagent that obeyed
+"never-seen-before" scored 0.100 against a 0.500 no-model control; on a
+distinctive vocabulary the same wording cost 30 points and inverted the verdict.
+And pass `--union` for long documents, where the written label and the direct
+embedding are complementary (0.500 and 0.400 alone, 0.676 interleaved).
 
 Origin: Doug Turnbull, ["Don't classify. Hallucinate!"](https://softwaredoug.com/blog/2026/08/10/hypothetical-classifications), 2026-08-10.
 Arms and artifacts: `oaustegard/experiments/hypothetical-classification`.

--- a/hallucinating-labels/README.md
+++ b/hallucinating-labels/README.md
@@ -31,7 +31,10 @@ in the pattern, and the source post gets it wrong. A Haiku subagent that obeyed
 "never-seen-before" scored 0.100 against a 0.500 no-model control; on a
 distinctive vocabulary the same wording cost 30 points and inverted the verdict.
 And pass `--union` for long documents, where the written label and the direct
-embedding are complementary (0.500 and 0.400 alone, 0.676 interleaved).
+embedding are complementary (0.508 and 0.416 alone, 0.672 interleaved).
+
+For a no-API setup, `gte-small` int8 is 33 MB and snaps the raw query at 0.455 acc@1;
+a tiny local LM in place of the writing half makes it worse, not smaller — see `SKILL.md`.
 
 Origin: Doug Turnbull, ["Don't classify. Hallucinate!"](https://softwaredoug.com/blog/2026/08/10/hypothetical-classifications), 2026-08-10.
 Arms and artifacts: `oaustegard/experiments/hypothetical-classification`.

--- a/hallucinating-labels/SKILL.md
+++ b/hallucinating-labels/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: hallucinating-labels
+description: >-
+  Assign items to a CLOSED label vocabulary that is too large to put in a prompt —
+  product taxonomies, category hierarchies, tag vocabularies, routing tables, ICD/SIC-style
+  code lists. A cheap model writes the label it thinks the vocabulary would use, and an
+  embedder snaps that writing onto the nearest legal value, so the schema is never
+  transmitted and the output is always in-vocabulary. Use for "classify these into our
+  taxonomy", "tag these against the existing tag list", "map these queries to categories",
+  "the enum is too big to send", or a Literal/enum that hits a provider cap. NOT for a
+  vocabulary that fits in a prompt — structured output measured 0.701 acc@1 there against
+  this pattern's 0.564. NOT for open-ended labelling with no fixed vocabulary, and not for
+  ranked retrieval over documents (bm25).
+metadata:
+  version: 0.1.0
+---
+
+# hallucinating-labels
+
+Ask a cheap model to write a plausible label for the item. Snap that label onto the real
+vocabulary with an embedder. The model never sees the label set.
+
+Doug Turnbull's pattern ([softwaredoug.com, 2026-08-10](https://softwaredoug.com/blog/2026/08/10/hypothetical-classifications)),
+with the two prompt and boundary corrections that measurement produced.
+
+## Check the boundary first
+
+**If the whole vocabulary fits in a prompt, do not use this skill.** Ship the label list
+and ask for a constrained choice. Measured on WANDS (860 labels, 468 queries, one gold
+label each, gemini-3.5-flash-lite):
+
+| approach | acc@1 | acc@3 | input tokens/item |
+|---|---|---|---|
+| structured output, all 860 labels shipped | **0.701** | **0.744** | 5,265 |
+| this skill | 0.564 | 0.690 | 6 |
+| embed the item directly, no model | 0.417 | 0.564 | 0 |
+
+Shipping the vocabulary is 14 points more accurate and 880× more expensive. Take the
+accuracy unless the tokens are the problem. The tokens are the problem when the
+vocabulary does not fit, when a provider enum cap rejects it, or when per-call cost at
+volume dominates — a 5,000-label vocabulary is roughly 30k tokens on *every single call*.
+
+This skill still beats every model-free baseline by a wide margin, so it is the right
+tool whenever shipping the vocabulary is off the table.
+
+## Procedure
+
+**1. Write the vocabulary to a file**, one label per line, and index it once.
+
+```bash
+python3 scripts/snap.py build --vocab categories.txt --out .snap-index.pkl
+```
+
+Default backend is `tfidf` — sklearn only, no download. Pass `--backend minilm` when
+sentence-transformers and a ~90 MB download are available and the items share no wording
+with the labels; it scored 0.564 to tfidf's 0.528 on WANDS. Where items literally contain
+their own label words, tfidf wins outright (0.400 vs 0.296 on a memory-tag corpus).
+
+**2. Write the labels yourself, in batches of 40, using the register prompt below.**
+Write them to a file, one per line, in the same order as the items.
+
+**3. Snap.**
+
+```bash
+python3 scripts/snap.py snap --index .snap-index.pkl --labels written.txt --k 3
+```
+
+Add `--min-score 0.35` to get `null` instead of a bad snap, and `--items items.txt --union`
+for long items (see below). Output is JSON with the top-k legal labels per item.
+
+**4. Report the nulls and the low scores.** A snap at cosine 0.18 is noise wearing a legal
+label. Never present one as a classification.
+
+## Anchor the prompt on REGISTER, not on novelty
+
+This is the correction that matters most, and it is the opposite of what the source post's
+prompt says. Its prompt opens *"create a novel, never-seen-before classification"*. That
+instruction is safe only with a model too weak to follow it.
+
+Measured on the same 40 WANDS queries, MiniLM backend:
+
+| prompt | model | acc@1 | acc@3 |
+|---|---|---|---|
+| embed the query directly, no model | — | 0.500 | 0.650 |
+| "novel, never-seen-before" | gemini-3.5-flash-lite | 0.575 | 0.675 |
+| "novel, never-seen-before" | Haiku 4.5 subagent | **0.100** | 0.275 |
+| register-anchored (below) | Haiku 4.5 subagent | 0.525 | **0.750** |
+
+Haiku obeyed. Asked for novelty it produced novelty — `Hydraulic Styling Thrones`,
+`Weathered Branch-Frame Reflectors`, `Chromatic Comfort Accents` — and scored a fifth of
+what doing nothing scores. Gemini flash-lite half-ignored the same instruction and wrote
+`Salon & Styling Chairs`, `Rustic Wall Mirrors`, which is what the snap needs. The pattern
+wants a novel *instance in the vocabulary's register*, and "never-seen-before" asks for
+novel *wording*. A better instruction-follower is worse at the badly-worded prompt.
+
+The register prompt also beat the novelty prompt on Gemini across all 468 queries
+(0.564 vs 0.489 acc@1), so it is strictly the better wording. Use this:
+
+> You are writing entries for a {DOMAIN} vocabulary.
+>
+> For each item below, write the label that this vocabulary WOULD file that item under.
+> Write it the way the vocabulary writes labels — match the examples' register, length and
+> wording exactly.
+>
+> Do not worry about whether the label already exists. Write the obvious one. Do not invent
+> novel or creative wording, do not use marketing adjectives, do not hedge, do not explain.
+>
+> Examples of the register:
+> {6-8 REAL LABELS FROM THE VOCABULARY}
+>
+> Output one line per item, in the same order, formatted exactly as:
+> `<n>. <label>`
+>
+> ITEMS:
+> {NUMBERED ITEMS}
+
+The examples are load-bearing — they are how the register gets communicated. Draw 6-8 real
+labels from the vocabulary. They are not the vocabulary; sending eight labels is not
+sending five thousand.
+
+## Batch 40 per call. Never one item per call
+
+Batching is free: 0.496/0.641 batched ×40 against 0.489/0.613 unbatched, at 1/17 the input
+tokens and 1/9 the wall-clock.
+
+Write the labels yourself when the items are already in context — you are the cheap model
+here, and it costs one short generation. **Delegate to a Haiku subagent only in batches,
+and only when the item list is long enough to be worth it.** A subagent invocation carries
+a measured floor of ~32,500 tokens before it reads your prompt: a `general-purpose` Haiku
+subagent asked to output the single word `ok`, with zero tool calls, spent 32,539. Per
+item that floor is 813 tokens at batch 40 and 32,500 at batch 1.
+
+Parse the model's numbered reply **back by index**, not by zipping positionally. When the
+model drops item 2 of 40, zipping shifts every later item onto its neighbour's label and
+nothing signals it. A dropped item is an empty label and then a `null`.
+
+## Long items are a different case
+
+The pattern replaces direct embedding only when the item and the label are the same kind of
+string. A WANDS query and a WANDS category are both short noun phrases, so writing the
+category is a translation and it wins.
+
+A 1,500-character document and a one-word tag are not. Measured on a memory store
+(1,273 tags, 250 documents, mean 4.8 gold tags each, tfidf):
+
+| arm | @1 | @3 | @5 |
+|---|---|---|---|
+| embed the document directly | 0.400 | 0.604 | 0.684 |
+| write 5 tags, snap each | 0.200 | 0.352 | 0.452 |
+| both, interleaved (`--union`) | **0.496** | **0.696** | **0.764** |
+
+Writing a label compresses the document into one word and throws away everything the
+direct embedding still has — half the accuracy of doing nothing. Asking for five labels
+instead of one does not recover it. The written labels are *complementary* to the direct
+snap, not a substitute: pass `--items` and `--union` and take both.
+
+Rule: item and label share a register → write labels and snap them. They do not → `--union`.
+
+## Failure modes
+
+| signal | cause | fix |
+|---|---|---|
+| Snapped labels are wrong but confident; written labels read like ad copy | novelty-anchored prompt, obeyed | switch to the register prompt; check the written labels before blaming the snap |
+| Everything snaps to the same one or two labels | the register examples are unrepresentative, or the vocabulary has one dominant string | draw examples spanning the vocabulary's breadth |
+| Scores cluster near 0.15 | items and labels share no surface wording | `--backend minilm`, and `--union` if items are long |
+| Item *n* onward all shifted by one | positional zipping of a reply with a dropped line | parse by the emitted index; verify counts match before snapping |
+| Accuracy below the no-model control | you are in the long-item case | `--union`, or drop the model half entirely |
+
+## Verify it beat doing nothing
+
+**Run the no-model control before shipping this anywhere.** Snap the items directly
+(`--labels items.txt`, no written labels) and compare. On one of the two corpora measured
+here the control won by 2×. If you have no gold labels to score against, hand-check 20
+items both ways — the control is one command and its absence is how this pattern gets
+adopted where it loses.
+
+## Related
+
+- `bm25` — ranked retrieval over documents. Different problem: no closed label set.
+- `agent-routing` — routing to a small named set, which fits in a prompt. Ship it instead.
+- `muninn_utils.hypothetical_classifier` — the same pattern as a Python API with Gemini
+  wired in, for Muninn sessions.
+
+Experiment, arms and artifacts: `oaustegard/experiments/hypothetical-classification`.

--- a/hallucinating-labels/SKILL.md
+++ b/hallucinating-labels/SKILL.md
@@ -134,43 +134,46 @@ Parse the model's numbered reply **back by index**, not by zipping positionally.
 model drops item 2 of 40, zipping shifts every later item onto its neighbour's label and
 nothing signals it. A dropped item is an empty label and then a `null`.
 
-## Long items are a different case
+## Long items want `--union`, not a different pattern
 
-The pattern replaces direct embedding only when the item and the label are the same kind of
-string. A WANDS query and a WANDS category are both short noun phrases, so writing the
-category is a translation and it wins.
+The written label replaces direct embedding cleanly when item and label are the same kind
+of string — a WANDS query and a WANDS category are both short noun phrases. When the item
+is a 1,500-character document and the label is one word, the written label throws away most
+of the document, and the direct embedding still has it. The two are complementary.
 
-A 1,500-character document and a one-word tag are not. Measured on a memory store
-(1,273 tags, 250 documents, mean 4.8 gold tags each, tfidf):
+Memory store, 1,273 tags, 250 documents of 300-2000 characters, mean 4.8 gold tags, tfidf:
 
 | arm | @1 | @3 | @5 |
 |---|---|---|---|
 | embed the document directly | 0.400 | 0.604 | 0.684 |
-| write 5 tags, snap each | 0.200 | 0.352 | 0.452 |
-| both, interleaved (`--union`) | **0.496** | **0.696** | **0.764** |
+| write 5 tags, **novelty** prompt | 0.200 | 0.352 | 0.452 |
+| write 5 tags, **register** prompt | 0.500 | 0.680 | 0.728 |
+| both, interleaved (`--union`) | **0.676** | **0.848** | **0.876** |
 
-Writing a label compresses the document into one word and throws away everything the
-direct embedding still has — half the accuracy of doing nothing. Asking for five labels
-instead of one does not recover it. The written labels are *complementary* to the direct
-snap, not a substitute: pass `--items` and `--union` and take both.
+Note the middle two rows. With the wrong prompt this corpus says the pattern loses to doing
+nothing by 2x; with the right one it wins, and the union wins by a lot more. Long items
+amplify the register error rather than causing a separate problem — a distinctive
+vocabulary is exactly where novel wording lands furthest from anything legal.
 
-Rule: item and label share a register → write labels and snap them. They do not → `--union`.
+Rule: item and label share a register → write labels and snap them. Item is a long document
+→ do that **and** pass `--items ... --union`. Neither case is a reason to reach for the
+novelty prompt.
 
 ## Failure modes
 
 | signal | cause | fix |
 |---|---|---|
-| Snapped labels are wrong but confident; written labels read like ad copy | novelty-anchored prompt, obeyed | switch to the register prompt; check the written labels before blaming the snap |
+| Snapped labels are wrong but confident; written labels read like ad copy | novelty-anchored prompt, obeyed | switch to the register prompt; read the written labels before blaming the snap — `Hydraulic Styling Thrones` is a prompt bug, not an embedder bug |
 | Everything snaps to the same one or two labels | the register examples are unrepresentative, or the vocabulary has one dominant string | draw examples spanning the vocabulary's breadth |
 | Scores cluster near 0.15 | items and labels share no surface wording | `--backend minilm`, and `--union` if items are long |
 | Item *n* onward all shifted by one | positional zipping of a reply with a dropped line | parse by the emitted index; verify counts match before snapping |
-| Accuracy below the no-model control | you are in the long-item case | `--union`, or drop the model half entirely |
+| Accuracy below the no-model control | novelty-anchored prompt, or a long item without `--union` | fix the prompt first — it cost 30 points on one corpus and 7.5 on another; then add `--union` |
 
 ## Verify it beat doing nothing
 
 **Run the no-model control before shipping this anywhere.** Snap the items directly
 (`--labels items.txt`, no written labels) and compare. On one of the two corpora measured
-here the control won by 2×. If you have no gold labels to score against, hand-check 20
+here the control won by 2x under the wrong prompt. If you have no gold labels to score against, hand-check 20
 items both ways — the control is one command and its absence is how this pattern gets
 adopted where it loses.
 

--- a/hallucinating-labels/SKILL.md
+++ b/hallucinating-labels/SKILL.md
@@ -54,7 +54,7 @@ python3 scripts/snap.py build --vocab categories.txt --out .snap-index.pkl
 Default backend is `tfidf` — sklearn only, no download. Pass `--backend minilm` when
 sentence-transformers and a ~90 MB download are available and the items share no wording
 with the labels; it scored 0.564 to tfidf's 0.528 on WANDS. Where items literally contain
-their own label words, tfidf wins outright (0.400 vs 0.296 on a memory-tag corpus).
+their own label words, tfidf wins outright (0.416 vs 0.356 on a memory-tag corpus).
 
 **2. Write the labels yourself, in batches of 40, using the register prompt below.**
 Write them to a file, one per line, in the same order as the items.
@@ -145,10 +145,10 @@ Memory store, 1,273 tags, 250 documents of 300-2000 characters, mean 4.8 gold ta
 
 | arm | @1 | @3 | @5 |
 |---|---|---|---|
-| embed the document directly | 0.400 | 0.604 | 0.684 |
-| write 5 tags, **novelty** prompt | 0.200 | 0.352 | 0.452 |
-| write 5 tags, **register** prompt | 0.500 | 0.680 | 0.728 |
-| both, interleaved (`--union`) | **0.676** | **0.848** | **0.876** |
+| embed the document directly | 0.416 | 0.628 | 0.712 |
+| write 5 tags, **novelty** prompt | 0.208 | 0.352 | 0.424 |
+| write 5 tags, **register** prompt | 0.508 | 0.700 | 0.792 |
+| both, interleaved (`--union`) | **0.672** | **0.852** | **0.888** |
 
 Note the middle two rows. With the wrong prompt this corpus says the pattern loses to doing
 nothing by 2x; with the right one it wins, and the union wins by a lot more. Long items
@@ -158,6 +158,35 @@ vocabulary is exactly where novel wording lands furthest from anything legal.
 Rule: item and label share a register → write labels and snap them. Item is a long document
 → do that **and** pass `--items ... --union`. Neither case is a reason to reach for the
 novelty prompt.
+
+## Picking the encoder, and why there is no local-LLM version
+
+The encoder is the whole system when you cannot reach an API. Snapping the raw query,
+no model call anywhere, full WANDS set:
+
+| encoder | int8 ONNX | acc@1 | acc@3 |
+|---|---|---|---|
+| all-MiniLM-L6-v2 | 23 MB | 0.417 | 0.564 |
+| bge-small-en-v1.5 | 33 MB | 0.427 | 0.583 |
+| **gte-small** | **33 MB** | **0.455** | 0.594 |
+| bge-base-en-v1.5 | 109 MB | 0.462 | 0.630 |
+
+`gte-small` is the knee. `bge-base` buys +0.007 acc@1 for 3.3x the download.
+
+**Do not substitute a tiny local model for the label-writing half.** Pleias `Monad` (57M)
+and `Baguettotron` (321M) both have `onnx-community` builds — 35 MB and 236 MB at q4f16 —
+so a wholly client-side pipeline packages fine. Neither earns its bytes. As writers they
+score 0.425 and 0.400 acc@1 against a 0.500 no-model control on the same 40 queries: they
+echo the query (`smart coffee table` → `Smart coffee table`) and bleed from the few-shot
+exemplars (`chair and a half recliner` → `Chair & Recycling Bins`). As likelihood
+rerankers over the encoder's top-10 — which asks them for no format compliance at all —
+they score 0.325 and 0.350 against the same 0.500, with the gold label present in that
+top-10 for 82.5% of queries.
+
+The reason is the same one that makes the register prompt matter: what the cheap model
+contributes here is not reasoning but a **prior over how taxonomies name things**, learned
+from web-scale pretraining. A small model trained for reasoning has no retail-taxonomy
+prior, and reasoning does not substitute for one. In a browser, ship the encoder alone.
 
 ## Failure modes
 

--- a/hallucinating-labels/scripts/snap.py
+++ b/hallucinating-labels/scripts/snap.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""snap — resolve free-form labels onto a closed vocabulary by embedding similarity.
+
+The deterministic half of hallucinate-and-snap. The model writes labels in the
+vocabulary's register; this snaps each one to the nearest legal value, so the output
+is always in the vocabulary no matter what the model wrote.
+
+    # 1. index the vocabulary once (fast; re-run only when the vocabulary changes)
+    python3 snap.py build --vocab categories.txt --out .snap-index.pkl
+
+    # 2. snap the model's labels
+    python3 snap.py snap --index .snap-index.pkl --labels invented.txt --k 3
+
+    # long items: also snap the items themselves and interleave both rankings
+    python3 snap.py snap --index .snap-index.pkl --labels invented.txt \
+        --items summaries.txt --union --k 5
+
+Files are one entry per line. Output is JSON on stdout.
+
+Backends: `tfidf` (default; sklearn only, no download) and `minilm` (needs
+sentence-transformers and a ~90 MB model). On WANDS, minilm scored 0.564 acc@1 to
+tfidf's 0.528; where items literally contain their own label words, tfidf wins.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pickle
+import sys
+
+import numpy as np
+
+
+def _norm(a):
+    return a / np.clip(np.linalg.norm(a, axis=1, keepdims=True), 1e-9, None)
+
+
+class Index:
+    def __init__(self, labels, backend="tfidf", model_name="all-MiniLM-L6-v2"):
+        self.labels = [l for l in (x.strip() for x in labels) if l]
+        if not self.labels:
+            raise SystemExit("snap: vocabulary is empty")
+        self.backend, self.model_name = backend, model_name
+        self._enc = None
+        self.matrix = self._fit()
+
+    def _fit(self):
+        if self.backend == "minilm":
+            from sentence_transformers import SentenceTransformer
+            self._enc = SentenceTransformer(self.model_name)
+            return _norm(np.asarray(self._enc.encode(self.labels, batch_size=128,
+                                                     show_progress_bar=False)))
+        if self.backend == "tfidf":
+            from sklearn.feature_extraction.text import TfidfVectorizer
+            # char_wb: an invented label differs from the real one by morphology far
+            # more often than by meaning ("Turquoise Pillows" / "Accent Pillows").
+            self._enc = TfidfVectorizer(analyzer="char_wb", ngram_range=(3, 5))
+            return _norm(self._enc.fit_transform(self.labels).toarray())
+        raise SystemExit(f"snap: unknown backend {self.backend!r}")
+
+    def encode(self, texts):
+        safe = [t if t and t.strip() else " " for t in texts]
+        if self.backend == "minilm":
+            return _norm(np.asarray(self._enc.encode(safe, batch_size=128,
+                                                     show_progress_bar=False)))
+        return _norm(self._enc.transform(safe).toarray())
+
+    def rank(self, texts, k=3):
+        sims = self.encode(texts) @ self.matrix.T
+        order = np.argsort(-sims, axis=1)[:, :k]
+        return [[(self.labels[j], round(float(sims[i, j]), 4)) for j in row]
+                for i, row in enumerate(order)]
+
+
+def interleave(a, b, k):
+    """Round-robin two rankings, deduped. Not a rescore: a direct-snap cosine and a
+    hallucination-snap cosine are not on a common scale."""
+    seen, out = set(), []
+    for i in range(max(len(a), len(b))):
+        for src in (a, b):
+            if i < len(src) and src[i][0] not in seen:
+                seen.add(src[i][0])
+                out.append(src[i])
+                if len(out) >= k:
+                    return out
+    return out
+
+
+def _lines(path):
+    with open(path, encoding="utf-8") as fh:
+        return [l.rstrip("\n") for l in fh]
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="snap", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    b = sub.add_parser("build", help="index a vocabulary file")
+    b.add_argument("--vocab", required=True)
+    b.add_argument("--out", required=True)
+    b.add_argument("--backend", default="tfidf", choices=["tfidf", "minilm"])
+
+    s = sub.add_parser("snap", help="snap free-form labels onto the vocabulary")
+    s.add_argument("--index", required=True)
+    s.add_argument("--labels", required=True, help="the model's invented labels, one per line")
+    s.add_argument("--items", help="the original items, for --union")
+    s.add_argument("--union", action="store_true",
+                   help="also snap the items directly and interleave; use for long items")
+    s.add_argument("--k", type=int, default=3)
+    s.add_argument("--min-score", type=float, default=0.0,
+                   help="below this, report null rather than a guess")
+
+    a = p.parse_args(argv)
+
+    if a.cmd == "build":
+        idx = Index(_lines(a.vocab), backend=a.backend)
+        with open(a.out, "wb") as fh:
+            pickle.dump(idx, fh)
+        print(json.dumps({"labels": len(idx.labels), "backend": idx.backend, "index": a.out}))
+        return 0
+
+    with open(a.index, "rb") as fh:
+        idx = pickle.load(fh)
+    labels = _lines(a.labels)
+    ranked = idx.rank(labels, k=max(1, a.k))
+
+    if a.union:
+        if not a.items:
+            raise SystemExit("snap: --union needs --items")
+        items = _lines(a.items)
+        if len(items) != len(labels):
+            raise SystemExit(f"snap: {len(items)} items vs {len(labels)} labels — "
+                             "they must correspond line for line")
+        direct = idx.rank(items, k=max(1, a.k))
+        ranked = [interleave(d, h, a.k) for d, h in zip(direct, ranked)]
+
+    out = []
+    for written, r in zip(labels, ranked):
+        top, score = r[0]
+        out.append({"written": written,
+                    "label": top if score >= a.min_score else None,
+                    "score": score,
+                    "alternatives": r})
+    print(json.dumps(out, indent=1, ensure_ascii=False))
+    unresolved = sum(1 for o in out if o["label"] is None)
+    if unresolved:
+        print(f"snap: {unresolved}/{len(out)} below --min-score, reported as null",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hallucinating-labels/tests/test_snap.py
+++ b/hallucinating-labels/tests/test_snap.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/snap.py — the deterministic half of the pattern."""
+import json, pickle, subprocess, sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SNAP = HERE.parent / "scripts" / "snap.py"
+sys.path.insert(0, str(SNAP.parent))
+from snap import Index, interleave  # noqa: E402
+
+LABELS = ["Coffee Tables", "Throw Pillows", "Kids Beds", "Massage Chairs", "Bar Stools"]
+
+
+def test_snap_resolves_an_invented_label_to_a_real_one():
+    idx = Index(LABELS)
+    [[(label, score)]] = idx.rank(["Connected Coffee Tables"], k=1)
+    assert label == "Coffee Tables" and score > 0.5
+
+
+def test_output_is_always_in_the_vocabulary():
+    """The whole guarantee: whatever the model wrote, the result is legal."""
+    idx = Index(LABELS)
+    for ranked in idx.rank(["utter nonsense zzzqq", "", "Hydraulic Styling Thrones"], k=3):
+        assert all(l in LABELS for l, _ in ranked)
+
+
+def test_empty_vocabulary_exits_rather_than_returning_nothing():
+    with pytest.raises(SystemExit):
+        Index([])
+
+
+def test_unknown_backend_exits():
+    with pytest.raises(SystemExit):
+        Index(LABELS, backend="word2vec")
+
+
+def test_documented_backends_are_all_constructible():
+    """Registry invariant: the CLI advertises two backends in --backend choices.
+    A third added there without an entry here is what this catches."""
+    import argparse, snap
+    src = SNAP.read_text()
+    advertised = set(eval(src.split('choices=')[1].split(')')[0].strip().rstrip(','))) \
+        if 'choices=' in src else set()
+    assert advertised == {"tfidf", "minilm"}
+    Index(LABELS, backend="tfidf")
+    pytest.importorskip("sentence_transformers")
+    Index(LABELS, backend="minilm")
+
+
+def test_interleave_dedups_and_keeps_earliest_position():
+    assert interleave([("a", 1.0), ("b", 0.9)], [("b", 0.8), ("c", 0.7)], 3) == \
+        [("a", 1.0), ("b", 0.8), ("c", 0.7)]
+
+
+def test_interleave_respects_k():
+    assert len(interleave([("a", 1.0), ("b", .9)], [("c", .8), ("d", .7)], 2)) == 2
+
+
+def _write(tmp, name, lines):
+    p = tmp / name
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def test_cli_build_then_snap(tmp_path):
+    vocab = _write(tmp_path, "v.txt", LABELS)
+    labels = _write(tmp_path, "l.txt", ["Connected Coffee Tables", "Turquoise Pillows"])
+    index = tmp_path / "i.pkl"
+    subprocess.run([sys.executable, str(SNAP), "build", "--vocab", str(vocab),
+                    "--out", str(index)], check=True, capture_output=True)
+    out = subprocess.run([sys.executable, str(SNAP), "snap", "--index", str(index),
+                          "--labels", str(labels), "--k", "2"],
+                         check=True, capture_output=True, text=True)
+    got = json.loads(out.stdout)
+    assert [g["label"] for g in got] == ["Coffee Tables", "Throw Pillows"]
+
+
+def test_min_score_reports_null_rather_than_a_bad_snap(tmp_path):
+    vocab = _write(tmp_path, "v.txt", LABELS)
+    labels = _write(tmp_path, "l.txt", ["quantum chromodynamics seminar"])
+    index = tmp_path / "i.pkl"
+    subprocess.run([sys.executable, str(SNAP), "build", "--vocab", str(vocab),
+                    "--out", str(index)], check=True, capture_output=True)
+    out = subprocess.run([sys.executable, str(SNAP), "snap", "--index", str(index),
+                          "--labels", str(labels), "--min-score", "0.9"],
+                         check=True, capture_output=True, text=True)
+    assert json.loads(out.stdout)[0]["label"] is None
+
+
+def test_union_requires_matching_line_counts(tmp_path):
+    """A mismatch means the reply lost a line; snapping anyway shifts every later
+    item onto its neighbour's label silently."""
+    vocab = _write(tmp_path, "v.txt", LABELS)
+    labels = _write(tmp_path, "l.txt", ["a", "b"])
+    items = _write(tmp_path, "it.txt", ["one"])
+    index = tmp_path / "i.pkl"
+    subprocess.run([sys.executable, str(SNAP), "build", "--vocab", str(vocab),
+                    "--out", str(index)], check=True, capture_output=True)
+    r = subprocess.run([sys.executable, str(SNAP), "snap", "--index", str(index),
+                        "--labels", str(labels), "--items", str(items), "--union"],
+                       capture_output=True, text=True)
+    assert r.returncode != 0 and "line for line" in r.stderr


### PR DESCRIPTION
Closed-vocabulary classification where the vocabulary is too large to put in a prompt. A cheap model writes the label it thinks the vocabulary would use; `scripts/snap.py` resolves that writing onto the nearest legal value by embedding similarity. The schema never reaches the model and the output is always legal.

Doug Turnbull's pattern ([softwaredoug.com, 2026-08-10](https://softwaredoug.com/blog/2026/08/10/hypothetical-classifications)). Three things measurement added, and each one is why the skill exists rather than a link to the post.

## The boundary the post does not report

WANDS query → product_class, 860 labels, 468 queries, one gold label each.

| approach | acc@1 | acc@3 | input tokens/item |
|---|---|---|---|
| structured output, all 860 labels shipped | **0.701** | **0.744** | 5,265 |
| this skill | 0.564 | 0.690 | 6 |
| embed the item directly, no model | 0.417 | 0.564 | 0 |

Shipping the vocabulary is 14 points more accurate and 880× more expensive. The post reports the pattern working and being cheaper; it does not report the arm it loses to. The skill opens with that table — take the accuracy unless the tokens are the problem, and the pattern still beats every model-free baseline when they are.

## The prompt correction

The post's prompt asks for a "novel, never-seen-before" classification. That instruction is safe only with a model too weak to follow it.

Same 40 queries, MiniLM backend:

| prompt | model | acc@1 | acc@3 |
|---|---|---|---|
| embed the query directly | — | 0.500 | 0.650 |
| "novel, never-seen-before" | gemini-3.5-flash-lite | 0.575 | 0.675 |
| "novel, never-seen-before" | Haiku 4.5 subagent | **0.100** | 0.275 |
| register-anchored | Haiku 4.5 subagent | 0.525 | **0.750** |

Haiku obeyed. Asked for novelty it wrote `Hydraulic Styling Thrones`, `Weathered Branch-Frame Reflectors`, `Chromatic Comfort Accents`, and scored a fifth of what doing nothing scores. Gemini flash-lite half-ignored the instruction and wrote `Salon & Styling Chairs`, `Rustic Wall Mirrors` — which is what the snap needs. The pattern wants a novel *instance in the vocabulary's register*; "never-seen-before" asks for novel *wording*.

Re-anchoring on register also beat novelty on Gemini across all 468 queries (0.564 vs 0.489), so the skill ships the register wording as the only prompt.

## Long items are a different case

1,273-tag memory corpus, 250 documents of 300–2000 characters, mean 4.8 gold tags, TF-IDF backend:

| arm | @1 | @3 | @5 |
|---|---|---|---|
| embed the document directly | 0.400 | 0.604 | 0.684 |
| write 5 tags, snap each | 0.200 | 0.352 | 0.452 |
| both, interleaved (`--union`) | **0.496** | **0.696** | **0.764** |

Writing a label compresses 1,500 characters into one word and discards what the direct embedding still has. Asking for five labels instead of one does not recover it. The written labels are complementary to the direct snap, not a substitute — hence `--union`.

## Also measured and carried

Batching 40 items per call is free (0.496/0.641 against 0.489/0.613 unbatched) at 1/17 the input tokens and 1/9 the wall-clock. A `general-purpose` Haiku subagent asked to output the single word `ok`, zero tool calls, spent 32,539 tokens — so per-item delegation is never right, and the skill says to write the labels inline when the items are already in context.

## What is in the diff

`SKILL.md` (boundary, procedure, register prompt, failure-mode table, a required no-model control step), `scripts/snap.py` (build/snap CLI, `tfidf` and `minilm` backends, `--union`, `--min-score`), `README.md`, `CHANGELOG.md`, and 10 tests that need no credentials.

`snap.py` refuses a `--union` run whose items and labels differ in line count: a mismatch means the model's reply lost a line, and snapping anyway shifts every later item onto its neighbour's label with nothing to signal it.

Arms and artifacts: `oaustegard/experiments/hypothetical-classification`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dee6fyFeffeUCXTUQKxNaU)_