### PR TITLE
invoking-gemini: Gemini 3.8 Flash is the default, add 3.7, retire Pro from routing, handle minimal-thinking 400

### DIFF
--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -1,5 +1,40 @@
 # invoking-gemini - Changelog
 
+## 2026-09-03
+
+### ⚠️ BREAKING — `flash` alias and `DEFAULT_MODEL` repointed to gemini-3.8-flash
+- Gemini 3.8 Flash reached GA on 2026-09-02. It is now the registry default and
+  the `flash` alias. Google also shipped 3.7 Flash on 2026-08-13, which this
+  skill missed; both are added to `MODELS`.
+- New pinned aliases `flash-3.7` and `flash-3.6`. `flash-3.5` and `flash-3`
+  are unchanged. Nothing is removed; no 3.x Flash has a shutdown date.
+- Price is the same as 3.6 on Google's current page ($0.75 in / $3.75 out
+  through 2026-12-31, then $1.50 / $7.50), so the swap costs nothing per token.
+  Google says 3.8 "works harder" at higher effort levels, so per-task thinking
+  tokens may go up.
+
+### Changed — `thinking_level='minimal'` on 3.7 / 3.8 Flash
+- Both models return HTTP 400 for `minimal` (verified live 2026-09-03; 3.6,
+  3.5 and 3.5-lite accept it). `invoke_gemini()` now downgrades `minimal` to
+  `low` on those two model IDs and prints a one-line note to stderr, so callers
+  that pass `minimal` uniformly (transcription, classification) keep working
+  on the new default instead of burning a non-retriable 400 and returning
+  `None`. Measured on 3.8: `low` spent 0 thinking tokens on a one-word reply,
+  the default `medium` spent 79. On 3.7, `low` still spent 45–88 on the same
+  prompt, so the downgrade is not free there — budget output generously.
+- For a true no-thinking pass, pin `flash-3.6` or `lite`.
+
+### Fixed — stale figures in the model tables
+- gemini-3.1-pro-preview output above 200K is $18.00 / 1M, not $24.00.
+- gemini-3.6-flash pricing carried the flat $1.50 / $7.50 from its launch
+  table; Google's pricing page now lists it on the same introductory schedule
+  as 3.7 and 3.8.
+- 3.5 Pro was still described as "slated for June 2026"; it has not shipped
+  as of 2026-09-03.
+- Deprecation table gains the 3.x preview rows and the 2026-10-02 shutdown of
+  `gemini-2.5-flash-image` (the `nano-banana` alias target).
+- Two docstrings still named `gemini-3-flash-preview` as the default.
+
 ## 2026-07-29
 
 ### Fixed — nested Pydantic models raised a bare HTTP 400

--- a/invoking-gemini/CHANGELOG.md
+++ b/invoking-gemini/CHANGELOG.md
@@ -13,6 +13,15 @@
   Google says 3.8 "works harder" at higher effort levels, so per-task thinking
   tokens may go up.
 
+### ⚠️ BREAKING — `pro` alias repointed to gemini-3.8-flash; Pro tier off routing
+- Oskar, 2026-09-03: "We should never use 3.1 Pro, its Pareto efficiency is
+  too poor compared to the later Flash models." `gemini-3.1-pro-preview` costs
+  2.7× / 3.2× (in / out) what 3.8 Flash does at today's rates and the 3.5+
+  Flash line already beat it on coding and agentic benchmarks. The ID stays in
+  `MODELS` for pinned callers; the table marks it DEPRECATED. "Maximum
+  reasoning" is now Flash with `thinking_level='high'`. A future 3.5 Pro gets
+  the same test before any alias points at it.
+
 ### Changed — `thinking_level='minimal'` on 3.7 / 3.8 Flash
 - Both models return HTTP 400 for `minimal` (verified live 2026-09-03; 3.6,
   3.5 and 3.5-lite accept it). `invoke_gemini()` now downgrades `minimal` to

--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -201,6 +201,12 @@ callable under a pinned alias (`flash-3.7`, `flash-3.6`, `flash-3.5`,
 `flash-3`), and none has a shutdown date. `gemini-3.1-flash-lite-preview` from
 earlier docs is gone (shut down 2026-05-25).
 
+The Pro tier is off routing. `gemini-3.1-pro-preview` costs 2.7× the input and
+3.2× the output of 3.8 Flash at today's rates and loses to the 3.5+ Flash line
+on the coding and agentic benchmarks that matter here. Do not target it; the
+`pro` alias now resolves to gemini-3.8-flash, and "maximum reasoning" means
+`thinking_level='high'` on Flash.
+
 ### Text / Reasoning Models
 
 | Model | Alias | Input/1M | Output/1M | Context | Notes |
@@ -210,7 +216,7 @@ earlier docs is gone (shut down 2026-05-25).
 | gemini-3.6-flash | `flash-3.6` | $0.75 → $1.50 | $3.75 → $7.50 | 1M / 64K | GA 2026-07-21. ~17% fewer output tokens than 3.5 Flash. Last Flash that accepts `thinking_level='minimal'` (verified 2026-09-03). |
 | gemini-3.5-flash | `flash-3.5` | $1.50 | $9.00 | 1M | GA 2026-05-19. Google's model list now labels it "legacy". Accepts `minimal`. Costs more on output than 3.6–3.8. |
 | gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Older preview Flash, kept for back compat. Google's listed migration target for it is gemini-3.6-flash; no shutdown date. |
-| gemini-3.1-pro-preview | `pro` | $2.00 (≤200K) / $4.00 | $12.00 / $18.00 | 1M | Current Pro tier. 3.5 Pro was announced at I/O 2026-05-19 for June and is still absent from the API model list as of 2026-09-03. |
+| ~~gemini-3.1-pro-preview~~ | — | $2.00 (≤200K) / $4.00 | $12.00 / $18.00 | 1M | **DEPRECATED from routing (2026-09-03).** Price/quality dominated by 3.6+ Flash; 3.5 Flash already beat it on most coding/agentic benchmarks. ID stays callable for pinned code. `pro` now resolves to gemini-3.8-flash. 3.5 Pro was announced at I/O 2026-05-19 for June and is still absent from the API as of 2026-09-03; it gets the same price/quality test before any alias points at it. |
 | gemini-3.5-flash-lite | `lite` | $0.30 | $2.50 | 1M | **Cheap/bulk tier.** GA 2026-07-21. Fastest 3.5-class (350 output tok/sec); beats gemini-3-flash on SWE-Bench Pro and OSWorld-Verified. |
 | ~~gemini-2.5-flash~~ | `stable-flash` | $0.30 | $2.50 | 1M | **DEPRECATED** — 2025-era generation, do not route here. |
 | ~~gemini-2.5-flash-lite~~ | — | $0.10 | $0.40 | 1M | **DEPRECATED** — cheaper, but a 2025-era generation. `lite` now resolves to gemini-3.5-flash-lite. |

--- a/invoking-gemini/SKILL.md
+++ b/invoking-gemini/SKILL.md
@@ -2,7 +2,7 @@
 name: invoking-gemini
 description: Invokes Google Gemini models for structured outputs, image generation, multi-modal tasks, and Google-specific features. Use when users request Gemini, image generation, structured JSON output, Google API integration, or cost-effective parallel processing.
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Invoking Gemini
@@ -135,7 +135,7 @@ from gemini_client import invoke_gemini
 
 response = invoke_gemini(
     prompt="Explain quantum computing in 3 bullet points",
-    model="flash",  # gemini-3.6-flash (default)
+    model="flash",  # gemini-3.8-flash (default)
 )
 print(response)
 ```
@@ -194,23 +194,32 @@ results = invoke_parallel(
 
 ## Available Models
 
-The current frontier Flash is **gemini-3.6-flash** (GA 2026-07-21), the
-default and the `flash` alias. Prior-gen `gemini-3.5-flash` (GA May 2026)
-remains callable as `flash-3.5`. `gemini-3-flash-preview` and
-`gemini-3.1-flash-lite-preview` from earlier docs are out of date.
+The current frontier Flash is **gemini-3.8-flash** (GA 2026-09-02), the
+default and the `flash` alias. Google shipped three Flash generations in six
+weeks: 3.6 (2026-07-21), 3.7 (2026-08-13), 3.8 (2026-09-02). Each stays
+callable under a pinned alias (`flash-3.7`, `flash-3.6`, `flash-3.5`,
+`flash-3`), and none has a shutdown date. `gemini-3.1-flash-lite-preview` from
+earlier docs is gone (shut down 2026-05-25).
 
 ### Text / Reasoning Models
 
 | Model | Alias | Input/1M | Output/1M | Context | Notes |
 |-------|-------|----------|-----------|---------|-------|
-| gemini-3.6-flash | `flash` | $1.50 | $7.50 | 1M in / 64K out | **Default.** GA 2026-07-21. Current frontier Flash: ~17% fewer output tokens than 3.5 Flash, better coding/agentic (DeepSWE 49% vs 37%, OSWorld 83% vs 78%). Default `thinking_level=medium` — set `minimal` for non-reasoning tasks. Model card notes a slight tone regression vs 3.5. |
-| gemini-3.5-flash | `flash-3.5` | $1.50 | $9.00 | 1M | Prior frontier Flash (GA May 2026). Beats 3.1 Pro on most coding/agentic benchmarks. |
-| gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Older preview Flash, kept for back compat |
-| gemini-3.1-pro-preview | `pro` | $2.00 (≤200K) / $4.00 | $12.00 / $24.00 | 1M | Current Pro tier; 3.5 Pro slated for June 2026 |
+| gemini-3.8-flash | `flash` | $0.75 → $1.50 | $3.75 → $7.50 | 1M in / 64K out | **Default.** GA 2026-09-02. Current frontier Flash. Vs 3.7: Terminal-Bench 2.1 90.8% vs 81.6%, SWE-Bench Pro 61.6% vs 60.4%, SWE-Atlas 51.9% vs 48.0%, HLE flat (45.4% vs 45.7%). Google says it "works harder" at higher effort, so expect more thinking tokens per task. `thinking_level` is low/medium/high only — `minimal` returns HTTP 400 and the client downgrades it to `low`. Default `medium` spent 79 thinking tokens on a one-word reply (measured 2026-09-03); pass `low` for non-reasoning tasks. |
+| gemini-3.7-flash | `flash-3.7` | $0.75 → $1.50 | $3.75 → $7.50 | 1M / 64K | GA 2026-08-13. DeepSWE v1.1 65.3% vs 49.0% on 3.6, Terminal-Bench 2.1 85.8%. Same `minimal` restriction as 3.8. Google keeps it "fully supported for efficiency-first workloads". |
+| gemini-3.6-flash | `flash-3.6` | $0.75 → $1.50 | $3.75 → $7.50 | 1M / 64K | GA 2026-07-21. ~17% fewer output tokens than 3.5 Flash. Last Flash that accepts `thinking_level='minimal'` (verified 2026-09-03). |
+| gemini-3.5-flash | `flash-3.5` | $1.50 | $9.00 | 1M | GA 2026-05-19. Google's model list now labels it "legacy". Accepts `minimal`. Costs more on output than 3.6–3.8. |
+| gemini-3-flash-preview | `flash-3` | $0.30 | $2.50 | 1M | Older preview Flash, kept for back compat. Google's listed migration target for it is gemini-3.6-flash; no shutdown date. |
+| gemini-3.1-pro-preview | `pro` | $2.00 (≤200K) / $4.00 | $12.00 / $18.00 | 1M | Current Pro tier. 3.5 Pro was announced at I/O 2026-05-19 for June and is still absent from the API model list as of 2026-09-03. |
 | gemini-3.5-flash-lite | `lite` | $0.30 | $2.50 | 1M | **Cheap/bulk tier.** GA 2026-07-21. Fastest 3.5-class (350 output tok/sec); beats gemini-3-flash on SWE-Bench Pro and OSWorld-Verified. |
 | ~~gemini-2.5-flash~~ | `stable-flash` | $0.30 | $2.50 | 1M | **DEPRECATED** — 2025-era generation, do not route here. |
 | ~~gemini-2.5-flash-lite~~ | — | $0.10 | $0.40 | 1M | **DEPRECATED** — cheaper, but a 2025-era generation. `lite` now resolves to gemini-3.5-flash-lite. |
 | ~~gemini-2.5-pro~~ | `stable-pro` | $1.25 (≤200K) / $2.50 | $10.00 / $20.00 | 1M | **DEPRECATED** — 2025-era generation, do not route here. |
+
+`$0.75 → $1.50` means introductory pricing: Google's pricing page (fetched
+2026-09-03) lists 3.6, 3.7 and 3.8 Flash at $0.75 in / $3.75 out through
+2026-12-31 and $1.50 / $7.50 from 2027-01-01. Context caching is $0.075 → $0.15;
+Batch is half of standard. Output prices include thinking tokens.
 
 ### Image Models
 
@@ -225,11 +234,20 @@ See [references/models.md](references/models.md) for full details.
 
 Gemini 3.x models reason before responding. The parameter changed in
 2026: integer `thinking_budget` is gone; use string `thinking_level`
-∈ {`minimal`, `low`, `medium`, `high`}. Default for 3.5 Flash is
+∈ {`minimal`, `low`, `medium`, `high`}. Default for 3.5–3.8 Flash is
 `medium`. For transcription / classification / extraction tasks, pass
 `thinking_level='minimal'` or the model will silently spend output
 tokens on reasoning (symptom: empty response with
 `finishReason=MAX_TOKENS`).
+
+**3.7 and 3.8 Flash reject `minimal`** with HTTP 400 (`Thinking level MINIMAL
+is not supported for this model`); `low` is their floor. The client downgrades
+`minimal` to `low` on those two models and prints a note to stderr, so existing
+callers keep working. Measured on 3.8 (2026-09-03): `low` spent 0 thinking
+tokens on a one-word reply, the default `medium` spent 79. On 3.7, `low` still
+spent 45–88, and a `max_output_tokens=50` call at `low` hit MAX_TOKENS and
+returned None, so budget output generously there. If a job needs a true
+no-thinking pass, pin `flash-3.6` or `lite`, which still accept `minimal`.
 
 ```python
 response = invoke_gemini(
@@ -262,7 +280,7 @@ Common issues: Missing API key → see Setup. Rate limit → auto-retries with b
 ```python
 response = invoke_gemini(
     prompt="Write a haiku",
-    model="flash",                  # gemini-3.6-flash
+    model="flash",                  # gemini-3.8-flash
     temperature=0.9,
     max_output_tokens=200,
     top_p=0.95,

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -1,19 +1,108 @@
 # Gemini Models Reference
 
-Detailed information about available Gemini models (as of July 2026).
+Detailed information about available Gemini models (as of September 2026).
 
 ## Model Comparison
 
-### Gemini 3.6 — Frontier Flash (GA, current default)
+### Gemini 3.8 — Frontier Flash (GA, current default)
+
+#### gemini-3.8-flash
+
+**Status:** Generally available (released September 2, 2026)
+**Alias:** `flash` (the current default Flash)
+
+**Strengths:**
+- Google's "most intelligent Flash model", positioned for long-horizon
+  software engineering, autonomous agents, and multi-step enterprise work
+- Vs 3.7 Flash (Google's own numbers): Terminal-Bench 2.1 90.8% vs 81.6%,
+  SWE-Bench Pro 61.6% vs 60.4%, SWE-Atlas 51.9% vs 48.0%, τ³-bench Banking
+  38.1% vs 30.9%, CharXiv 86.2% vs 84.5%; HLE-Verified 54.9%
+- Humanity's Last Exam is flat (45.4% vs 45.7%) — the gains are agentic and
+  tool-use, not open-ended reasoning
+- Artificial Analysis Intelligence Index: 57 at `medium` (3.7 Flash 56,
+  3.6 Flash 52); ~310 output tok/sec
+- Prompt-injection robustness improved (Gray Swan); CBRN and cyber-offense
+  safeguards carried forward
+
+**Specifications:**
+- Context window: 1,048,576 tokens input / 65,536 tokens output
+- Multimodal input: text, image, video, audio, PDF; text output only
+- `thinking_level`: `low`, `medium` (default), `high`. **`minimal` is not
+  supported and returns HTTP 400** ("Thinking level MINIMAL is not supported
+  for this model", verified 2026-09-03). The client downgrades `minimal` to
+  `low` on this model.
+- Google's release note: the model "works harder" on complex tasks — extra
+  reasoning steps, iterative tool calls — so higher effort levels cost more
+  tokens. Measured 2026-09-03: `low` spent 0 thinking tokens on a one-word
+  reply; the default `medium` spent 79.
+- Supports caching, code execution, computer use (preview), file search,
+  function calling, Maps and Search grounding, structured outputs, URL
+  context, Batch / Flex / Priority inference. No audio generation, image
+  generation, or Live API.
+- Google's migration notes for the 3.x line: `thinking_budget` is gone
+  (use `thinking_level`); `temperature` / `top_p` / `top_k` /
+  `candidate_count` are deprecated sampling params on this model.
+
+**Best for:**
+- Default Flash / sub-agent-delegation choice for most tasks
+- Agentic coding loops, terminal automation, multi-file projects
+- Finance/legal agent workflows (Vals Finance Agent V2, Harvey's Legal
+  Agent Benchmark lead their Flash class)
+
+**Pricing:**
+- Input: $0.75 / 1M tokens through 2026-12-31; $1.50 from 2027-01-01
+- Output: $3.75 / 1M tokens through 2026-12-31; $7.50 from 2027-01-01
+  (includes thinking tokens)
+- Context caching $0.075 → $0.15; Batch 50% off
+- 1M context window at base price (no surcharge tier)
+
+Shipped alongside **`gemini-3.8-flash-cyber`** — vulnerability discovery and
+patching (>70% on Google's internal 20-language vuln benchmark, 47.2% pass@1
+on CWE-Bench patching). Access is limited to Google's Fairwind Program
+(government authorities, critical-infrastructure operators, software
+maintainers), so this client cannot alias it.
+
+---
+
+### Gemini 3.7 — Prior Frontier Flash (GA)
+
+#### gemini-3.7-flash
+
+**Status:** Generally available (released August 13, 2026)
+**Alias:** `flash-3.7` (was `flash` for three weeks until 3.8 shipped)
+
+**Strengths:**
+- The coding jump in the 3.x Flash line: DeepSWE v1.1 65.3% vs 49.0% on
+  3.6 Flash, FrontierCode 1.1 43.6% vs 34.4%, AutomationBench 30.4% vs
+  17.0%, WebDev Arena Elo 1588 vs 1538
+- Terminal-Bench 2.1 85.8%, OSWorld-2.0 47.9%, GDM-MRCR v2 (128k) 97.0%
+- Google keeps it "fully supported for efficiency-first workloads". Measured
+  2026-09-03 on a one-word prompt, though, `low` on 3.7 still spent 45–88
+  thinking tokens where `low` on 3.8 spent 0, and a `max_output_tokens=50`
+  call at `low` hit MAX_TOKENS. Budget output generously on this model.
+
+**Specifications:**
+- Context window: 1,048,576 tokens input / 65,536 tokens output
+- Multimodal input: text, image, video, audio, PDF
+- `thinking_level`: `low`, `medium` (default), `high`; **`minimal` returns
+  HTTP 400** (verified 2026-09-03), same as 3.8
+
+**Pricing:**
+- Same schedule as 3.8: $0.75 / $3.75 through 2026-12-31, then $1.50 / $7.50
+
+---
+
+### Gemini 3.6 — Older Flash (GA)
 
 #### gemini-3.6-flash
 
 **Status:** Generally available (released July 21, 2026)
-**Alias:** `flash` (the current default Flash)
+**Alias:** `flash-3.6` (was `flash` until 3.7 shipped)
 
 **Strengths:**
-- Current frontier Flash — builds on 3.5 Flash for coding, knowledge work,
-  and multimodal tasks
+- Builds on 3.5 Flash for coding, knowledge work, and multimodal tasks
+- The last Flash that accepts `thinking_level='minimal'` (verified
+  2026-09-03) — pin here for true no-thinking transcription/extraction
 - ~17% fewer output tokens than 3.5 Flash on the Artificial Analysis index
   (the headline efficiency win — addresses 3.5's verbosity)
 - Quality gains alongside efficiency: DeepSWE 49% vs 37%, MLE-Bench 63.9%
@@ -31,13 +120,13 @@ Detailed information about available Gemini models (as of July 2026).
   notes a slight tone regression vs 3.5 Flash
 
 **Best for:**
-- Default Flash / sub-agent-delegation choice for most tasks
-- Agentic coding loops, terminal automation, multi-file projects
+- Pinning prior-gen behavior, and `minimal`-thinking bulk work
 - Cost-sensitive high-volume agentic work (cheaper output than 3.5)
 
 **Pricing:**
-- Input: $1.50 / 1M tokens
-- Output: $7.50 / 1M tokens (down from 3.5 Flash's $9.00)
+- Same schedule as 3.7 and 3.8 on Google's pricing page (fetched
+  2026-09-03): $0.75 / $3.75 through 2026-12-31, then $1.50 / $7.50. The
+  July table here said $1.50 / $7.50 flat; the intro rate now covers all three.
 - 1M context window at base price (no surcharge tier)
 
 Shipped alongside two sibling models, neither wired into this client's alias
@@ -55,11 +144,12 @@ table:
 
 ---
 
-### Gemini 3.5 — Prior Frontier Flash (GA)
+### Gemini 3.5 — Legacy Flash (GA)
 
 #### gemini-3.5-flash
 
-**Status:** Generally available (released May 19, 2026 at Google I/O)
+**Status:** Generally available (released May 19, 2026 at Google I/O);
+Google's model list now labels it "legacy". No shutdown date.
 **Alias:** `flash-3.5` (was `flash` until 3.6 shipped)
 
 **Strengths:**
@@ -78,7 +168,7 @@ table:
   the model will silently spend output tokens on reasoning)
 
 **Best for:**
-- Pinning to prior-gen Flash behavior when 3.6 output differs
+- Pinning to prior-gen Flash behavior when 3.6–3.8 output differs
 - Agentic coding loops, terminal automation, multi-file projects
 - Multimodal document analysis where structure must be preserved
 
@@ -97,8 +187,9 @@ table:
 **Alias:** `flash-3`
 
 The previous-generation Flash. Use when you need to pin behavior
-established before the 3.5 cutover. New code should target `flash`
-(gemini-3.5-flash) instead.
+established before the 3.5 cutover. Google's deprecation page lists
+gemini-3.6-flash as its replacement, with no shutdown date. New code should
+target `flash` (gemini-3.8-flash) instead.
 
 **Pricing:**
 - Input: $0.30 / 1M tokens
@@ -106,7 +197,8 @@ established before the 3.5 cutover. New code should target `flash`
 
 #### gemini-3.1-pro-preview
 
-**Status:** Preview (Pro-tier upgrade pending — 3.5 Pro slated for June 2026)
+**Status:** Preview (Pro-tier upgrade pending — 3.5 Pro was announced for
+June 2026 and has not shipped)
 **Alias:** `pro`
 
 **Strengths:**
@@ -126,10 +218,13 @@ established before the 3.5 cutover. New code should target `flash`
 
 **Pricing:**
 - Input: $2.00 / 1M tokens (≤200K), $4.00 (>200K)
-- Output: $12.00 / 1M tokens (≤200K), $24.00 (>200K)
+- Output: $12.00 / 1M tokens (≤200K), $18.00 (>200K) — the July table here
+  said $24.00; Google's pricing page says $18.00 (fetched 2026-09-03)
 
-**Note:** Google has signaled `gemini-3.5-pro` rolling out in June 2026.
-When it ships, `pro` alias will likely repoint there.
+**Note:** Google announced `gemini-3.5-pro` at I/O on 2026-05-19 for June.
+As of 2026-09-03 it is not in the API model list or on the pricing page;
+DeepMind still lists it as "coming soon". When it ships, `pro` will likely
+repoint there.
 
 ---
 
@@ -278,10 +373,12 @@ with up to 3 input images.
 ## Model Selection Guide
 
 ```
-Default Flash (frontier)?              → gemini-3.6-flash (alias: flash)
+Default Flash (frontier)?              → gemini-3.8-flash (alias: flash)
 Maximum reasoning?                     → gemini-3.1-pro-preview (alias: pro)
 Routine / bulk / cheap / fastest?      → gemini-3.5-flash-lite (alias: lite)
-Pin to prior frontier Flash (3.5)?     → gemini-3.5-flash (alias: flash-3.5)
+No-thinking pass (minimal) on Flash?   → gemini-3.6-flash (alias: flash-3.6)
+Pin to prior frontier Flash (3.7)?     → gemini-3.7-flash (alias: flash-3.7)
+Pin to legacy Flash (3.5)?             → gemini-3.5-flash (alias: flash-3.5)
 Pin to older preview Flash?            → gemini-3-flash-preview (alias: flash-3)
 Image generation (fast)?               → nano-banana-2 (alias: image)
 Image generation (high-fidelity)?      → nano-banana-pro (alias: image-pro)
@@ -290,12 +387,22 @@ Image generation (high-fidelity)?      → nano-banana-pro (alias: image-pro)
 ## Thinking Configuration (Gemini 3.x family)
 
 Gemini 3.x models reason before responding. By default, the model spends
-output tokens on reasoning, then on the visible answer. For Gemini 3.5
-Flash specifically, the default is `medium` — down from `high` on prior
-3.x — and the parameter shape changed:
+output tokens on reasoning, then on the visible answer. From Gemini 3.5
+Flash on, the default is `medium` — down from `high` on prior 3.x — and the
+parameter shape changed:
 
 - **Old:** integer `thinking_budget`
 - **New:** string enum `thinking_level` ∈ {`minimal`, `low`, `medium`, `high`}
+
+Which models take `minimal` (all verified live 2026-09-03):
+
+| Model | `minimal` |
+|---|---|
+| gemini-3.8-flash | HTTP 400 — client downgrades to `low` |
+| gemini-3.7-flash | HTTP 400 — client downgrades to `low` |
+| gemini-3.6-flash | accepted |
+| gemini-3.5-flash | accepted |
+| gemini-3.5-flash-lite | accepted |
 
 The Python client exposes this as `invoke_gemini(..., thinking_level="...")`.
 Pass `None` (default) to let the model use its built-in default.
@@ -311,7 +418,7 @@ Pass `None` (default) to let the model use its built-in default.
 - Math, complex analysis
 
 **Why it matters:** A `max_output_tokens=50` request can return empty if
-thinking_level (default `medium` on 3.5) consumes all 50 tokens before
+thinking_level (default `medium` on 3.5–3.8) consumes all 50 tokens before
 emitting visible output. Symptom: response text is empty, `finishReason`
 is `MAX_TOKENS`. Fix: either raise `max_output_tokens` substantially or
 set `thinking_level='minimal'`.
@@ -331,9 +438,15 @@ on Flash-tier models.
 | Model | Status | Migration Target |
 |---|---|---|
 | gemini-3-pro-preview | Retired (March 9, 2026) | gemini-3.1-pro-preview |
-| gemini-2.0-flash-exp | Retiring June 1, 2026 | gemini-3.6-flash |
-| gemini-2.0-flash | Retiring June 1, 2026 | gemini-3.6-flash |
-| gemini-2.0-flash-lite | Retiring June 1, 2026 | gemini-3.5-flash-lite |
+| gemini-3-flash-preview | Callable, no shutdown date | gemini-3.6-flash (Google's listed target) |
+| gemini-3.1-flash-lite-preview | Retired (May 25, 2026) | gemini-3.1-flash-lite |
+| gemini-3.1-flash-lite | Shutdown May 7, 2027 | gemini-3.5-flash-lite |
+| gemini-3.1-flash-image-preview | Shutdown listed June 25, 2026 (still resolves) | gemini-3.1-flash-image |
+| gemini-3-pro-image-preview | Shutdown listed June 25, 2026 (still resolves) | gemini-3-pro-image |
+| gemini-2.5-flash-image (`nano-banana`) | Shutdown October 2, 2026 | gemini-3.1-flash-image |
+| gemini-2.0-flash-exp | Retired June 1, 2026 | gemini-3.6-flash |
+| gemini-2.0-flash | Retired June 1, 2026 | gemini-3.6-flash |
+| gemini-2.0-flash-lite | Retired June 1, 2026 | gemini-3.5-flash-lite |
 | gemini-1.5-pro | Retired (404) | gemini-2.5-pro |
 | gemini-1.5-flash | Retired (404) | gemini-3.6-flash |
 | gemini-1.0-* | Retired (404) | — |

--- a/invoking-gemini/references/models.md
+++ b/invoking-gemini/references/models.md
@@ -197,13 +197,16 @@ target `flash` (gemini-3.8-flash) instead.
 
 #### gemini-3.1-pro-preview
 
-**Status:** Preview (Pro-tier upgrade pending — 3.5 Pro was announced for
-June 2026 and has not shipped)
-**Alias:** `pro`
+**Status:** Preview. **DEPRECATED from routing 2026-09-03** (Oskar): "its
+Pareto efficiency is too poor compared to the later Flash models." At today's
+rates it costs 2.7× the input and 3.2× the output of 3.8 Flash (1.3× / 1.6× once
+the Flash intro pricing ends), and 3.5 Flash already beat it on most coding and
+agentic benchmarks. The ID stays callable for pinned code.
+**Alias:** none — `pro` now resolves to gemini-3.8-flash. For maximum
+reasoning use Flash with `thinking_level='high'`.
 
 **Strengths:**
-- Most capable Gemini Pro currently in API
-- Advanced intelligence and complex problem-solving
+- Was the most capable Gemini Pro in the API
 - 1M context with tiered pricing above 200K
 
 **Specifications:**
@@ -212,9 +215,7 @@ June 2026 and has not shipped)
 - Multimodal: text, image, video, audio
 
 **Best for:**
-- Complex analysis requiring deep reasoning
-- Tasks where Pro-tier judgment matters more than cost
-- Cases where Flash output isn't quite enough
+- Nothing in new code. Pinned callers only.
 
 **Pricing:**
 - Input: $2.00 / 1M tokens (≤200K), $4.00 (>200K)
@@ -223,8 +224,8 @@ June 2026 and has not shipped)
 
 **Note:** Google announced `gemini-3.5-pro` at I/O on 2026-05-19 for June.
 As of 2026-09-03 it is not in the API model list or on the pricing page;
-DeepMind still lists it as "coming soon". When it ships, `pro` will likely
-repoint there.
+DeepMind still lists it as "coming soon". When it ships it gets the same
+price/quality test against the current Flash before any alias points at it.
 
 ---
 
@@ -374,7 +375,8 @@ with up to 3 input images.
 
 ```
 Default Flash (frontier)?              → gemini-3.8-flash (alias: flash)
-Maximum reasoning?                     → gemini-3.1-pro-preview (alias: pro)
+Maximum reasoning?                     → gemini-3.8-flash, thinking_level='high' (alias: pro)
+Pro tier?                              → off routing since 2026-09-03; see gemini-3.1-pro-preview
 Routine / bulk / cheap / fastest?      → gemini-3.5-flash-lite (alias: lite)
 No-thinking pass (minimal) on Flash?   → gemini-3.6-flash (alias: flash-3.6)
 Pin to prior frontier Flash (3.7)?     → gemini-3.7-flash (alias: flash-3.7)

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -13,6 +13,7 @@ Credential priority:
 
 import json
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -48,7 +49,11 @@ if not HAS_REQUESTS and not HAS_GENAI:
 
 # Text generation models
 MODELS = {
-    # Gemini 3.6 — current frontier Flash (GA 2026-07-21)
+    # Gemini 3.8 — current frontier Flash (GA 2026-09-02)
+    "gemini-3.8-flash": "gemini-3.8-flash",
+    # Gemini 3.7 — prior frontier Flash (GA 2026-08-13)
+    "gemini-3.7-flash": "gemini-3.7-flash",
+    # Gemini 3.6 — older Flash (GA 2026-07-21)
     "gemini-3.6-flash": "gemini-3.6-flash",
     # Gemini 3.5 — prior frontier Flash (GA May 2026)
     "gemini-3.5-flash": "gemini-3.5-flash",
@@ -77,13 +82,16 @@ IMAGE_MODELS = {
     "nano-banana": "gemini-2.5-flash-image",
 }
 
-# Convenience aliases. `flash` points to the current frontier Flash (3.6, GA
-# 2026-07-21); `flash-3.5` and `flash-3` keep stable handles on the prior Flash
-# generations for code that pinned to them. `lite` repointed 2026-07-21 from
-# gemini-2.5-flash-lite to gemini-3.5-flash-lite (BREAKING: ~6x output cost,
-# $0.40 -> $2.50/M, in exchange for a current-generation model).
+# Convenience aliases. `flash` points to the current frontier Flash (3.8, GA
+# 2026-09-02); `flash-3.7`, `flash-3.6`, `flash-3.5` and `flash-3` keep stable
+# handles on the prior Flash generations for code that pinned to them. `lite`
+# repointed 2026-07-21 from gemini-2.5-flash-lite to gemini-3.5-flash-lite
+# (BREAKING: ~6x output cost, $0.40 -> $2.50/M, in exchange for a
+# current-generation model).
 MODEL_ALIASES = {
-    "flash": "gemini-3.6-flash",
+    "flash": "gemini-3.8-flash",
+    "flash-3.7": "gemini-3.7-flash",
+    "flash-3.6": "gemini-3.6-flash",
     "flash-3.5": "gemini-3.5-flash",
     "flash-3": "gemini-3-flash-preview",
     "pro": "gemini-3.1-pro-preview",
@@ -95,7 +103,12 @@ MODEL_ALIASES = {
     "image-pro": "nano-banana-pro",
 }
 
-DEFAULT_MODEL = "gemini-3.6-flash"
+DEFAULT_MODEL = "gemini-3.8-flash"
+
+# Flash 3.7 and 3.8 reject thinking_level='minimal' with HTTP 400 ("Thinking
+# level MINIMAL is not supported for this model"); 3.6, 3.5 and 3.5-lite accept
+# it. All five verified live through the CF gateway on 2026-09-03.
+_MINIMAL_THINKING_UNSUPPORTED = frozenset({"gemini-3.7-flash", "gemini-3.8-flash"})
 
 # ---------------------------------------------------------------------------
 # Cloudflare AI Gateway constants
@@ -567,9 +580,12 @@ def invoke_gemini(
         thinking_level: Reasoning budget for thinking models (Gemini 3.x).
             One of 'minimal', 'low', 'medium', 'high'. Default (None) lets
             the model use its built-in default — 'medium' for 3.x Flash
-            (incl. 3.6), which silently eats output budget. Set 'minimal' for tasks that
+            (incl. 3.8), which silently eats output budget. Set 'minimal' for tasks that
             don't need reasoning (transcription, classification, extraction).
-            Ignored by 2.5 models (which use a different parameter).
+            Flash 3.7 and 3.8 do not accept 'minimal' (HTTP 400); on those the
+            client downgrades it to 'low', the cheapest level they take, and
+            says so on stderr. Ignored by 2.5 models (which use a different
+            parameter).
 
     Returns:
         Response text if successful, None if error
@@ -581,6 +597,12 @@ def invoke_gemini(
     # Silently drop for non-3.x so callers can pass it uniformly without branching.
     if thinking_level is not None and not model_id.startswith("gemini-3"):
         thinking_level = None
+    if thinking_level == "minimal" and model_id in _MINIMAL_THINKING_UNSUPPORTED:
+        print(
+            f"Note: {model_id} does not support thinking_level='minimal'; using 'low'.",
+            file=sys.stderr,
+        )
+        thinking_level = "low"
 
     max_retries = 3
     for attempt in range(max_retries):
@@ -806,7 +828,7 @@ def invoke_with_structured_output(
     Args:
         prompt: The text prompt to send
         pydantic_model: Pydantic model class for response schema
-        model: Model name or alias (default: gemini-3-flash-preview).
+        model: Model name or alias (default: DEFAULT_MODEL, gemini-3.8-flash).
             Aliases: flash, pro, lite, stable-flash, stable-pro
         temperature: Sampling temperature (0.0–1.0)
         image_path: Optional path to a media file for multi-modal input.
@@ -892,7 +914,7 @@ def invoke_parallel(
 
     Args:
         prompts: List of text prompts to process
-        model: Model name or alias (default: gemini-3-flash-preview).
+        model: Model name or alias (default: DEFAULT_MODEL, gemini-3.8-flash).
             Aliases: flash, pro, lite, stable-flash, stable-pro
         temperature: Sampling temperature (0.0–1.0)
         max_workers: Maximum concurrent requests

--- a/invoking-gemini/scripts/gemini_client.py
+++ b/invoking-gemini/scripts/gemini_client.py
@@ -59,6 +59,9 @@ MODELS = {
     "gemini-3.5-flash": "gemini-3.5-flash",
     # Gemini 3.x — preview (still callable, kept for back compat)
     "gemini-3-flash-preview": "gemini-3-flash-preview",
+    # Gemini 3.1 Pro — DEPRECATED from routing 2026-09-03 (Oskar): its
+    # price/quality is dominated by the 3.6+ Flash line. ID kept callable for
+    # pinned code; `pro` no longer points here.
     "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
     # Gemini 3.5 Flash-Lite — cheap/bulk tier (GA 2026-07-21)
     "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
@@ -94,7 +97,10 @@ MODEL_ALIASES = {
     "flash-3.6": "gemini-3.6-flash",
     "flash-3.5": "gemini-3.5-flash",
     "flash-3": "gemini-3-flash-preview",
-    "pro": "gemini-3.1-pro-preview",
+    # `pro` repointed 2026-09-03 from gemini-3.1-pro-preview to the frontier
+    # Flash. The Pro tier is off routing (price/quality dominated by Flash);
+    # "maximum reasoning" is Flash with thinking_level='high'.
+    "pro": "gemini-3.8-flash",
     "lite": "gemini-3.5-flash-lite",
     # DEPRECATED aliases (Gemini 2.5). Retained for back compat only.
     "stable-flash": "gemini-2.5-flash",


### PR DESCRIPTION
Gemini 3.8 Flash went GA on 2026-09-02. This PR makes it the `flash` alias and `DEFAULT_MODEL`, adds the 3.7 Flash release (2026-08-13) that the table had missed, takes the Pro tier off routing, and rechecks the SKILL.md and models.md tables against Google's model, pricing and deprecation pages. All three were fetched 2026-09-03.

## Changes

- `MODELS` gains gemini-3.8-flash and gemini-3.7-flash. New pinned aliases `flash-3.7` and `flash-3.6`. Nothing is removed; no 3.x Flash has a shutdown date.
- **Pro tier off routing.** Oskar, 2026-09-03: "We should never use 3.1 Pro, its Pareto efficiency is too poor compared to the later Flash models." `gemini-3.1-pro-preview` costs 2.7× / 3.2× (in / out) what 3.8 Flash does at today's rates, and 3.5 Flash already beat it on most coding and agentic benchmarks. The ID stays in `MODELS` for pinned callers and the tables mark it DEPRECATED; the `pro` alias now resolves to gemini-3.8-flash, and "maximum reasoning" is Flash at `thinking_level='high'`. A future 3.5 Pro gets the same test before any alias points at it.
- 3.7 and 3.8 Flash return HTTP 400 on `thinking_level='minimal'`. `invoke_gemini()` now downgrades `minimal` to `low` on those two IDs and prints a one-line note to stderr, so callers that pass `minimal` uniformly (transcription, classification) keep working on the new default instead of burning a non-retriable 400 and getting `None`.
- Table fixes: 3.1 Pro output above 200K is $18.00, not $24.00. 3.6 Flash is on the same $0.75 / $3.75 introductory schedule as 3.7 and 3.8 (standard $1.50 / $7.50 from 2027-01-01). 3.5 Pro has still not shipped. The deprecation table gains the 3.x preview rows and the 2026-10-02 shutdown of gemini-2.5-flash-image, which the `nano-banana` alias targets.
- Two docstrings still named gemini-3-flash-preview as the default.
- `metadata.version` 0.7.1 → 0.8.0 (default-model swap is a minor bump per the release convention).

## Verified

Live through the CF gateway on 2026-09-03:

- `minimal` returns 400 on 3.7 and 3.8; accepted on 3.6, 3.5 and 3.5-lite.
- `invoke_gemini("...", model="flash", thinking_level="minimal")` returns `'OK'` after the downgrade.
- On 3.8, `low` spent 0 thinking tokens on a one-word prompt and the default `medium` spent 79. On 3.7, `low` still spent 45–88, and a `max_output_tokens=50` call at `low` hit MAX_TOKENS and returned None. The docs say so.
- `_resolve_model('pro')` → gemini-3.8-flash; the full 3.1 Pro ID still resolves.
- `uvx ruff@0.16.0 check gemini_client.py` is clean.

## Not in this PR

- `orchestrating-agents/SKILL.md` still tells callers to pass `gemini-3.6-flash` explicitly, and `declauding/scripts/declaude_review.py` hardcodes the same ID. `challenging/scripts/challenger.py` hardcodes `gemini-3.1-pro-preview` in two URLs. Separate skills, separate PRs.
- Image model IDs stay on `-preview`; models.md already notes the GA IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAUH6VipHhm8jriqj7mYvM