### PR TITLE
fix(exploring-data): weight MinHash by token count in dups

### DIFF
--- a/exploring-data/CHANGELOG.md
+++ b/exploring-data/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `exploring-data` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-09-06
+
+### Fixed
+
+- `scripts/sketch_ops.py dups`: build each row's MinHash from token *counts*, not the token set. `MinHash.update` keeps a per-permutation minimum, so hashing a token twice changed nothing and `new york new york` scored Jaccard 1.0 against `york new`. A token occurring c times now contributes c distinct elements `(t, 0) … (t, c-1)`, which makes the signature estimate the weighted Jaccard index `sum(min(a_i, b_i)) / sum(max(a_i, b_i))`. Rows whose tokens are all distinct are unaffected.
+
+### Added
+
+- `dups --unweighted`: keeps the pre-0.2.0 set semantics for callers that want them.
+- `tests/test_sketch_ops.py`: covers both metrics, including a pair that differs only in token counts.
+
+### Changed
+
+- The `dups` summary line now names the metric it used — `weighted Jaccard>=` by default, `Jaccard>=` under `--unweighted`.
+
 ## [0.1.2] - 2026-08-25
 
 ### Fixed

--- a/exploring-data/SKILL.md
+++ b/exploring-data/SKILL.md
@@ -2,7 +2,7 @@
 name: exploring-data
 description: Exploratory data analysis. Use when users upload .csv/.xlsx/.json/.parquet files or request "explore data", "analyze dataset", "EDA", "profile data". Small files get ydata-profiling HTML/JSON reports; large files (over 200MB or 5M rows) get fixed-memory DuckDB/sketch profiling. Also covers near-duplicate row detection, cross-file key overlap ("can these join?"), dataset drift vs a stored baseline, and time-series profiling.
 metadata:
-  version: 0.1.2
+  version: 0.2.0
 ---
 
 # Exploring Data
@@ -124,10 +124,13 @@ questions profilers don't:
 
 ### Near-duplicate rows
 ```bash
-python3 sketch_ops.py dups <file> [--threshold 0.9] [--cols a,b,c]
+python3 sketch_ops.py dups <file> [--threshold 0.9] [--cols a,b,c] [--unweighted]
 ```
 Exact duplicates counted by hash; near-duplicates via MinHash LSH over row
-tokens. Use `--cols` to restrict to the columns that define identity.
+tokens. `--threshold` is a **weighted** Jaccard cutoff: a token occurring c
+times in a row counts c times, so `new york new york` and `york new` score 0.5
+rather than 1.0. Pass `--unweighted` for set semantics, where repeats are
+discarded. Use `--cols` to restrict to the columns that define identity.
 
 ### Key overlap / join feasibility
 ```bash

--- a/exploring-data/scripts/sketch_ops.py
+++ b/exploring-data/scripts/sketch_ops.py
@@ -2,7 +2,8 @@
 """Sketch-based exploration ops that profilers miss. Fixed memory, any file size.
 
 Subcommands:
-  dups <file> [--threshold 0.9] [--cols a,b]   near-duplicate row detection (MinHash LSH)
+  dups <file> [--threshold 0.9] [--cols a,b] [--unweighted]
+                                               near-duplicate row detection (MinHash LSH)
   overlap <fileA> <fileB> --key <col> [--key-b <col>]   key overlap / join feasibility (theta sketch)
   snapshot <file> --out <sketches.json>        persist HLL+KLL sketches per column
   drift <file> --baseline <sketches.json>      compare current file against a snapshot
@@ -12,6 +13,7 @@ Files stream through DuckDB in batches; sketches are the only state held.
 import base64
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 
 try:
@@ -49,6 +51,28 @@ def batches(con, sql):
         yield rows
 
 
+def row_minhash(tokens, weighted=True, num_perm=128):
+    """MinHash over a row's tokens.
+
+    Weighted (the default) inserts c distinct elements (t, 0) ... (t, c-1) for
+    a token t occurring c times, so the signature estimates the weighted
+    Jaccard index sum(min(a_i, b_i)) / sum(max(a_i, b_i)). Unweighted collapses
+    the tokens to a set: `new york new york` and `york new` then score 1.0
+    against each other, because MinHash.update keeps a per-permutation minimum
+    and hashing a token twice changes nothing. Rows whose tokens are all
+    distinct produce the same signature either way.
+    """
+    m = MinHash(num_perm=num_perm)
+    if weighted:
+        for tok, c in Counter(tokens).items():
+            for j in range(c):
+                m.update(f"{tok}\x00{j}".encode())
+    else:
+        for tok in tokens:
+            m.update(tok.encode())
+    return m
+
+
 def cmd_dups(argv):
     path = Path(argv[0])
     thresh = float(argv[argv.index("--threshold") + 1]) if "--threshold" in argv else 0.9
@@ -56,6 +80,7 @@ def cmd_dups(argv):
     src = reader_sql(path)
     cols = ('"' + '", "'.join(argv[argv.index("--cols") + 1].split(",")) + '"'
             ) if "--cols" in argv else "*"
+    weighted = "--unweighted" not in argv
     lsh = MinHashLSH(threshold=thresh, num_perm=128)
     exact_seen, exact_dups, clusters, i = set(), 0, [], 0
     for rows in batches(con, f"SELECT {cols} FROM {src}"):
@@ -66,16 +91,15 @@ def cmd_dups(argv):
                 exact_dups += 1
                 continue
             exact_seen.add(key)
-            m = MinHash(num_perm=128)
-            for tok in " ".join(key).lower().split():
-                m.update(tok.encode())
+            m = row_minhash(" ".join(key).lower().split(), weighted=weighted)
             near = lsh.query(m)
             if near:
                 clusters.append((near[0], i))
             lsh.insert(f"row{i}", m)
     print(f"# Near-duplicate scan: {path.name}")
+    metric = "weighted Jaccard" if weighted else "Jaccard"
     print(f"{i:,} rows; {exact_dups:,} exact duplicates; "
-          f"{len(clusters):,} near-duplicate pairs at Jaccard>={thresh}")
+          f"{len(clusters):,} near-duplicate pairs at {metric}>={thresh}")
     for anchor, dup in clusters[:10]:
         print(f"  {anchor} ~ row{dup}")
     if len(clusters) > 10:

--- a/exploring-data/tests/test_sketch_ops.py
+++ b/exploring-data/tests/test_sketch_ops.py
@@ -1,0 +1,91 @@
+"""Tests for sketch_ops MinHash duplicate detection.
+
+Coverage:
+- row_minhash weighted vs unweighted on rows that share a token set but
+  differ in token counts (the case #787 reported)
+- rows whose tokens are all distinct: both metrics agree
+- cmd_dups end to end over a CSV, both metrics, including the printed label
+"""
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from sketch_ops import cmd_dups, row_minhash
+
+# Same token set {new, york}; counts 2:2 vs 1:1.
+# Weighted Jaccard = sum(min)/sum(max) = (1+1)/(2+2) = 0.5.
+REPEATED = ["new", "york", "new", "york"]
+DISTINCT = ["york", "new"]
+
+
+class TestRowMinhash(unittest.TestCase):
+
+    def test_unweighted_collapses_repeats(self):
+        a = row_minhash(REPEATED, weighted=False)
+        b = row_minhash(DISTINCT, weighted=False)
+        self.assertEqual(a.jaccard(b), 1.0)
+
+    def test_weighted_separates_by_count(self):
+        a = row_minhash(REPEATED, weighted=True)
+        b = row_minhash(DISTINCT, weighted=True)
+        est = a.jaccard(b)
+        self.assertLess(est, 0.9)
+        # 128 permutations; ±0.15 is well outside the sampling error here.
+        self.assertAlmostEqual(est, 0.5, delta=0.15)
+
+    def test_distinct_tokens_unaffected(self):
+        toks = ["alpha", "beta", "gamma", "delta"]
+        for weighted in (True, False):
+            a = row_minhash(toks, weighted=weighted)
+            b = row_minhash(list(reversed(toks)), weighted=weighted)
+            self.assertEqual(a.jaccard(b), 1.0, f"weighted={weighted}")
+
+    def test_weighted_default(self):
+        self.assertEqual(
+            row_minhash(REPEATED).digest().tolist(),
+            row_minhash(REPEATED, weighted=True).digest().tolist(),
+        )
+
+
+class TestCmdDups(unittest.TestCase):
+    """The two rows are not exact duplicates, so only the sketch separates them."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.csv = Path(self.tmp.name) / "counts.csv"
+        self.csv.write_text("city\nnew york new york\nyork new\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cmd_dups(argv)
+        return buf.getvalue()
+
+    def test_weighted_rejects_the_pair(self):
+        out = self._run([str(self.csv), "--threshold", "0.9"])
+        self.assertIn("0 exact duplicates", out)
+        self.assertIn("0 near-duplicate pairs at weighted Jaccard>=0.9", out)
+
+    def test_unweighted_matches_the_pair(self):
+        out = self._run([str(self.csv), "--threshold", "0.9", "--unweighted"])
+        self.assertIn("1 near-duplicate pairs at Jaccard>=0.9", out)
+
+    def test_exact_duplicates_still_counted(self):
+        csv = Path(self.tmp.name) / "exact.csv"
+        csv.write_text("city\nnew york new york\nnew york new york\n")
+        out = self._run([str(csv)])
+        self.assertIn("1 exact duplicates", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/data-and-visualization/skills/exploring-data/CHANGELOG.md
+++ b/plugins/data-and-visualization/skills/exploring-data/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `exploring-data` skill are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - 2026-09-06
+
+### Fixed
+
+- `scripts/sketch_ops.py dups`: build each row's MinHash from token *counts*, not the token set. `MinHash.update` keeps a per-permutation minimum, so hashing a token twice changed nothing and `new york new york` scored Jaccard 1.0 against `york new`. A token occurring c times now contributes c distinct elements `(t, 0) … (t, c-1)`, which makes the signature estimate the weighted Jaccard index `sum(min(a_i, b_i)) / sum(max(a_i, b_i))`. Rows whose tokens are all distinct are unaffected.
+
+### Added
+
+- `dups --unweighted`: keeps the pre-0.2.0 set semantics for callers that want them.
+- `tests/test_sketch_ops.py`: covers both metrics, including a pair that differs only in token counts.
+
+### Changed
+
+- The `dups` summary line now names the metric it used — `weighted Jaccard>=` by default, `Jaccard>=` under `--unweighted`.
+
 ## [0.1.2] - 2026-08-25
 
 ### Fixed

--- a/plugins/data-and-visualization/skills/exploring-data/SKILL.md
+++ b/plugins/data-and-visualization/skills/exploring-data/SKILL.md
@@ -2,7 +2,7 @@
 name: exploring-data
 description: Exploratory data analysis. Use when users upload .csv/.xlsx/.json/.parquet files or request "explore data", "analyze dataset", "EDA", "profile data". Small files get ydata-profiling HTML/JSON reports; large files (over 200MB or 5M rows) get fixed-memory DuckDB/sketch profiling. Also covers near-duplicate row detection, cross-file key overlap ("can these join?"), dataset drift vs a stored baseline, and time-series profiling.
 metadata:
-  version: 0.1.2
+  version: 0.2.0
 ---
 
 # Exploring Data
@@ -124,10 +124,13 @@ questions profilers don't:
 
 ### Near-duplicate rows
 ```bash
-python3 sketch_ops.py dups <file> [--threshold 0.9] [--cols a,b,c]
+python3 sketch_ops.py dups <file> [--threshold 0.9] [--cols a,b,c] [--unweighted]
 ```
 Exact duplicates counted by hash; near-duplicates via MinHash LSH over row
-tokens. Use `--cols` to restrict to the columns that define identity.
+tokens. `--threshold` is a **weighted** Jaccard cutoff: a token occurring c
+times in a row counts c times, so `new york new york` and `york new` score 0.5
+rather than 1.0. Pass `--unweighted` for set semantics, where repeats are
+discarded. Use `--cols` to restrict to the columns that define identity.
 
 ### Key overlap / join feasibility
 ```bash

--- a/plugins/data-and-visualization/skills/exploring-data/scripts/sketch_ops.py
+++ b/plugins/data-and-visualization/skills/exploring-data/scripts/sketch_ops.py
@@ -2,7 +2,8 @@
 """Sketch-based exploration ops that profilers miss. Fixed memory, any file size.
 
 Subcommands:
-  dups <file> [--threshold 0.9] [--cols a,b]   near-duplicate row detection (MinHash LSH)
+  dups <file> [--threshold 0.9] [--cols a,b] [--unweighted]
+                                               near-duplicate row detection (MinHash LSH)
   overlap <fileA> <fileB> --key <col> [--key-b <col>]   key overlap / join feasibility (theta sketch)
   snapshot <file> --out <sketches.json>        persist HLL+KLL sketches per column
   drift <file> --baseline <sketches.json>      compare current file against a snapshot
@@ -12,6 +13,7 @@ Files stream through DuckDB in batches; sketches are the only state held.
 import base64
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 
 try:
@@ -49,6 +51,28 @@ def batches(con, sql):
         yield rows
 
 
+def row_minhash(tokens, weighted=True, num_perm=128):
+    """MinHash over a row's tokens.
+
+    Weighted (the default) inserts c distinct elements (t, 0) ... (t, c-1) for
+    a token t occurring c times, so the signature estimates the weighted
+    Jaccard index sum(min(a_i, b_i)) / sum(max(a_i, b_i)). Unweighted collapses
+    the tokens to a set: `new york new york` and `york new` then score 1.0
+    against each other, because MinHash.update keeps a per-permutation minimum
+    and hashing a token twice changes nothing. Rows whose tokens are all
+    distinct produce the same signature either way.
+    """
+    m = MinHash(num_perm=num_perm)
+    if weighted:
+        for tok, c in Counter(tokens).items():
+            for j in range(c):
+                m.update(f"{tok}\x00{j}".encode())
+    else:
+        for tok in tokens:
+            m.update(tok.encode())
+    return m
+
+
 def cmd_dups(argv):
     path = Path(argv[0])
     thresh = float(argv[argv.index("--threshold") + 1]) if "--threshold" in argv else 0.9
@@ -56,6 +80,7 @@ def cmd_dups(argv):
     src = reader_sql(path)
     cols = ('"' + '", "'.join(argv[argv.index("--cols") + 1].split(",")) + '"'
             ) if "--cols" in argv else "*"
+    weighted = "--unweighted" not in argv
     lsh = MinHashLSH(threshold=thresh, num_perm=128)
     exact_seen, exact_dups, clusters, i = set(), 0, [], 0
     for rows in batches(con, f"SELECT {cols} FROM {src}"):
@@ -66,16 +91,15 @@ def cmd_dups(argv):
                 exact_dups += 1
                 continue
             exact_seen.add(key)
-            m = MinHash(num_perm=128)
-            for tok in " ".join(key).lower().split():
-                m.update(tok.encode())
+            m = row_minhash(" ".join(key).lower().split(), weighted=weighted)
             near = lsh.query(m)
             if near:
                 clusters.append((near[0], i))
             lsh.insert(f"row{i}", m)
     print(f"# Near-duplicate scan: {path.name}")
+    metric = "weighted Jaccard" if weighted else "Jaccard"
     print(f"{i:,} rows; {exact_dups:,} exact duplicates; "
-          f"{len(clusters):,} near-duplicate pairs at Jaccard>={thresh}")
+          f"{len(clusters):,} near-duplicate pairs at {metric}>={thresh}")
     for anchor, dup in clusters[:10]:
         print(f"  {anchor} ~ row{dup}")
     if len(clusters) > 10:

--- a/plugins/data-and-visualization/skills/exploring-data/tests/test_sketch_ops.py
+++ b/plugins/data-and-visualization/skills/exploring-data/tests/test_sketch_ops.py
@@ -1,0 +1,91 @@
+"""Tests for sketch_ops MinHash duplicate detection.
+
+Coverage:
+- row_minhash weighted vs unweighted on rows that share a token set but
+  differ in token counts (the case #787 reported)
+- rows whose tokens are all distinct: both metrics agree
+- cmd_dups end to end over a CSV, both metrics, including the printed label
+"""
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from sketch_ops import cmd_dups, row_minhash
+
+# Same token set {new, york}; counts 2:2 vs 1:1.
+# Weighted Jaccard = sum(min)/sum(max) = (1+1)/(2+2) = 0.5.
+REPEATED = ["new", "york", "new", "york"]
+DISTINCT = ["york", "new"]
+
+
+class TestRowMinhash(unittest.TestCase):
+
+    def test_unweighted_collapses_repeats(self):
+        a = row_minhash(REPEATED, weighted=False)
+        b = row_minhash(DISTINCT, weighted=False)
+        self.assertEqual(a.jaccard(b), 1.0)
+
+    def test_weighted_separates_by_count(self):
+        a = row_minhash(REPEATED, weighted=True)
+        b = row_minhash(DISTINCT, weighted=True)
+        est = a.jaccard(b)
+        self.assertLess(est, 0.9)
+        # 128 permutations; ±0.15 is well outside the sampling error here.
+        self.assertAlmostEqual(est, 0.5, delta=0.15)
+
+    def test_distinct_tokens_unaffected(self):
+        toks = ["alpha", "beta", "gamma", "delta"]
+        for weighted in (True, False):
+            a = row_minhash(toks, weighted=weighted)
+            b = row_minhash(list(reversed(toks)), weighted=weighted)
+            self.assertEqual(a.jaccard(b), 1.0, f"weighted={weighted}")
+
+    def test_weighted_default(self):
+        self.assertEqual(
+            row_minhash(REPEATED).digest().tolist(),
+            row_minhash(REPEATED, weighted=True).digest().tolist(),
+        )
+
+
+class TestCmdDups(unittest.TestCase):
+    """The two rows are not exact duplicates, so only the sketch separates them."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.csv = Path(self.tmp.name) / "counts.csv"
+        self.csv.write_text("city\nnew york new york\nyork new\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cmd_dups(argv)
+        return buf.getvalue()
+
+    def test_weighted_rejects_the_pair(self):
+        out = self._run([str(self.csv), "--threshold", "0.9"])
+        self.assertIn("0 exact duplicates", out)
+        self.assertIn("0 near-duplicate pairs at weighted Jaccard>=0.9", out)
+
+    def test_unweighted_matches_the_pair(self):
+        out = self._run([str(self.csv), "--threshold", "0.9", "--unweighted"])
+        self.assertIn("1 near-duplicate pairs at Jaccard>=0.9", out)
+
+    def test_exact_duplicates_still_counted(self):
+        csv = Path(self.tmp.name) / "exact.csv"
+        csv.write_text("city\nnew york new york\nnew york new york\n")
+        out = self._run([str(csv)])
+        self.assertIn("1 exact duplicates", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`sketch_ops.py dups` built each row's MinHash from a token set. `MinHash.update` keeps a per-permutation minimum, so hashing a token twice changed nothing: a row of `new york new york` and a row of `york new` produced identical signatures and scored Jaccard 1.0 against each other.

## The change

A token occurring `c` times now contributes `c` distinct elements `(t, 0) … (t, c-1)`, the construction in Ryan Moulton's [MinHashing writeup](https://moultano.wordpress.com/2018/11/08/minhashing-3kbzhsxyg4467-6/). The signature then estimates the weighted Jaccard index `sum(min(a_i, b_i)) / sum(max(a_i, b_i))`. Rows whose tokens are all distinct produce the same signature as before, so set-valued data is unaffected.

`--unweighted` keeps the old set semantics. The summary line names the metric it used: `weighted Jaccard>=` by default, `Jaccard>=` under the flag. `SKILL.md` documents both.

Cost is one `Counter` per row plus one `update` per token occurrence instead of per distinct token.

## Tests

`exploring-data/tests/test_sketch_ops.py`, 7 cases:

- `new york new york` vs `york new`: unweighted scores 1.0, weighted 0.5 within sampling error at 128 permutations.
- All-distinct tokens in either order: 1.0 under both metrics.
- `cmd_dups` over a two-row CSV at `--threshold 0.9`: 0 pairs weighted, 1 pair unweighted, and the printed label matches.
- Exact duplicates still counted by hash.

Sanity run outside the suite, on 20,010 synthetic rows carrying 10 planted single-token mutations at `--threshold 0.7`: both metrics return the same 8 pairs, which is what you get when every row's tokens are distinct.

## Housekeeping

`plugins/data-and-visualization/skills/exploring-data/` carries a copy of the script and SKILL.md; both got the change, and `diff -r` reports the two trees identical. Version 0.1.2 to 0.2.0 with a CHANGELOG entry. `ruff check` passes.

Closes #787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQQkxL2QUQYMabuhqScN7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQQkxL2QUQYMabuhqScN7i)_