### PR TITLE
agent-routing 2.1.0: measured cascade rungs, escalation signal, tier gap

### DIFF
--- a/agent-routing/CHANGELOG.md
+++ b/agent-routing/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `agent-routing` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.1.0] - 2026-09-03
+
+Measured against a 14-repo seeded-bug agentic battery (~120 subagent runs;
+`oaustegard/experiments` -> `temporal-routing-headroom`). Nothing was retracted; the
+cascade section gained the numbers it was missing.
+
+### Added
+
+- The escalation call belongs to whoever holds the verifier, never the worker. 58 of 58
+  graded runs self-reported success; 44 had passed. Every failure claimed to be done.
+- Rung 2 is the same model one effort step up; a tier jump is the exception. From an
+  identical failed attempt, `sonnet` @ `medium` and `opus` @ `high` rescued the same 4 of
+  5 tasks at 11,691 vs 32,504 output tokens (0.31x vs 0.76x always-`opus` composed).
+- A cascade can beat the frontier solo arm on correctness: 13/14 vs 10/14.
+- Caching in the cascade: caches are model-scoped with no escape hatch, so a tier jump
+  discards rung 1's prefix; an `effort` change invalidates the messages cache on every
+  model, and the per-message effort hatch is Opus 5 / Fable 5.1 / Mythos 5.1 only.
+- Informed retry means the artifacts, not the prior model's narrative: adding rung 1's
+  stated diagnosis moved 12/15 to 13/15 on one replicate of one unstable task.
+- Concision does not reach small-output work: 2.9% on agentic repair vs 37% on generation.
+- Route up for capability, not thoroughness: `opus` @ `high` fell into the same
+  stop-early trap as `sonnet` @ `low` on three of four tasks.
+- Seeded-bug repair in a small module is measured as not tier-separating across three
+  probe shapes.
+
+### Changed
+
+- Cost-model caveat made explicit: every figure prices output tokens only.
+
 ## [2.0.0] - 2026-08-18
 
 ### Added

--- a/agent-routing/SKILL.md
+++ b/agent-routing/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agent-routing
-description: Decide which model, effort level, and cascade shape each subagent gets, and how to keep improvement loops safe (evaluator-as-selector, stop on regression). Routes on measured cost-per-completed-task rather than per-token price, because a tier's token count varies more by task shape than price varies across tiers. Covers per-model effort semantics, the concision lever, cascade preconditions, context handoff, and watching a subagent fan-out live. Use when spawning subagents via the Agent or Workflow tools, when fanning out more than a handful of agents, or when asked which model or effort a task should get. Grounded in measured calibration (references/calibration-2026-07-15.md) plus a 2026-08 coding-cost study; Managed Agents API specifics are operational, not calibrated.
+description: Decide which model, effort level, and cascade shape each subagent gets, and how to keep improvement loops safe (evaluator-as-selector, stop on regression). Routes on measured cost-per-completed-task rather than per-token price, because a tier's token count varies more by task shape than price varies across tiers. Covers per-model effort semantics, the concision lever, cascade preconditions, context handoff, and watching a subagent fan-out live. Use when spawning subagents via the Agent or Workflow tools, when fanning out more than a handful of agents, or when asked which model or effort a task should get. Grounded in measured calibration (references/calibration-2026-07-15.md), a 2026-08 coding-cost study, and a 2026-09 agentic-repair battery that measured the cascade rungs directly; Managed Agents API specifics are operational, not calibrated.
 compatibility: Designed for Claude Code / Claude Code on the Web — assumes an orchestrator with Agent/Workflow subagent tools exposing per-call model and effort options. Not applicable to claude.ai chat use.
 metadata:
   author: Oskar Austegard and Claude
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Agent Routing — model, effort, and cascade selection
@@ -103,6 +103,12 @@ enumerate test cases or weigh alternative designs; write it directly* — cut ou
 **37% on Sonnet** and **27% on Haiku**, at no quality cost. It composes with effort.
 Use it on every long-output generation spawn.
 
+**It does not reach work whose output is small.** On agentic bug repair — a patch plus a
+paragraph — the same instruction cut Sonnet output **2.9%**, at no quality change either
+way. The lever acts on deliberation the model would have written down, so a task that
+emits little has little to cut. Measure before carrying it to a new task family; "every
+long-output generation spawn" is the scope, and repair work is not in it.
+
 **Then stop.** Thinking below a model's natural level is load-bearing, and cutting
 into it buys tokens with correctness:
 
@@ -130,6 +136,14 @@ cost 2× the destination's entire job. Compute this before designing the ladder.
 **Second precondition: no verifier ⇒ no cascade.** Route by the table instead;
 silent cheap-tier errors compound with nothing to catch them.
 
+**The verifier's holder makes the escalation call. Never the worker.** A subagent asked
+whether it finished says yes: across 58 graded runs carrying an explicit "did you finish"
+field, 58 said yes and 44 had passed the held-out suite. Every one of the 14 failures
+self-reported success. The workers were not lying — they had passed the tests they could
+see, and those tests stay satisfiable while the task is unfinished. "Try it, and ask for
+help if you fail" therefore fails on exactly the tasks that need escalation. Put the
+decision wherever the stronger check lives; in a fan-out that is the orchestrator.
+
 The shape that worked (measured, 14/14 at 0.41× Opus):
 
 ```
@@ -139,14 +153,39 @@ if verify(result) fails:
                     prior=result, failure=test_output)
 ```
 
-Rungs can be **the same model at different effort** — often better than a tier jump,
-because it keeps rung 1 genuinely cheap.
+**Rung 2 is the same model one effort step up. A tier jump is the exception you justify.**
+Measured twice. On a second battery (14 seeded-bug repos, 2026-09-03) rung 2 ran from an
+identical failed attempt at both settings: `sonnet` @ `medium` and `opus` @ `high` rescued
+the same 4 of 5 tasks and both missed the same fifth, at 11,691 against 32,504 output
+tokens. Composed over the same rung 1, the same-model cascade cost **0.31×** always-`opus`
+and the tier jump **0.76×**. The tier jump costs 2.5× and buys nothing.
+
+**A cascade can beat the frontier solo arm on correctness, not only on cost.** In that run
+the `sonnet`→`sonnet` cascade solved 13/14 where always-`opus` solved 10/14. `opus`
+starting from the issue text fell into the same stop-early trap as `sonnet` on three
+tasks; `opus` starting from the failed patch and the failing assertions fixed all three.
+
+**Caching pushes the same way.** Caches are model-scoped with no escape hatch, so a tier
+jump discards rung 1's prefix while a same-model rung keeps at least the tools and system
+tiers. An `effort` change still invalidates the messages cache on every model, and the
+per-message effort escape hatch (`{"role": "system", "content": [], "output_config":
+{"effort": …}}`, beta `mid-conversation-output-config-2026-07-01`) is
+Opus 5 / Fable 5.1 / Mythos 5.1 only — not Sonnet 5. The real bill gap is therefore wider
+than the output-token ratio above. Every figure in this skill prices output tokens only;
+input and cache effects sit outside its cost model.
 
 **Carry the prior attempt and the raw failure output into the retry.** Informed retry
 fixed **12/12**; a blind re-attempt fixed **9/12** and failed one task *identically
 across all three replicates* — a systematic blind spot re-rolling never escapes. The
 extra input averaged 866 tokens, **5.9%** of the retry's cost. Input is 1/5 the price
 of output, so context is nearly free relative to thinking.
+
+**The artifacts, not the prior model's account of itself.** Adding rung 1's stated
+diagnosis on top of the patch and the assertions did nothing: 13/15 against 12/15 over
+three replicates, 1% fewer output tokens, and the whole difference was one replicate of
+one unstable task. It does not help and it does not anchor — SWE-Router (arXiv
+2607.00053) restarts its strong model from the task description to avoid an anchoring
+effect that is not there. Pass the diff and the test output; skip the rationale.
 
 **Don't pay a frontier model to write guidance.** An Opus diagnosis added zero over
 raw test output in two independent tests, at ~$0.15/task. The failing test already
@@ -221,7 +260,10 @@ iteration 2 and froze on the broken text for every iteration after.
 
 ## Escalation triggers (route up despite the table)
 
-- The verifier fails twice at the same tier.
+- The verifier fails twice at the same tier. **Route up for capability, not for
+  thoroughness** — `opus` @ `high` fell into the same stop-early trap as `sonnet` @ `low`
+  on three of four tasks built to reward a second look. A verifier catches that; a bigger
+  model does not.
 - The task requires weighing trade-offs with no checkable ground truth.
 - Output ships verbatim to a human without review.
 - The subagent must plan its own multi-step tool strategy over many turns.
@@ -259,14 +301,19 @@ Operational, not calibrated. Source: Anthropic Managed Agents notebook
 
 ## Measure before trusting this
 
-Everything above is measured on two batteries: a 300-call deterministic calibration
-(references/calibration-2026-07-15.md) and a 14-task hidden-test coding suite
-(2026-08-17, ~190 subagent runs). Re-measure when:
+Everything above is measured on three batteries: a 300-call deterministic calibration
+(references/calibration-2026-07-15.md), a 14-task hidden-test coding suite (2026-08-17,
+~190 subagent runs), and a 14-repo seeded-bug agentic battery (2026-09-03, ~120 subagent
+runs, `oaustegard/experiments` → `temporal-routing-headroom`) that measured the cascade
+rungs, the escalation signal, and the tier gap against each other. Re-measure when:
 
 - **A model or price revision lands.** Both the verbosity multipliers and the
   cost table above invert on either.
-- **The task family is off both batteries.** No deterministic task has made Haiku
-  fail on correctness yet, so the capability cliff is past what's been probed.
+- **The task family is off all three batteries.** No deterministic task has made Haiku
+  fail on correctness yet, so the capability cliff is past what's been probed. Seeded-bug
+  repair in a small module is now measured as *not* tier-separating: three probe shapes
+  aimed at thoroughness, at ambiguity the tests underdetermine, and at a repo with no test
+  suite at all, and `sonnet` @ `low` solved all six cells against `opus` @ `high`.
 - **Output length differs materially** from what was measured. The whole cost model
   keys on token volume; a 10× longer artifact re-opens the tier question.
 - **You need pass-rate differences of 1–2 tasks.** Run-to-run variance swamps them:


### PR DESCRIPTION
Measured against a 14-repo seeded-bug agentic battery (~120 subagent runs), built in [oaustegard/experiments#76](https://github.com/oaustegard/experiments/pull/76) → `temporal-routing-headroom`. That work started as a comparison against SWE-Router (arXiv 2607.00053) and ended up measuring this skill's own cascade against itself.

**Nothing is retracted.** Every claim the skill already made held up. The cascade section gained the numbers it was missing, and one aside became the default.

## The escalation call belongs to whoever holds the verifier

New rule, strongest evidence in the set. Across 58 graded runs carrying an explicit "did you finish" field, 58 said yes and 44 had passed the held-out suite — every one of the 14 failures self-reported success, in three independent workflows.

The workers were not lying. They had passed the tests they could see, and those tests stay satisfiable while the task is unfinished. So "try it, and ask for help if you fail" fails on exactly the tasks that need escalation. The skill had `no verifier ⇒ no cascade` but nothing stopping you from letting the worker raise its hand.

## Rung 2 is the same model one effort step up

The skill already said this, as a soft aside. It now has a second measurement, so it becomes the default and a tier jump becomes the exception you justify.

From an identical failed attempt, with the prior patch and the failing assertions in both:

| rung 2 | output tokens | rescued |
|---|---|---|
| `opus` @ `high` | 32,504 | 4/5 |
| `sonnet` @ `medium` + concision | 11,691 | 4/5 — the same four |

Composed over the same rung 1: **0.31×** always-`opus` for the same-model cascade, **0.76×** for the tier jump.

## A cascade can beat the frontier solo arm on correctness

The section framed cascades as a cost play at equal quality. The `sonnet`→`sonnet` cascade solved **13/14** where always-`opus` solved **10/14**. `opus` starting from the issue text fell into the same stop-early trap as `sonnet` on three tasks; `opus` starting from the failed patch and the failing assertions fixed all three.

## Caching, previously absent from the section

Caches are model-scoped with no escape hatch, so a tier jump discards rung 1's prefix while a same-model rung keeps at least the tools and system tiers — a second, independent argument for the change above. An `effort` change still invalidates the messages cache on every model, and the per-message effort escape hatch is Opus 5 / Fable 5.1 / Mythos 5.1 only, not Sonnet 5.

Sourced from the `claude-api` reference rather than measured here, and flagged as such. It also means the skill's cost model is incomplete for cross-model cascades, so the cost-only caveat is now explicit.

## Informed retry means the artifacts, not the narrative

`Carry the prior attempt and the raw failure output` is right as written. Adding the prior model's stated diagnosis on top: 13/15 against 12/15 over three replicates, 1% fewer output tokens, and the whole difference was one replicate of one unstable task. It neither helps nor anchors — SWE-Router restarts its strong model from the task description to avoid an anchoring effect that is not there.

## Smaller

- **Concision does not reach small-output work.** 2.9% on agentic repair against the 37% measured on generation. The existing scope line was correct and I still misapplied it, so the negative result is recorded to make the scope stick.
- **Route up for capability, not thoroughness.** `opus` @ `high` fell into the same stop-early trap as `sonnet` @ `low` on three of four tasks built to reward a second look.
- **Seeded-bug repair in a small module is measured as not tier-separating**, across three probe shapes including one with no test suite at all. Previously the caveat said only that the cliff was unprobed.

## Unchanged

The routing table, the effort-semantics table, loop discipline, judge rules, and the fan-out observability section. Nothing measured touches them.

## Verification

`python3 scripts/validate_skills.py agent-routing` passes. Version 2.1.0, CHANGELOG updated, provenance line now names three batteries.

Caveats worth carrying: the new numbers come from one task family at n=5–14, and `interval_merge` in that set flips uncorrelated with the manipulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Q5vTgwhyfy125jFMyvy6j

---
_Generated by [Claude Code](https://claude.ai/code/session_016Q5vTgwhyfy125jFMyvy6j)_