### PR TITLE
challenging: run the Gemini adversary on 3.8 Flash at thinking high, not 3.1 Pro

### DIFF
--- a/challenging/README.md
+++ b/challenging/README.md
@@ -16,7 +16,7 @@ See [`SKILL.md`](SKILL.md) for the full protocol, profile table, system prompts,
 | Environment | Adversary | How it works | Cost |
 |---|---|---|---|
 | **Claude Code** (primary) | Native sub-Claude via the Task tool | `prepare()` → Task tool → `parse_response()`. Fresh context, same model. | Free |
-| **claude.ai, Codex, headless** with API creds | Gemini 3.1 Pro or Anthropic API | `challenge(adversary='auto')` resolves gemini > claude. Cross-context; gemini is cross-model. | Incremental API call |
+| **claude.ai, Codex, headless** with API creds | Gemini 3.8 Flash (thinking high) or Anthropic API | `challenge(adversary='auto')` resolves gemini > claude. Cross-context; gemini is cross-model. | Incremental API call |
 | **Any environment** | Caller assistant in adversary persona | `prepare_self()` → caller produces JSON in a dedicated response → `parse_response()`. Retains conversation context; explicit persona switch is the discipline. | Free |
 
 `adversary='auto'` (the default for `challenge()`) ladders gemini → claude → self based on credentials. Claude Code callers stay on `prepare()` + Task tool explicitly — subagent is strictly better than self there, and auto-detecting Claude Code is brittle.

--- a/challenging/SKILL.md
+++ b/challenging/SKILL.md
@@ -2,7 +2,7 @@
 name: challenging
 description: Cross-context adversarial review for deliverables before shipping. Use when producing blog posts, technical recommendations, analysis briefs, code, or any artifact where accuracy matters more than speed. Triggers on "challenge this", "review before shipping", "adversarial pass", "stress test this".
 metadata:
-  version: 0.11.0
+  version: 0.12.0
 ---
 
 # Challenging — Adversarial Review
@@ -139,7 +139,7 @@ result = challenge(
 
 `adversary` accepts:
 - **`auto`** (default) — resolves to gemini > claude > self based on available credentials. Logs the choice.
-- **`gemini`** — Gemini 3.1 Pro. Cross-model + cross-context. Requires Gemini credentials.
+- **`gemini`** — Gemini 3.8 Flash at `thinking_level='high'`. Cross-model + cross-context. Requires Gemini credentials. (Was 3.1 Pro until 2026-09-03; the Pro tier is off routing, its price/quality is dominated by the later Flash models.)
 - **`claude`** — Anthropic API. Cross-context, same model family. **Do not use this in Claude Code** — use the subagent path instead.
 - **`self`** — NOT runnable via `challenge()` (raises with a pointer to `prepare_self()`). Self-challenge requires the caller assistant to produce the adversary response, which a synchronous function cannot do.
 

--- a/challenging/scripts/challenger.py
+++ b/challenging/scripts/challenger.py
@@ -156,6 +156,13 @@ def _load_env_file(name: str) -> dict:
     return {}
 
 
+# Adversary model. Was gemini-3.1-pro-preview until 2026-09-03; the Pro tier is
+# off routing (Oskar: its price/quality is dominated by the later Flash models).
+# Maximum reasoning on Flash is thinking_level='high', set in _gemini_raw.
+GEMINI_MODEL = 'gemini-3.8-flash'
+GEMINI_THINKING_LEVEL = 'high'
+
+
 def _get_gemini_config() -> tuple:
     """Returns (url, headers) for Gemini API — gateway or direct."""
     # Try Cloudflare AI Gateway first
@@ -164,13 +171,13 @@ def _get_gemini_config() -> tuple:
     gw = os.environ.get('CF_GATEWAY_ID') or proxy.get('CF_GATEWAY_ID')
     token = os.environ.get('CF_API_TOKEN') or proxy.get('CF_API_TOKEN')
     if acct and gw and token:
-        url = f'https://gateway.ai.cloudflare.com/v1/{acct}/{gw}/google-ai-studio/v1beta/models/gemini-3.1-pro-preview:generateContent'
+        url = f'https://gateway.ai.cloudflare.com/v1/{acct}/{gw}/google-ai-studio/v1beta/models/{GEMINI_MODEL}:generateContent'
         return url, {'Content-Type': 'application/json', 'cf-aig-authorization': f'Bearer {token}'}
 
     # Direct Google API
     key = os.environ.get('GOOGLE_API_KEY')
     if key:
-        url = f'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key={key}'
+        url = f'https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent?key={key}'
         return url, {'Content-Type': 'application/json'}
 
     raise ValueError('No Gemini credentials found. Set CF_ACCOUNT_ID/CF_GATEWAY_ID/CF_API_TOKEN or GOOGLE_API_KEY.')
@@ -310,6 +317,7 @@ def _gemini_raw(user_prompt: str, system_prompt: str) -> dict:
     body = {
         'system_instruction': {'parts': [{'text': system_prompt}]},
         'contents': [{'role': 'user', 'parts': [{'text': user_prompt}]}],
+        'generationConfig': {'thinkingConfig': {'thinkingLevel': GEMINI_THINKING_LEVEL}},
     }
     resp = requests.post(url, headers=headers, json=body, timeout=120)
     resp.raise_for_status()
@@ -327,7 +335,8 @@ def _gemini_raw(user_prompt: str, system_prompt: str) -> dict:
             f"Thinking tokens may have consumed the budget. "
             f"Usage: {json.dumps(usage)}"
         )
-    text = parts[0].get('text', '')
+    # Join every non-thought text part; thinking models can return more than one.
+    text = ''.join(p.get('text', '') for p in parts if not p.get('thought'))
     return _parse(text)
 
 


### PR DESCRIPTION
Companion to #783. `challenger.py` hardcoded `gemini-3.1-pro-preview` in both request URLs, so the adversary pass kept running on Pro after the `pro` alias moved. Oskar, 2026-09-03: never use 3.1 Pro; its price/quality is dominated by the later Flash models.

## Changes

- Both URLs read a module constant `GEMINI_MODEL = 'gemini-3.8-flash'`. The request body now sets `thinkingLevel: high`, the Flash substitute for Pro-tier reasoning.
- `_gemini_raw()` joins every non-thought text part instead of reading `parts[0]`; thinking models can return more than one.
- SKILL.md and README name the adversary model. `metadata.version` 0.11.0 → 0.12.0.
- CHANGELOG.md is left alone; the release workflow generates it from the commit message.

## Verified

Live through the CF gateway, 2026-09-03: `_gemini_raw()` with the `code` profile on a three-line `mean()` helper came back in 8.7s with verdict REVISE and two findings (division by zero on an empty list, missing input validation). `uvx ruff@0.16.0 check challenger.py` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAUH6VipHhm8jriqj7mYvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAUH6VipHhm8jriqj7mYvM)_