### PR TITLE
optimizing-skills v0.3.0: ledger the rejected candidates

### DIFF
--- a/optimizing-skills/CHANGELOG.md
+++ b/optimizing-skills/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `optimizing-skills` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-09-05
+
+### Added
+
+- **Ledger step.** Every revision now runs `skill_ledger.py check` before
+  scoring and `skill_ledger.py record` after the gate decides, rejections
+  included. Previously a rejected candidate was discarded with nothing written
+  down, so a later session with no view of this one could propose the same edit
+  and pay to score it again. Imported from WikiSkill's `skill-impact.md`
+  (arXiv:2608.27454); the script lives in claude-workspace
+  (`scripts/skill_ledger.py`) and computes the diff itself rather than
+  accepting one from the proposing model.
+
+### Changed
+
+- **Gate step 3 isolates the scoring agent.** It receives the skill version and
+  the check task only, never the ledger, the revision notes, or the diagnosis
+  behind the edit. WikiSkill ablated this and measured final quality falling
+  from 63.7 to 60.9 on average, and 72.6 to 64.8 on their hardest split, when
+  the worker could read the improver's knowledge store.
+- **`remember()` is now scoped to judgment.** The ledger carries the diffs and
+  their scores; the memory carries what was learned about editing this
+  particular skill.
+
 ## [0.2.0] - 2026-05-29
 
 ### Other

--- a/optimizing-skills/SKILL.md
+++ b/optimizing-skills/SKILL.md
@@ -2,7 +2,7 @@
 name: optimizing-skills
 description: Disciplined, validation-gated revision of an EXISTING skill so each edit is a measured improvement rather than a guess. Use when editing, revising, or tuning a skill that already exists and there is evidence it underperforms (observed failures, drift, complaints) — invoke by name, or have versioning-skills / creating-skill defer to it before applying edits. Not for authoring a brand-new skill from scratch (use creating-skill) or one-off prose.
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # Optimizing Skills
@@ -30,7 +30,13 @@ improvement from a confident guess.
    silently degrade). `candidate` = `best` + your proposed edits.
 3. **Score both on the check set.** "Run" here = dispatch each check task to the
    **Agent tool** (`subagent_type=general-purpose`) with the skill version in
-   context, or evaluate by hand for small sets. Score **per criterion**, not one
+   context, or evaluate by hand for small sets. Give the scoring agent the skill
+   version and the task, and nothing else. Never hand it the ledger, your
+   revision notes, or the diagnosis that motivated the edit: it will solve the
+   task from those instead of from the skill, and the score stops measuring the
+   skill. WikiSkill (arXiv:2608.27454) ablated exactly this and lost 2.8 points
+   of final quality, 7.8 on their hardest split, by letting the worker read the
+   improver's knowledge store. Score **per criterion**, not one
    collapsed pass/fail. When a task carries several criteria, the criterion that
    decides accept/reject is **the failure that prompted this revision**; the
    others are regression guards that must not get worse. Collapsing criteria
@@ -93,11 +99,44 @@ catch slow drift and regressions that single-edit review misses. (SkillOpt
 fences this region with HTML-comment markers and only rewrites it at epoch
 boundaries — the same idea, manual cadence.)
 
+## Recording rejected proposals
+
+**FIRST action of any revision, before you score anything:**
+
+```bash
+python3 scripts/skill_ledger.py check --skill <name> --before best.md --after candidate.md
+```
+
+Exit 1 means this exact edit was proposed before and failed the gate. Read the
+recorded criterion and score, then propose something else. Do not re-score it.
+
+**After the gate decides, record the outcome — accepted or rejected:**
+
+```bash
+python3 scripts/skill_ledger.py record --skill <name> \
+    --before best.md --after candidate.md --outcome rejected \
+    --criterion "<the triggering failure>" --score-before 0.6 --score-after 0.6
+```
+
+The ledger computes the diff itself and appends it. A rejected candidate is the
+artifact worth keeping. The edit reverts and the record stays. The next
+session cannot see this one, which is why the record has to live outside your
+context rather than in it.
+
+This is WikiSkill's `skill-impact.md` (arXiv:2608.27454), whose outer loop
+keeps a never-rolled-back record of every proposal and its fate while the skill
+itself rolls back. Their proposer is told in prose not to repeat rejected
+approaches. `check` makes that mechanical instead, so it no longer depends on
+anyone having read the ledger. The script lives in claude-workspace at
+`scripts/skill_ledger.py`.
+
 ## Carry memory across revisions
 
-After a revision, record what you learned about editing **this** skill — which
-kinds of edits helped, which were brittle, redundant, or harmful — via
-`remember()` tagged with the skill name. Before the next revision, `recall()`
+The ledger above holds the artifacts: which diffs were tried and how they
+scored. `remember()` holds the judgment the diffs cannot carry. After a
+revision, record what you learned about editing **this** skill — which kinds of
+edits helped, which were brittle, redundant, or harmful — via `remember()`
+tagged with the skill name. Before the next revision, `recall()`
 it. This is the compounding part: each revision starts smarter than the last,
 the way SkillOpt's optimizer-side meta-skill conditions its future edits.
 
@@ -122,6 +161,9 @@ and verify each edit landed before scoring.
 - [ ] Candidate scored per-criterion against `best`; accept decided by the triggering-failure criterion, others as regression guards; shipped only if strictly better
 - [ ] For Agent-compiled artifacts (down-skilling, creating-skill): ≥2 author samples per version, or a fixed author across arms
 - [ ] Hard-won core left untouched unless doing a deliberate longitudinal review
+- [ ] Candidate run through `skill_ledger.py check` before scoring; a repeat was dropped, not re-scored
+- [ ] Scoring agent given the skill version and the task only, never the ledger or the diagnosis
+- [ ] Gate outcome recorded via `skill_ledger.py record`, rejections included
 - [ ] Lesson about editing this skill recorded via `remember()`
 
 For the deeper "dispatch reflection/scoring to the Agent tool" recipe and the

--- a/plugins/skill-development/skills/optimizing-skills/CHANGELOG.md
+++ b/plugins/skill-development/skills/optimizing-skills/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `optimizing-skills` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-09-05
+
+### Added
+
+- **Ledger step.** Every revision now runs `skill_ledger.py check` before
+  scoring and `skill_ledger.py record` after the gate decides, rejections
+  included. Previously a rejected candidate was discarded with nothing written
+  down, so a later session with no view of this one could propose the same edit
+  and pay to score it again. Imported from WikiSkill's `skill-impact.md`
+  (arXiv:2608.27454); the script lives in claude-workspace
+  (`scripts/skill_ledger.py`) and computes the diff itself rather than
+  accepting one from the proposing model.
+
+### Changed
+
+- **Gate step 3 isolates the scoring agent.** It receives the skill version and
+  the check task only, never the ledger, the revision notes, or the diagnosis
+  behind the edit. WikiSkill ablated this and measured final quality falling
+  from 63.7 to 60.9 on average, and 72.6 to 64.8 on their hardest split, when
+  the worker could read the improver's knowledge store.
+- **`remember()` is now scoped to judgment.** The ledger carries the diffs and
+  their scores; the memory carries what was learned about editing this
+  particular skill.
+
 ## [0.2.0] - 2026-05-29
 
 ### Other

--- a/plugins/skill-development/skills/optimizing-skills/SKILL.md
+++ b/plugins/skill-development/skills/optimizing-skills/SKILL.md
@@ -2,7 +2,7 @@
 name: optimizing-skills
 description: Disciplined, validation-gated revision of an EXISTING skill so each edit is a measured improvement rather than a guess. Use when editing, revising, or tuning a skill that already exists and there is evidence it underperforms (observed failures, drift, complaints) — invoke by name, or have versioning-skills / creating-skill defer to it before applying edits. Not for authoring a brand-new skill from scratch (use creating-skill) or one-off prose.
 metadata:
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # Optimizing Skills
@@ -30,7 +30,13 @@ improvement from a confident guess.
    silently degrade). `candidate` = `best` + your proposed edits.
 3. **Score both on the check set.** "Run" here = dispatch each check task to the
    **Agent tool** (`subagent_type=general-purpose`) with the skill version in
-   context, or evaluate by hand for small sets. Score **per criterion**, not one
+   context, or evaluate by hand for small sets. Give the scoring agent the skill
+   version and the task, and nothing else. Never hand it the ledger, your
+   revision notes, or the diagnosis that motivated the edit: it will solve the
+   task from those instead of from the skill, and the score stops measuring the
+   skill. WikiSkill (arXiv:2608.27454) ablated exactly this and lost 2.8 points
+   of final quality, 7.8 on their hardest split, by letting the worker read the
+   improver's knowledge store. Score **per criterion**, not one
    collapsed pass/fail. When a task carries several criteria, the criterion that
    decides accept/reject is **the failure that prompted this revision**; the
    others are regression guards that must not get worse. Collapsing criteria
@@ -93,11 +99,44 @@ catch slow drift and regressions that single-edit review misses. (SkillOpt
 fences this region with HTML-comment markers and only rewrites it at epoch
 boundaries — the same idea, manual cadence.)
 
+## Recording rejected proposals
+
+**FIRST action of any revision, before you score anything:**
+
+```bash
+python3 scripts/skill_ledger.py check --skill <name> --before best.md --after candidate.md
+```
+
+Exit 1 means this exact edit was proposed before and failed the gate. Read the
+recorded criterion and score, then propose something else. Do not re-score it.
+
+**After the gate decides, record the outcome — accepted or rejected:**
+
+```bash
+python3 scripts/skill_ledger.py record --skill <name> \
+    --before best.md --after candidate.md --outcome rejected \
+    --criterion "<the triggering failure>" --score-before 0.6 --score-after 0.6
+```
+
+The ledger computes the diff itself and appends it. A rejected candidate is the
+artifact worth keeping. The edit reverts and the record stays. The next
+session cannot see this one, which is why the record has to live outside your
+context rather than in it.
+
+This is WikiSkill's `skill-impact.md` (arXiv:2608.27454), whose outer loop
+keeps a never-rolled-back record of every proposal and its fate while the skill
+itself rolls back. Their proposer is told in prose not to repeat rejected
+approaches. `check` makes that mechanical instead, so it no longer depends on
+anyone having read the ledger. The script lives in claude-workspace at
+`scripts/skill_ledger.py`.
+
 ## Carry memory across revisions
 
-After a revision, record what you learned about editing **this** skill — which
-kinds of edits helped, which were brittle, redundant, or harmful — via
-`remember()` tagged with the skill name. Before the next revision, `recall()`
+The ledger above holds the artifacts: which diffs were tried and how they
+scored. `remember()` holds the judgment the diffs cannot carry. After a
+revision, record what you learned about editing **this** skill — which kinds of
+edits helped, which were brittle, redundant, or harmful — via `remember()`
+tagged with the skill name. Before the next revision, `recall()`
 it. This is the compounding part: each revision starts smarter than the last,
 the way SkillOpt's optimizer-side meta-skill conditions its future edits.
 
@@ -122,6 +161,9 @@ and verify each edit landed before scoring.
 - [ ] Candidate scored per-criterion against `best`; accept decided by the triggering-failure criterion, others as regression guards; shipped only if strictly better
 - [ ] For Agent-compiled artifacts (down-skilling, creating-skill): ≥2 author samples per version, or a fixed author across arms
 - [ ] Hard-won core left untouched unless doing a deliberate longitudinal review
+- [ ] Candidate run through `skill_ledger.py check` before scoring; a repeat was dropped, not re-scored
+- [ ] Scoring agent given the skill version and the task only, never the ledger or the diagnosis
+- [ ] Gate outcome recorded via `skill_ledger.py record`, rejections included
 - [ ] Lesson about editing this skill recorded via `remember()`
 
 For the deeper "dispatch reflection/scoring to the Agent tool" recipe and the


### PR DESCRIPTION
Consumer side of `scripts/skill_ledger.py` (claude-workspace#261). Both halves come from WikiSkill (arXiv:2608.27454, Google Research, 2026-08-27).

## What was missing

The gate holds `best` against `candidate` and ships only on a strict win, which is right. What it does with a loser is throw it away. A rejected edit leaves no trace, so a later session that cannot see this one is free to propose it again and pay to score it a second time.

WikiSkill's `skill-impact.md` is the fix. The outer loop writes it, it carries the full rejected diff, and it survives the rollback that reverts the edit.

## Three bounded edits

**New section, `Recording rejected proposals`.** Run `skill_ledger.py check` before scoring; exit 1 means this exact edit already failed the gate, so read the recorded criterion and propose something else. Run `skill_ledger.py record` after the gate decides, rejections included.

**Gate step 3 isolates the scoring agent.** It gets the skill version and the check task, and nothing else. Handing it the ledger or the diagnosis lets it solve the task from those instead of from the skill, at which point the score stops measuring the skill. WikiSkill ablated this: 63.7 → 60.9 average, 72.6 → 64.8 on their hardest split.

**`remember()` scoped to judgment.** The ledger holds the diffs and their scores. The memory holds what was learned about editing this particular skill, which a diff cannot carry.

## Past the paper

WikiSkill tells its Skill Proposer "DO NOT repeat rejected approaches" in the system prompt and trusts it to comply — the prose enforcement `skill-language-compliance` says does not hold. `check` makes the test mechanical and signals through an exit code, so it does not depend on the proposer having read anything.

## Verification

- `validate_skill_file()` passes, version 0.3.0.
- `detect-version-changes.py HEAD~1 HEAD` returns both paths, so this releases rather than landing as a silent no-op.
- `optimizing-skills/` and `plugins/skill-development/skills/optimizing-skills/` are byte-identical.
- Added prose linted with `declaude_lint`; the pre-existing body was left alone.

Depends on claude-workspace#261 for the script the new section calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ2GKXwDxrtaq3hmerxqQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJ2GKXwDxrtaq3hmerxqQf)_