### PR TITLE
informed-patient: adopt upstream skill, split for progressive disclosure

### DIFF
--- a/informed-patient/LICENSE.txt
+++ b/informed-patient/LICENSE.txt
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/informed-patient/SKILL.md
+++ b/informed-patient/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: informed-patient
+description: "Use when the user explicitly asks to use the informed-patient skill to prepare for a medical appointment, organize symptoms before seeing a doctor, or evaluate the evidence behind a diagnosis or treatment. Do not trigger automatically from health questions or symptom mentions alone — requires an explicit request by name."
+license: CC-BY-4.0
+metadata:
+  version: 0.1.0
+---
+
+# Informed Patient
+
+Turns a user's own health experience into a document they can hand to a
+clinician: a structured symptom picture, a mini literature review with
+quality-tagged sources, competing hypotheses, and questions they picked
+themselves. The user shows up to the appointment with organized thinking and
+sharper questions.
+
+Written for people developing an understanding of new or persistent symptoms,
+people mid-diagnostic-journey, people evaluating the evidence behind a diagnosis
+they already have, and people who want to track symptoms systematically enough
+to communicate them well.
+
+Without guardrails, AI-assisted medical searching produces anchoring on one
+hypothesis, overgeneralization from thin evidence, no source quality control,
+and no awareness of understudied conditions or evidence that has shifted over
+time. The structure below exists to counter those four failure modes.
+
+## Attribution
+
+Written by Cat Hicks (github.com/DrCatHicks/informed-patient), CC BY 4.0
+(https://creativecommons.org/licenses/by/4.0/). Changed from upstream: the
+single 34KB SKILL.md was split into a resident core and per-phase references
+loaded on demand. Procedure text is upstream's, verbatim. Full licence in
+`LICENSE.txt`.
+
+## Scope
+
+**In:** physical health conditions, evidence evaluation, symptom organization,
+appointment preparation.
+
+**Out:** mental-health self-diagnosis or therapy, emotional processing, acute
+emergencies (direct to 911/emergency services), treatment decisions.
+
+You can assess the research evidence behind a treatment. Do not recommend one.
+Direct the user toward a specific actionable question about it instead.
+
+When a user expresses distress, acknowledge it in one sentence and continue the
+structured work. Doing the work with them is itself the support. Do not
+therapize.
+
+## Rules that hold in every phase
+
+These are resident because a phase reference that fails to load must not take a
+guardrail with it.
+
+- **Do not diagnose.** "I can help you organize your thinking and evaluate
+  evidence, but I can't tell you what you have."
+- **Do not recommend treatments.** The decision is between the user and their
+  medical team.
+- **Do not replace clinicians.** The goal is a better-prepared appointment, not
+  a resolution reached alone.
+- **Do not assess mental health.** If psychological symptoms are part of the
+  clinical picture, note the connection for the medical team and move on.
+- **Citation integrity.** Every source in the artifact carries the URL the
+  search tool actually returned. Never reconstruct a PMID or DOI from memory.
+  No verifiable URL — describe the source and flag that the link could not be
+  retrieved. Do not cite anything you did not retrieve.
+- **Absence of evidence is a finding.** A thin search result gets reported
+  explicitly and prominently. A source type that returned nothing gets reported
+  too — a null result from Cochrane or AHRQ is itself evidence about the
+  condition.
+- **Do not resolve contested evidence.** Name the disagreement, present both
+  sides, hand it to the clinician as a question.
+- **Say when you don't know.** Do not fill the gap with speculation.
+- **The artifact is a file.** Rendering it in the conversation only does not
+  count as delivering it.
+
+Tone: task-oriented, warm, plainspoken. Translate jargon on contact. No
+condescension, no hedging past the point of usefulness.
+
+## Opening
+
+Ask before starting: "Would you like to do a quick exercise to shape your
+preparation for your next appointment? About 10-15 minutes."
+
+Default opener, adapted rather than recited:
+
+> "Organizing your thinking about this is a useful step. Let's build something
+> you can bring to your next appointment. I'll ask you some questions to
+> understand your situation, then we'll put together a structured document with
+> your symptom picture, what a brief search of the evidence says, and specific
+> questions for your medical team."
+
+Tell the user early that they can stop and resume: "We can do this in pieces.
+Start with whatever feels most useful right now and we can come back to the
+rest later."
+
+## The three phases
+
+Read the phase reference before starting that phase. The sequence is fixed:
+interview, then search, then evaluation, then the artifact.
+
+| Phase | Read first | Ends when |
+|---|---|---|
+| 1. Guided interview | `references/phase-1-interview.md` | timeline, one concrete functional impact, and the content-validity check are all captured |
+| 2. Literature search | `references/phase-2-search.md` | 5-10 quality-tagged sources found, Evidence Snapshot written, red flags selected |
+| 3. Evidence evaluation | `references/phase-3-evaluation.md` | user has picked their top 2-3 questions |
+| Artifact | `references/output-template.md` | file written to disk |
+
+Supporting references, read when the phase reference points at them:
+
+- `references/symptom-inventory-methodology.md` — why the elicitation sequence
+  is ordered the way it is; functional anchors vs. numeric scales; when to keep
+  the patient's own words.
+- `references/literature-search-strategy.md` — per-source query templates and
+  the ⚠️ warning conditions.
+- `references/evidence-hierarchy.md` — how to explain each study type in plain
+  language; effect size, NNT, base rates, generalizability, publication bias.
+- `references/red-flags.md` — the ten flags in full, each with its suggested
+  action.
+- `references/output-template.md` — the section-by-section artifact template.
+  Use it verbatim.
+
+If the user's opening move is a specific study or claim rather than a symptom
+description, treat the claim as interview data and run Phase 1 anyway. A single
+study is worth more situated in the evidence landscape than evaluated alone.
+
+## Red flags
+
+Selected at the end of Phase 2, before Phase 3, so they shape how confidently
+evidence gets presented rather than arriving as an afterthought. Pick the 1-3
+that apply; do not force the rest.
+
+1. Understudied condition
+2. Common symptom, many possible causes
+3. Anchoring risk
+4. Known demographic disparities in diagnosis
+5. Exclusion diagnosis
+6. Symptom overlap with a more common condition
+7. Long average time-to-diagnosis
+8. Self-report as primary evidence
+9. Treatment is highly personalized
+10. Metascience concerns
+
+Full text and per-flag actions: `references/red-flags.md`. Frame each one as a
+feature of the diagnostic territory: here is something worth knowing about this
+territory, and here is a question it suggests the user could ask.
+
+## Recurring situations
+
+**User cites a study.** Identify the evidence type, sample size and population,
+effect size separately from statistical significance, and whether it has been
+replicated. Clinician judgment counts as its own kind of evidence alongside the research.
+
+**User is locked onto one explanation.** Prompt once for alternatives. If they
+resist and the diagnosis is unconfirmed, keep the alternatives in the artifact
+and note it as something for the medical team. If the diagnosis is confirmed, their resistance is correct. Do not push.
+
+**User hits alarming information.** Ground it in base rates, separate possible
+from probable, and route it back into the structured evaluation as a question
+for the clinician.
+
+## Output
+
+Write `health-evidence-review-[condition]-[YYYY-MM-DD].md` to the working
+directory. Fill in `references/output-template.md` verbatim. Use the
+"Possible Explanations" section for differential-diagnosis questions and
+"Possible Scenarios" for confirmed-diagnosis progression or risk questions —
+one or the other, never both. Cite into the References section throughout so
+the user and their clinicians can trace where each question came from.

--- a/informed-patient/references/evidence-hierarchy.md
+++ b/informed-patient/references/evidence-hierarchy.md
@@ -1,0 +1,80 @@
+# Evidence Hierarchy: A Plain-Language Guide
+
+This reference helps you explain study types to someone who is not a researcher, is probably tired, and needs to make decisions about their health. Use clear language. Avoid jargon unless you define it immediately.
+
+## Why this matters
+
+Not all evidence is equal. A single person's story about what worked for them is real, but it tells you different things than a study of 5,000 people. When someone is evaluating health information, knowing *what kind* of evidence they're looking at helps them weigh it appropriately.
+
+## Source rules
+
+**Peer-reviewed publications only.** Only cite evidence from peer-reviewed scientific and medical literature: journals, systematic review databases (Cochrane), and clinical guidelines from recognized bodies. Do not cite preprints (medRxiv, bioRxiv, SSRN, or similar) as evidence. Preprints have not passed peer review and should be excluded entirely, even if they appear in search results.
+
+**Non-academic web sources** (Mayo Clinic, WebMD, NHS, Healthline, patient advocacy sites, etc.) may be used for plain-language context or patient experience data, but must not be cited as evidence for a clinical claim. If a web source references a study, find and cite the original study instead. If the original cannot be found or accessed, note that the claim could not be traced to a primary source.
+
+## The hierarchy (strongest → weakest for clinical decision-making)
+
+### Systematic reviews and meta-analyses
+**What it is:** Researchers gather all the existing studies on a question and analyze them together.
+**Why it's strong:** Combines evidence across many studies, reducing the chance that one flawed study drives conclusions. Can reveal patterns no single study shows.
+**Watch for:** Quality varies: a meta-analysis of bad studies is still bad evidence. Check whether the authors assessed study quality (look for terms like "risk of bias assessment" or "GRADE"). Also check *how many* studies were included and whether they were actually studying the same thing. **If a non-Cochrane systematic review does not report a risk-of-bias assessment, flag it with ⚠️ — it should be treated as lower confidence than a Cochrane review even though the study type is the same.**
+**Plain-language version for the user:** "This is a study of studies — researchers looked at everything published on this question and combined the results. It's generally the strongest evidence available, but it's only as good as the studies it includes."
+
+### Clinical practice guidelines
+**What it is:** Recommendations developed by a panel of clinicians and methodologists, synthesizing the available evidence and adding expert consensus to produce guidance for clinical practice. Major producers include NICE (UK), ACP, WHO, and specialty societies (e.g., American Headache Society, ACR).
+**Why it's useful:** Represents the current standard of care as understood by a field. When a guideline is recent and methodology is transparent, it's a high-value source for understanding what clinicians are expected to do and why.
+**Watch for:** Guidelines age badly. A guideline more than 5-10 years old may not reflect current evidence, so always check whether an update has been issued. Quality also varies: the best guidelines use GRADE methodology to explicitly rate the evidence behind each recommendation; others are based primarily on expert consensus with limited transparency. Check whether the guideline reports its evidence-grading methodology. **Always flag guidelines older than 5-10 years with ⚠️.**
+**Plain-language version for the user:** "This is an official set of recommendations from a medical organization about how doctors should approach this condition. It tells you what the standard of care is supposed to be — but check when it was published, because guidelines don't always keep up with new research."
+
+### Randomized controlled trials (RCTs)
+**What it is:** Participants are randomly assigned to either receive the treatment or not. Neither they nor (ideally) their doctors know which group they're in.
+**Why it's strong:** Randomization means the groups should be similar in every way except the treatment, so differences in outcomes are more likely caused by the treatment itself.
+**Watch for:** Sample size matters. A 30-person RCT is much weaker than a 3,000-person RCT. Also check *who* was in the study — if a drug was only tested on 25-year-old men, the results may not apply to a 60-year-old woman. Look at effect sizes, not just whether results were "statistically significant." A statistically significant result can still be clinically tiny.
+**Plain-language version for the user:** "This is the gold standard for testing whether a treatment works. People were randomly put in groups so the comparison is fair. But check how many people were in the study and whether they're similar to you."
+
+### Cohort studies
+**What it is:** Researchers follow a group of people over time to see what happens. They compare people who were exposed to something (a treatment, an environmental factor) to people who weren't.
+**Why it's useful:** Good for studying things you can't or shouldn't randomize (you can't randomly assign people to smoke). Can track long-term outcomes.
+**Watch for:** Because people aren't randomly assigned, the groups might differ in ways that affect the outcome. Researchers try to control for this statistically, but they can't control for things they didn't measure.
+**Plain-language version for the user:** "Researchers followed people over time and compared groups. It's useful but not as clean as a randomized trial because the groups might have been different in ways that affect the results."
+
+### Case-control studies
+**What it is:** Starts with people who have a condition and compares them to people who don't, looking backward for differences in exposure or history.
+**Why it's useful:** Good for rare conditions where you can't wait for cases to accumulate prospectively. Relatively fast and inexpensive.
+**Watch for:** Relies on people accurately remembering their past, which is unreliable. People who are sick tend to search harder for explanations, which can introduce bias.
+**Plain-language version for the user:** "Researchers compared people who have the condition to people who don't, looking back at their histories for differences. It's a starting point for understanding causes, but memory is unreliable and there are other biases to watch for."
+
+### Case series and case reports
+**What it is:** Detailed descriptions of one patient or a small group of patients with a condition or response to treatment.
+**Why it's useful:** Can identify new conditions, unusual presentations, or unexpected treatment responses. Often the first signal that something exists.
+**Watch for:** No comparison group. What happened to this patient may not happen to anyone else. Cannot establish cause-and-effect. Most vulnerable to publication bias: unusual cases get published, typical cases don't.
+**Plain-language version for the user:** "This is a detailed description of what happened to one person or a few people. It can be an important early signal, but it can't tell you whether the same thing would happen to you. There's no comparison group."
+
+### Clinical framework papers and consensus statements
+**What it is:** A paper or document that synthesizes existing evidence into a structured clinical tool — a diagnostic framework, a list of red flags, a classification system — often developed by a working group or expert panel. Distinct from a guideline (which tells clinicians what to do) and from a systematic review (which aggregates study results). Examples: the SNNOOP10 red flag framework for headache, the Rome criteria for functional GI disorders, the ACR classification criteria for rheumatoid arthritis.
+**Why it's useful:** These are often the frameworks clinicians actually use in practice. Understanding them helps a patient understand how their clinician is thinking. When validated in subsequent studies, they carry meaningful evidential weight.
+**Watch for:** The framework itself may be based on expert consensus rather than primary research — check whether it cites underlying studies. Validation studies matter: a framework that has been prospectively tested is more trustworthy than one developed purely from expert opinion. Note whether the framework was developed by an independent group or by a body with a potential interest in a particular classification.
+**Plain-language version for the user:** "This is a structured tool that clinicians use to organize their thinking — like a checklist of warning signs or a set of criteria for a diagnosis. It's based on synthesized evidence and expert agreement, not a single study. Check whether it has been tested in real patients."
+
+### Expert opinion and clinical experience
+**What it is:** What experienced clinicians believe based on their practice, even without formal studies.
+**Why it's useful:** For conditions with very little research, clinical experience may be the best available guidance. Experienced clinicians recognize patterns across many patients.
+**Watch for:** Subject to all human cognitive biases. Clinicians remember dramatic cases more than routine ones. Their patient population may not represent the full picture. Can perpetuate outdated practices.
+**Plain-language version for the user:** "This is what experienced doctors think based on treating patients, not based on formal studies. It matters — especially for conditions without much research — but it's also subject to the same biases all humans have."
+
+## Key concepts to explain when relevant
+
+### Effect size vs. statistical significance
+"Statistically significant" means the result probably isn't due to random chance. But it doesn't tell you how *big* the effect is. A medication might have a statistically significant effect on pain but only reduce it by 0.3 points on a 10-point scale — real, but maybe not worth the side effects. Always ask: how *much* did it help?
+
+### Number needed to treat (NNT)
+How many people need to take a treatment for one person to benefit. A higher NNT indicates that treatment is less effective. NNT of 2 = very effective (treat 2 people, 1 benefits). NNT of 100 = modest (treat 100 people, 1 benefits beyond what would happen without treatment). Useful for putting treatment benefits in perspective.
+
+### Base rates
+How common a condition actually is in the relevant population, or how common a certain scenario is when looking across a population. Base rates also shift with context: if you already have a known risk factor for a condition, the base rate among people like you may be meaningfully higher than the general population figure. Base rates can help contextualize rare conditions and likely explanations: rare conditions are still rare even when your symptoms appear to match. This isn't a reason to dismiss the possibility, but it is a reason to consider the more common explanations too and let the evidence guide you.
+
+### Generalizability
+Do the study participants look like you? Many clinical trials have historically underrepresented women, older adults, people of color, and people with multiple conditions. If a study population doesn't match you, the results still have value, but the confidence that they apply to your specific case is lower.
+
+### Publication bias
+Studies with positive results get published more than studies showing no effect. This means the published evidence can overstate how well something works. Systematic reviews that look for unpublished studies are more trustworthy on this dimension.

--- a/informed-patient/references/literature-search-strategy.md
+++ b/informed-patient/references/literature-search-strategy.md
@@ -1,0 +1,46 @@
+# Literature Search Strategy: Source Hierarchy and Query Templates
+
+This reference gives the exact search queries, source-by-source rationale, and warning conditions for the **structured search** mode described in the informed-patient skill's Phase 2. Use it when running the source hierarchy; refer back to the skill for when to use open search instead, and for how to present results (transparency, tagging, the Evidence Snapshot).
+
+## Source hierarchy: query templates by source type
+
+Use web search to find evidence across these source types, in priority order.
+
+### 1. Systematic reviews — cast a wide net, not just Cochrane
+
+Cochrane is the gold standard for systematic reviews because of its standardized methodology, but it has a meaningful blind spot: it tends to cover high-burden conditions with ample RCT evidence. For rarer conditions, newer conditions, or anything where RCTs are scarce, Cochrane may have nothing — and that's not the same as no systematic review existing. Search all of these:
+
+- `Cochrane review [condition]` — Cochrane first. **If this returns no results, do not silently skip it.** Report one of two things: (a) "I found a Cochrane review: [title, URL]" or (b) "I searched for Cochrane reviews and found none for this condition — this could suggest the condition is understudied or complex, and may require more individualized search to verify clinical consensus."
+- `[condition] systematic review PubMed` or `[condition] systematic review PMID` — PubMed indexes systematic reviews published in any peer-reviewed journal; a well-conducted review in JAMA or The Lancet is strong evidence. If you have a PubMed MCP connector available, use it for more reliable and comprehensive retrieval.
+- `[condition] NICE guideline` — NICE (UK) produces high-quality evidence reviews as part of guideline development, often covering conditions Cochrane hasn't addressed.
+- `[condition] AHRQ evidence review` — AHRQ (US) commissions systematic reviews via Evidence-Based Practice Centers. **Do not silently skip this** (see SKILL.md's Phase 2 for why). If the search returns no results, note it explicitly: "I searched for AHRQ reviews and found none for this condition." If strong Cochrane coverage already exists and you're stopping early, still note the skip: "AHRQ not searched — Cochrane and guideline coverage was sufficient."
+
+**Quality check for non-Cochrane systematic reviews:** When using a journal-published systematic review, check whether it reports a risk-of-bias assessment or uses GRADE methodology. If not, treat it as lower confidence than a Cochrane review even though the study type is the same.
+
+**If systematic reviews are absent:** Search PROSPERO (`[condition] PROSPERO systematic review registered`) — the international register of systematic reviews in progress. Finding a registered in-progress review is itself useful information: tell the user that research is underway but not yet published.
+
+### 2. Clinical practice guidelines
+
+Search for current guidelines from major bodies (ACP, NICE, WHO, relevant specialty societies). Search: `[condition] clinical practice guidelines [current year or recent]`. Note whether guidelines are recent — guidelines older than 5-10 years may not reflect current evidence.
+
+### 3. Peer-reviewed primary research
+
+If systematic reviews are thin, search PubMed for the best available primary studies, prioritizing RCTs and prospective cohorts over retrospective and case studies. Search: `[condition] [key symptoms] RCT PubMed` and `[condition] cohort study PubMed`.
+
+### 4. FDA/regulatory information
+
+If treatments are being discussed, check for FDA-approved indications, black box warnings, or recent safety communications. This applies to drug classes as well as specific drug names. Search: `FDA [drug class or drug name] [condition]` (e.g., `FDA ACE inhibitors hypertension` or `FDA lisinopril approval`).
+
+### 5. Patient advocacy organizations
+
+For time-to-diagnosis data, patient-reported experience, and practical information that doesn't appear in clinical literature. Search: `[condition] patient advocacy` or `[condition] foundation`. These are context, not clinical evidence.
+
+## Source-level warning conditions (flag with ⚠️ inline)
+
+When a source has a nuanced issue that affects how much weight to give it, flag it directly in the source entry with a ⚠️ and a one-sentence explanation. Do not bury these caveats in prose — make them impossible to miss.
+
+- Guidelines older than 5-10 years: ⚠️ _Published [year] — check the link to see if an update has been issued._
+- Abstract-only access: ⚠️ _Only the abstract was available — full methodology not reviewed._
+- No risk-of-bias assessment in a non-Cochrane systematic review: ⚠️ _This review does not report a risk-of-bias assessment — treat as lower confidence than a Cochrane review._
+- Small sample size relative to the claim being made: ⚠️ _[N] participants — findings may not generalize._
+- Population mismatch with the user: ⚠️ _Study population was [X] — relevance to your situation is uncertain._

--- a/informed-patient/references/output-template.md
+++ b/informed-patient/references/output-template.md
@@ -1,0 +1,94 @@
+# Health Evidence Review: Output Template
+
+This is the exact structure for the output artifact described in the informed-patient skill. Fill in every section using the interview, search, and evaluation results, adapting depth to what the user provided. Use "Possible Explanations" for differential diagnosis questions or "Possible Scenarios" for confirmed diagnosis with progression/risk questions — include only the relevant one, not both.
+
+```
+# Health Evidence Review: [Condition/Symptoms]
+Generated: [date]
+
+## My Symptom Picture
+
+### Current Symptoms
+[Structured inventory with frequency, severity, duration, functional impact, patterns]
+
+### Timeline
+[When it started, how it's changed, key events]
+
+### What's Been Tried
+[Tests, treatments, specialists seen, results]
+
+## What Our Search Covered
+
+### Search Context
+> **What we searched for:** [1-2 sentences describing the symptom picture and diagnostic territory that framed the search — e.g., "New-onset severe episodic headache with sleep disruption, no identified trigger, in someone with no prior headache history. Search focused on: secondary headache red flags and workup, primary headache differential (migraine, cluster, NDPH), and new-onset headache evaluation in primary care."]
+>
+> *A single search session cannot cover everything. If you think a relevant condition or angle was missed, note it here and bring it to your next appointment.*
+
+### Evidence Snapshot
+[1-3 bullets orienting the user to the research landscape: how well-studied is this, the strongest relevant finding, and — if research exists — how challenging this is clinically (misdiagnosis rates, common errors, diagnostic delays)]
+
+### Sources Reviewed
+[Each source with plain-language quality tag: study type and what it means, sample size and population, recency, and relevance to this user's specific situation. Include what couldn't be found.]
+
+> **How to verify these sources:** Click each link below. For PubMed links, check that the title and the finding attributed to it match what's described. For guidelines (NICE, AAFP, etc.), check the publication date — if it's more than 5-10 years old, it may have been updated. If a link is broken or the paper isn't about what this document says it is, treat that source as unverified and don't rely on it.
+
+> **Dig deeper — search these yourself:** Paste any of these into Google or Bing to search the source databases directly. These queries are more reliable when run in a browser than when run by Claude's search tool.
+> - `site:cochranelibrary.com [condition]`
+> - `site:pubmed.ncbi.nlm.nih.gov [condition] systematic review`
+> - `site:nice.org.uk [condition]`
+> - `site:effectivehealthcare.ahrq.gov [condition]`
+>
+> *(Replace `[condition]` with the specific terms most relevant to your situation — use the Search Context above as a guide.)*
+
+## Possible Explanations
+
+### Hypothesis 1: [Most likely / user's primary concern]
+- How well it explains my symptoms:
+- What it doesn't explain:
+- What would confirm it:
+- What would rule it out:
+
+### Hypothesis 2: [Alternative]
+[Same structure]
+
+### Hypothesis 3: [Alternative]
+[Same structure]
+
+## Possible Scenarios
+
+### Scenario 1: [Condition remains stable]
+- What the evidence says about this likelihood:
+- What factors in my profile support this:
+- What monitoring would confirm stability:
+
+### Scenario 2: [Condition progresses — early signs]
+- What the evidence says about this likelihood:
+- Risk factors that apply to me:
+- What early detection looks like:
+- What monitoring would catch this:
+
+### Scenario 3: [Complication develops — intervention options]
+- What the evidence says about treatment if this occurs:
+- How early treatment changes outcomes:
+- Questions for my medical team about prevention/monitoring:
+
+## Evidence Evaluation
+[Any specific studies, claims, or information the user wanted to evaluate, with plain-language quality assessment]
+
+## Red Flags to Be Aware Of
+[1-3 relevant flags with plain-language explanation and suggested actions]
+
+## Questions for My Medical Team
+
+### My Top Questions (for this appointment)
+[The 2-3 questions the user selected as highest priority — surfaced prominently so they're impossible to miss during a time-limited appointment]
+
+### Full Question Bank
+[All specific questions generated from the hypotheses, evidence evaluation, and red flags. Concrete and actionable — not generic. Saved here for future appointments or if there's time.]
+
+## References
+[All references drawn on to for all pieces of information and all questions presented in this document, presented in alphabetical order by author name using National Library of Medicine (NLM) citation style]
+
+---
+*This document was created as a thinking tool, not medical advice. It's designed to support conversations with your medical team, not replace them. Bring it to your next appointment, or use it for your personal reference. Be aware that how you frame search terms, and describe your symptoms, and what information you emphasize, will change what is surfaced in the literature review. It may be useful to run this search multiple times for the same set of symptoms.*
+```

--- a/informed-patient/references/phase-1-interview.md
+++ b/informed-patient/references/phase-1-interview.md
@@ -1,0 +1,69 @@
+# Phase 1: Guided Interview (Symptoms & History)
+
+Read this before asking the first interview question. Phase 1 closes only when
+the three non-negotiables at the bottom are satisfied.
+
+Ask these questions conversationally, not as a form, and not all at once. Group them naturally based on where the user is in their journey. Skip questions that don't apply. The goal is to gather enough information to build a useful artifact.
+
+**Required branching questions — ask early, before going deeper:**
+
+These questions determine which body of evidence is relevant and should be surfaced in the first exchange, not discovered later:
+
+- **Onset trigger:** Did symptoms start after a specific event — a viral illness, injury, medication change, pregnancy, surgery, or other identifiable trigger? Note any trigger that changes the research landscape significantly.
+- **Co-occurrence:** Is anything else going on — even things that seem unrelated or minor? Fatigue, skin changes, joint pain, mood shifts, GI symptoms, sleep disruption, anything new or different? Do not suggest a connection or interpretation; just collect. Many conditions present as a constellation of symptoms that patients have mentally filed as separate problems. The user may have anchored on one as "the main issue" while co-occurring symptoms are diagnostically significant or change which hypotheses are worth investigating.
+- **Diagnosis status:** Has any diagnosis been given or seriously suggested, or is this still unexplained?
+- **Care context:** Is this a first appointment, a follow-up, or an attempt to get a second opinion?
+
+Do not wait for these to emerge organically. If the user's opening description doesn't answer them, ask directly before moving on.
+
+**If the user's opening question is about a specific study, article, or claim:**
+Treat the claim as interview data, not as the deliverable. Acknowledge it, note what condition and question it implies, and proceed with the guided interview: "That study is a useful starting point, let me ask you a few questions so I can put it in context for your specific situation." The claim will be evaluated in Phase 3 as part of the evidence quality assessment, but the literature search should establish the broader evidence landscape first. A single study evaluated in isolation is less useful than a single study situated within the full body of evidence.
+
+**Current symptoms:**
+
+- What symptoms are you experiencing? (Let them describe freely first)
+- For each significant symptom: When did it start? How often does it happen? How would you rate severity on a 0-10 scale? What makes it better or worse?
+- How do these symptoms affect your daily functioning? (What can't you do, or what's harder?)
+
+**Timeline:**
+
+- When did you first notice something was off?
+- Have symptoms changed over time — gotten better, worse, or shifted?
+- Are there any patterns? (Time of day, menstrual cycle, seasons, stress, food, activity)
+- Any significant life events, exposures, or changes around the time of onset?
+
+**Medical history context:**
+
+- What have you already tried? (Treatments, specialists, tests)
+- What diagnoses have been suggested or ruled out?
+- Is there relevant family history?
+- Are there known personal characteristics that might matter?
+- Are you taking any medications or supplements?
+
+**What they're looking for:**
+
+- Do you have a specific condition you're researching or wondering about?
+- What prompted you to look into this now?
+- What does your medical team currently think?
+- Is this a first appointment or a follow-up? Are you seeing a GP/primary care provider or a specialist? (This shapes which questions will be most useful — a first GP visit calls for different priorities than a specialist workup.)
+
+Build the symptom inventory from their answers using structured dimensions:
+
+- **Frequency:** How often (daily, weekly, episodic, constant)
+- **Severity:** 0-10 scale or mild/moderate/severe with functional anchors
+- **Duration:** How long each episode lasts
+- **Functional impact:** What activities are affected and how
+- **Temporal patterns:** When symptoms occur, any triggers or relieving factors
+- **Trajectory:** Getting better, worse, stable, fluctuating
+
+These dimensions come from validated clinical assessment approaches. They can help the user offer clinicians structured data instead of a narrative they have to decode during a time-pressured appointment. Refer to `symptom-inventory-methodology.md` for the methodological grounding behind the elicitation sequence, guidance on functional anchors vs. numeric scales, and when to preserve the patient's own language rather than translating it into clinical terminology.
+
+**Symptom assessment is non-negotiable on three points — these are required before closing Phase 1:**
+
+1. **A symptom timeline.** At minimum: when did this start, and has it gotten better, worse, or stayed the same? A clinician cannot evaluate a symptom without a trajectory. If the user says "a while ago" or "it's been bad," ask once for specificity: "Can you give me a rough timeframe — weeks, months, longer?"
+
+2. **One concrete functional impact statement.** Encourage the user to record something specific. Instead of, "It affects my life," they should report a concrete impact like "I can't sleep through the night," "I've missed work twice this month," "I stopped going to the gym." This helps make symptoms legible to a clinician in a time-pressured appointment and is often what gets taken seriously. If the user hasn't offered one, ask: "What's the one thing you can't do, or can't do as well, because of this?"
+
+3. **A content validity check.** Before closing the interview, ask: "Is there anything about how this affects you that we haven't captured yet?" This is not optional small talk — it is the mechanism by which important symptom information that falls outside standard categories gets surfaced. Patients with understudied, complex, or atypical conditions frequently have the most diagnostically significant information in their answer to this question. If the user answers, add it to the symptom inventory in their own words. Do not rephrase into clinical language if the original wording is more specific or vivid.
+
+For all other dimensions, use judgment: if the user gives a curt or vague answer and the detail seems clinically relevant, ask one follow-up. Do not interrogate. If they decline or don't know, move on.

--- a/informed-patient/references/phase-2-search.md
+++ b/informed-patient/references/phase-2-search.md
@@ -1,0 +1,134 @@
+# Phase 2: Literature Search
+
+Read this before running the first search query. The red-flags check at the end
+of this file runs before Phase 3 begins, not at the end of the session.
+
+After the interview and before evidence evaluation, conduct a structured mini literature review. This is one of the most valuable things the skill does: most patients don't know what to search for, don't have access to the right databases, and can't easily distinguish a landmark systematic review from a single case report. Claude does this legwork and shows its work.
+
+**Transition from Phase 1 (required, non-blocking):** Before beginning the search, state the search framing in 2-3 sentences: what symptom picture you'll be searching against and what diagnostic territory you'll explore. Format like: "Before I search, let me confirm what I'll be looking for: [brief symptom summary]. I'll focus on [conditions/territory]. Correct me if I'm missing something — otherwise I'll get started." Do not wait for explicit approval — if the user doesn't correct the framing, proceed. The purpose is to give the user a chance to redirect, not to create a mandatory gate. Even if the user asks to skip ahead, still state the framing in one sentence before searching.
+
+**Tell the user what's happening:**
+
+> "Now I'm going to search the medical literature based on what you've told me. I'll share the exact search terms I use so you can see what I looked for — and tell me if I'm missing anything."
+
+### Search Mode
+
+This skill supports two search modes. The default is **structured search**.
+The user can request **open search** at any point, or the facilitator can
+suggest it when the user's situation warrants it.
+
+**Structured search** (default): Follow the source hierarchy below in order.
+This ensures systematic coverage and is appropriate for most sessions —
+especially when the user is early in their diagnostic journey, dealing with
+a well-studied condition, or using this skill for the first time. The
+hierarchy is the deliverable: the user gets a reproducible, auditable
+search with clear source types and quality tags.
+
+**Open search**: The source hierarchy serves as a starting checklist, not a
+workflow. After ensuring baseline coverage (at minimum: one systematic
+review search and one guideline search), follow the evidence where the
+interview data leads. This mode is appropriate when:
+
+- The user's situation involves the intersection of multiple conditions
+  (where the most relevant evidence won't be in standard single-condition
+  searches)
+- The user has a confirmed diagnosis and is asking about risk, prognosis,
+  or prevention which are questions that require following mechanistic and
+  epidemiological threads rather than searching a single condition
+- The interview reveals an onset trigger or comorbidity pattern that
+  changes which body of literature is relevant (e.g., post-viral onset,
+  medication-triggered symptoms)
+- Standard searches return thin results and the evidence landscape
+  requires creative search strategies to map
+- The user brings specific claims, studies, or information they've
+  encountered and wants evaluated, requiring the search to engage with
+  the user's sources rather than only finding new ones
+
+In open search mode, adhere to general documentation and evidence assessment guidelines. Still document every search query, still tag every source with quality indicators, and still report what you couldn't find. Inform the user that open search mode is being used and why.
+
+**Structured Search strategy:**
+
+Use web search across these source types, in priority order. Full query templates and per-source rationale are in `literature-search-strategy.md` — read it before running the search.
+
+1. **Systematic reviews — cast a wide net, not just Cochrane.** Search Cochrane, then PubMed, NICE, and AHRQ. **If Cochrane or AHRQ return no results, do not silently skip them** — report the null result explicitly; it can itself signal an understudied condition. Silent omission has been a recurring failure in testing.
+2. **Clinical practice guidelines** from major bodies (ACP, NICE, WHO, specialty societies). Note whether they're recent — guidelines over 5-10 years old may not reflect current evidence.
+3. **Peer-reviewed primary research** — if systematic reviews are thin, prioritize RCTs and prospective cohorts over retrospective and case studies.
+4. **FDA/regulatory information** — if treatments are discussed, check approved indications, black box warnings, recent safety communications.
+5. **Patient advocacy organizations** — time-to-diagnosis data and patient experience. Context, not clinical evidence.
+
+**When to stop searching:** Work through the hierarchy in order, but stop once the evidence base is sufficient to support the user's questions. If Cochrane and guideline coverage is solid, lower-priority sources can be skipped unless they'd add something new. Use judgment. When you stop early, say so: "I stopped here because the Cochrane and guideline coverage was sufficient — see the informed-patient skill README if you want to force a complete search through all source types."
+
+**Search term transparency:**
+
+Share every search query with the user as you go. Format like:
+
+> "I searched for: `[exact query]` — here's what I found."
+
+This models good research practice and lets the user course-correct. They may know terminology, specialist names, or subtype distinctions that improve the search.
+
+**For each source found, tag it with a plain-language quality indicator:**
+
+- Study type and what that means (e.g., "Systematic review of 12 RCTs — this is strong synthesized evidence")
+- Sample size and population (e.g., "342 participants, mostly women aged 30-50"); for meta-analyses, number of studies included is more informative than participant count (e.g., "pooled analysis of 27 RCTs")
+- How recent it is (e.g., "Published 2023 — relatively current")
+- Relevance to the user's specific situation (e.g., "This studied the exact symptom pattern you described" or "This focused on a different population but the mechanism is relevant")
+
+Refer to `evidence-hierarchy.md` for how to explain each study type in plain language.
+
+**The "what I couldn't find" moment:**
+
+This is critical. If the search reveals limited evidence, say so explicitly and name what it means:
+
+> "I searched for [terms] and found very little published research. This is itself important information. It tells us this could be an understudied area, which means clinical practice may be based more on expert experience than on rigorous studies."
+
+Absence of evidence is not nothing, it's a finding. It should:
+
+- Trigger the "understudied condition" red flag
+- Be included prominently in the output artifact (not buried or glossed over)
+- Be framed as actionable: "This means it's especially important to find a clinician with direct experience treating this condition, since published guidance is limited"
+
+If the evidence is **contested** (conflicting meta-analyses, guideline disagreements, active scientific debate), name that too. Don't resolve it — present the disagreement clearly and flag it as a metascience concern for the red flags section. Contested evidence should:
+
+- Trigger the "metascience concerns" red flag and potentially the "treatment is highly personalized" red flag
+- Be included prominently in the output artifact (not buried or glossed over)
+- Be framed as actionable: "This means it's important to develop a specific treatment plan for your individual context with the guidance of a clinician"
+
+**Search scope:**
+
+Aim for 5-10 key sources that represent the best available evidence. Prioritize quality and relevance over volume. For each hypothesis generated later, there should be at least one relevant source — if there isn't, that's a notable gap to document.
+
+Do not cite sources you haven't actually found and reviewed through web search. If you can only access an abstract rather than the full text, say so: "I could only see the abstract of this study, so I can't assess the full methodology. The abstract reports [X]."
+
+**Citation integrity — non-negotiable:** Every source in the artifact must include the URL that was returned by the web search tool. Never construct or recall a PMID, DOI, or other identifier from memory — only use identifiers that appeared in an actual search result URL. If a search returned a result but no stable URL is available, describe the source (journal, author, year, title) and note that a direct link could not be retrieved. A source without a verifiable URL is weaker evidence of retrieval than one with a URL — flag it as such rather than omitting it or fabricating an identifier.  
+
+**Source-level warnings — use ⚠️ inline:** When a source has a nuanced issue that affects how much weight to give it, flag it directly in the source entry with a ⚠️ and a one-sentence explanation — don't bury it in prose, make it impossible to miss. See `literature-search-strategy.md` for the specific warning conditions and phrasing (outdated guidelines, abstract-only access, missing risk-of-bias assessment, small samples, population mismatch).
+
+**Evidence Snapshot (required):**
+
+Before presenting the detailed source list, synthesize 1-3 bullet points that orient the user to the research landscape. Keep each bullet to 1-2 sentences. These should collectively address:
+
+- **How well-studied is this?** Is there robust published evidence (systematic reviews, guidelines) or is this an understudied area where clinical practice is based more on expert experience?
+- **What does the strongest evidence tell us?** One specific, concrete finding that is most relevant to the user's situation.
+- **How challenging is this clinically?** If the research includes data on clinical care challenges — misdiagnosis rates, common errors in triage, conditions frequently confused with this one, or known diagnostic delays, include that here. This helps the user understand whether they're navigating a straightforward clinical situation or one where even experienced clinicians regularly struggle. If no such research was found, omit this bullet.
+
+Format like:
+
+> **What the research landscape looks like:**
+>
+> - [Well-studied / Moderately studied / Understudied]: [Brief reason — e.g., "Several systematic reviews exist, though most focus on treatment rather than early diagnosis."]
+> - Strongest relevant finding: [Specific, concrete takeaway from the best source found]
+> - [If applicable] Clinical challenges: [What the literature says about misdiagnosis, common errors, or diagnostic difficulty — omit if no relevant research found]
+
+The goal is to help the user immediately understand whether they're dealing with a common, well-mapped problem or a more complex, less-charted one, and whether the clinical pathway is typically clear or frequently goes wrong.
+
+**Red flags check (run immediately after the literature search, before Phase 3):**
+
+Based on what the search revealed, apply the red flags framework now, not later. The literature search is itself the primary input for flags 1, 7, and 9:
+
+- **Flag 1 (Understudied condition):** Did the search return few or no systematic reviews or RCTs? Say so explicitly and flag it.
+- **Flag 7 (Long time-to-diagnosis):** Did the literature or advocacy sources mention a long diagnostic delay for this condition?
+- **Flag 10 (Metascience concerns):** Did the search reveal conflicting guidelines, contested meta-analyses, or known evidence-practice gaps?
+
+Surface the 1-3 most relevant flags at this point and carry them into the output artifact. Flags identified here should shape how confidently evidence is presented in Phase 3. A condition with active flags warrants more scrutiny of hypotheses more explicit uncertainty than a well-mapped one.
+
+Refer to `red-flags.md` for the full set of flags and suggested actions.

--- a/informed-patient/references/phase-3-evaluation.md
+++ b/informed-patient/references/phase-3-evaluation.md
@@ -1,0 +1,69 @@
+# Phase 3: Evidence Evaluation
+
+Read this before drafting hypotheses. Phase 3 ends with the user picking their
+top 2-3 questions — that interaction is required, not optional.
+
+Once you understand the user's situation, shift to helping them summarize their understanding of how the evidence landscape relates to the questions they want to bring to their medical team. This phase is more template-driven: explain each section and help them think through it.
+
+**Competing hypotheses:**
+
+First, determine the user's diagnosis status from Phase 1. This changes how hypotheses are framed:
+
+**If the user has an unconfirmed or suspected diagnosis** (suggested but not clinically confirmed, or self-identified): Generate at least 3 possible explanations for their symptom picture. Include the condition they're most focused on, at least one more common alternative, and at least one less obvious possibility. For each, note: how well does it explain ALL the symptoms? What doesn't it explain? What would confirm or disconfirm it? This isn't about being right — present it as: "Let's map out the possibilities so we can think about which ones deserve more investigation."
+
+**If the user has a confirmed diagnosis** (clinically confirmed with objective evidence — test results, imaging, biopsy, specialist assessment): Treat the diagnosis as a known fact. Do not generate competing "maybe it's something else" hypotheses — this is unhelpful and potentially undermining. Instead, reframe the hypotheses section around: What subtypes or variants of this condition might apply? What complications or comorbidities are worth exploring? Are there any symptoms not fully explained by the known diagnosis that warrant separate investigation? This is still hypothesis generation, but anchored to the confirmed diagnosis rather than questioning it.
+
+**If diagnosis status is ambiguous** (e.g., "my doctor thinks it might be X" or "I was told it could be X"): Treat as unconfirmed and generate full competing hypotheses, noting clearly which diagnosis was suggested and what evidence would confirm or rule it out.
+
+**When a user resists considering alternatives:** If the user pushes back on competing hypotheses and their diagnosis is unconfirmed, note it once — "I'll keep these alternatives in the artifact as something to discuss with your medical team" — and do not remove them. Do not override the user's priorities, but do not abandon the hypotheses either. If their diagnosis is confirmed, their resistance is appropriate — don't push alternatives.
+
+**If the user has a confirmed diagnosis and is asking about a future complication or progression risk:** Do not frame hypotheses as competing explanations for current symptoms. Instead, frame them as scenarios: What is the likelihood of progression? What modifiable and non-modifiable risk factors apply to this user? What monitoring or early intervention evidence exists? The hypothesis structure becomes:
+
+- Scenario 1: [Condition remains stable / does not progress]
+- Scenario 2: [Condition progresses — what does early detection look like?]
+- Scenario 3: [Complication develops — what are the treatment options?]
+
+This reframing keeps the structured thinking without forcing the user into a differential diagnosis framework that doesn't match their actual question.
+
+**Evidence weighting:**
+For each hypothesis, help the user think through:
+
+- **Prior probability:** How common is this condition in people like you? (Base rates matter. However, note carefully where base rates are not well known)
+- **Evidence that increases probability:** Which of your symptoms, test results, or known history make this more likely?
+- **Evidence that decreases probability:** What doesn't fit? What would you expect to see that you don't?
+- **What would update your confidence most?** What test, finding, or specialist evaluation would most change how likely this explanation seems? What would we look for that would make us think we need to explore a different diagnosis?
+
+Explain this in plain language: "Let's think about what makes each possibility more or less likely given what you know."
+
+For scenarios (progression/risk questions), reframe as: How likely is this outcome? What factors increase or decrease that likelihood for me specifically?
+
+Do not:
+
+- Use statistical terms without explaining them in plain language
+- Attribute reasoning or why to the user that they have not stated
+
+**Evidence quality assessment:**
+If the user references specific studies, articles, or claims about a condition, help them evaluate using the reference file at `evidence-hierarchy.md`. Key questions to surface:
+
+- What kind of study is this? (Explain in plain language what that means for strength of evidence)
+- How many people were studied?
+- Were the study participants similar to you?
+- If a treatment effect is being considered, how big was the effect? Why is this considered practically significant (Not just "was it statistically significant" but "how much did it help?")?
+- Where are different diagnoses and conditions commonly confused? What evidence helps to distinguish and correct misdiagnoses?
+- Has this been replicated?
+
+Keep this accessible. The user is not becoming a researcher — they're learning to ask "how strong is this evidence?" in a structured way.
+
+**Question generation and prioritization:**
+
+Draft all questions that emerge from the hypotheses, evidence evaluation, and red flags. Then — before writing the artifact — ask the user to pick their top 2-3:
+
+> "I've put together [N] questions based on everything we've covered. A standard appointment won't have time for all of them. Which 2-3 feel most important to you right now?"
+
+Present the questions in a numbered list so they can respond by number. Tailor the list to the appointment context gathered in Phase 1 (first visit vs. follow-up, GP vs. specialist). After they pick:
+
+- Acknowledge their choices briefly — no need to re-explain the questions
+- If one of their selections seems lower-stakes given what the evidence suggests, you can note it once, but don't override their ranking
+- If they can't decide, offer to rank by stakes: "If you want, I can flag which ones I'd prioritize based on what the evidence suggests is most urgent"
+
+Their selected questions go into **My Top Questions** in the artifact. All questions go into **Full Question Bank**.

--- a/informed-patient/references/red-flags.md
+++ b/informed-patient/references/red-flags.md
@@ -1,0 +1,67 @@
+# Diagnostic Red Flags: Epistemic Risk Factors
+
+These are structural features of a diagnostic landscape, never accusations against individual clinicians or researchers. They represent situations where the evidence itself, or the conditions around it, warrant extra scrutiny, more questions, and sometimes a second perspective.
+
+Surface 1-3 of the most relevant flags per user situation. Each flag should be accompanied by a concrete suggested action.
+
+## The Flags
+
+### 1. Understudied condition
+**What it means:** Limited published research. Few or no RCTs. Clinical guidelines based on small studies or expert consensus rather than robust evidence.
+**Why it matters:** When evidence is sparse, clinical practice varies more. What one doctor recommends may differ substantially from another, and neither may have strong evidence backing their approach.
+**Suggested action:** "Ask your clinician: How strong is the evidence behind the recommended treatment? Is there consensus in the clinical perspective on this, or do different doctors approach this differently?"
+
+### 2. Common symptom, many possible causes
+**What it means:** The primary symptom(s) could be explained by many different conditions across different body systems (e.g., fatigue, chronic pain, dizziness, GI distress).
+**Why it matters:** When a symptom has dozens of possible explanations, early diagnostic decisions can narrow the search prematurely. The first specialist you see may look within their domain and miss causes outside it.
+**Suggested action:** "Ask your clinician: What else could explain these symptoms that we haven't tested for yet? Should I see a specialist in a different area?"
+
+### 3. Anchoring risk
+**What it means:** An initial diagnosis or hypothesis may be influencing all subsequent clinical thinking, even when new evidence doesn't fully support it.
+**Why it matters:** Anchoring is one of the most common cognitive biases in medicine. Once a diagnosis is in your chart, subsequent clinicians often start from that assumption rather than re-evaluating from scratch. This is a feature of human cognition, not a failure of any individual clinician.
+**Suggested action:** "Consider asking a new clinician to evaluate your symptoms without seeing your previous diagnosis first. You can also ask your current team: If we started from scratch today, would we reach the same conclusion?"
+
+### 4. Known demographic disparities in diagnosis
+**What it means:** Research shows that diagnosis rates, time-to-diagnosis, or treatment quality differ by demographic group (sex, race, age, weight, etc.) for this condition.
+**Why it matters:** These disparities are well-documented in the medical literature. They don't mean any individual clinician is biased, but they mean the system as a whole has patterns that can affect your care. Being aware of them helps you advocate more effectively.
+**Suggested action:** "If relevant, mention awareness of these disparities to your clinician. Many clinicians actively work to counteract these patterns when they're made visible."
+
+### 5. Exclusion diagnosis
+**What it means:** This condition is diagnosed by ruling everything else out rather than by a definitive test. There's no single biomarker or scan that confirms it.
+**Why it matters:** Exclusion diagnoses are inherently uncertain. The diagnosis is only as good as the thoroughness of the workup that preceded it. If the differential was too narrow, the exclusion may be premature.
+**Suggested action:** "Ask your clinician: What conditions did we rule out to reach this diagnosis? Are there any we haven't tested for yet? What would change your confidence in this diagnosis?"
+
+### 6. Symptom overlap with a more common condition
+**What it means:** Your symptoms closely match a condition that is much more common than the one being considered (or vice versa — you may have been diagnosed with the common condition when a rarer one fits better).
+**Why it matters:** Clinicians are trained to consider common conditions first ("when you hear hoofbeats, think horses, not zebras"). This is usually good medicine, but it means rarer conditions with overlapping symptoms can be missed or delayed.
+**Suggested action:** "Ask: What's the less common explanation for these symptoms? Has it been considered and ruled out, or just not considered?"
+
+### 7. Long average time-to-diagnosis
+**What it means:** For this condition, the published literature or patient advocacy data shows that the average time from symptom onset to diagnosis is years, not months.
+**Why it matters:** A long time-to-diagnosis usually signals that the condition is hard to recognize, lacks a definitive test, or overlaps with other conditions. It means your experience of "not getting answers" may be typical of the condition itself, not a reflection of your credibility or the quality of your care.
+**Suggested action:** "Mention this pattern to your clinician. Ask whether they've seen cases of this condition and what the diagnostic pathway typically looks like."
+
+### 8. Self-report as primary evidence
+**What it means:** For this condition, the patient's description of their symptoms is the primary or sole diagnostic evidence. There's no definitive lab test, imaging finding, or biomarker.
+**Why it matters:** Self-report-based diagnosis depends on the clinician believing and carefully listening to the patient, and on the patient being able to clearly describe their experience. Communication quality matters enormously. Having a structured symptom inventory can make a significant difference.
+**Suggested action:** "Bring a written symptom log with frequency, severity, timing, and functional impact. This gives the clinician structured data rather than relying entirely on what you remember to say in the appointment."
+
+### 9. Treatment is highly personalized
+**What it means:** Individual treatment and responses to treatment are highly idiosyncratic. Treating this condition often requires working closely with a provider to determine whether a treatment plan is working. Different individuals may respond better or worse to the same treatment. There are known issues in treatment effect heterogeneity (the fact that the same treatment can work very differently in different people) depending on individual characteristics.
+**Why it matters:** Medical research is heavily weighted toward population averages and generalizing from samples to average effects. Personalized medicine is still a new and emerging frontier, and does not always get translated into individual healthcare. For many conditions, clinicians need to develop a personalized plan with the patient. This may mean that even though the research is valid, your individual response does not match the average result found in studies.
+**Suggested action:** "Ask your clinician: How will we know if this treatment is working for me specifically? What's the timeline for seeing a response, and what's the plan if I don't respond as expected? Are there factors about my situation that might predict how I'll respond?"
+
+### 10. Metascience concerns
+**What it means:** There are controversies in the research literature itself — conflicting meta-analyses, clinical guidelines that haven't been updated to reflect recent evidence, known issues with replication, or documented gaps between evidence and clinical practice.
+**Why it matters:** Sometimes the problem isn't that evidence is missing, but rather that the evidence base itself is contested, or that clinical practice hasn't caught up with the best available evidence. This may mean you may encounter conflicting recommendations, and it may be particularly important for patients who are understudied or in a context with less access to cutting-edge clinical care to be aware of these issues.
+**Suggested action:** "Ask your clinician: Are there recent studies or updated guidelines that might change the approach? If you get conflicting advice from different specialists, ask each one what evidence they're basing their recommendation on."
+
+## How to use these flags
+
+These flags are tools for thinking, not diagnoses of your medical care. Their purpose is to help you:
+
+1. **Ask sharper questions** — each flag comes with specific questions you can bring to your clinician
+2. **Calibrate your confidence** — more flags active means more reason to seek additional perspectives
+3. **Understand your situation** — sometimes knowing "this condition is hard to diagnose" is itself valuable information that helps you be patient with the process while still advocating for yourself
+
+Include the 1-3 most relevant flags in the structured artifact, with the associated suggested actions framed as discussion points for the medical team.

--- a/informed-patient/references/symptom-inventory-methodology.md
+++ b/informed-patient/references/symptom-inventory-methodology.md
@@ -1,0 +1,138 @@
+# Symptom Inventory Methodology: A Reference for Elicitation Best Practice
+
+This reference grounds the skill's Phase 1 interview in measurement science. Use it to make better decisions about how to ask, when to press, when to use structured dimensions, and when to preserve the patient's own language.
+
+---
+
+## Why this matters
+
+Symptom inventories are the foundation of clinical reasoning, but most are poorly designed. The majority of symptom instruments in clinical use were developed by clinicians without systematic input from patients, validated in narrow populations, and then applied universally. The result is instruments that are legible to clinicians but frequently miss what patients actually experience.
+
+For this skill specifically, poor elicitation has two failure modes:
+1. **Under-capture:** The patient describes something in their own words that doesn't map to the structured dimensions Claude collects, so important information is lost before it reaches the clinician
+2. **Leading:** Asking about structured dimensions first anchors patients to the categories Claude offers rather than their own experience — this is the most common methodological error in survey design
+
+The research on this is unambiguous: do open-ended elicitation first, and create structured dimensions second.
+
+---
+
+## The core tension: standardized vs. patient-generated
+
+**Standardized symptom inventories** (structured dimensions: severity 0-10, frequency, duration, etc.) are valuable because:
+- They're legible to clinicians who see many patients and need to make fast comparisons
+- They map to validated outcome measures and diagnostic criteria
+- They reduce recall error by giving patients concrete anchors
+
+**Patient-generated descriptions** are valuable because:
+- Patients experience symptoms in ways that don't map neatly to pre-defined categories
+- The words a patient uses to describe a symptom can be diagnostically significant (e.g., "electric" vs. "aching" vs. "stabbing" pain)
+- Forcing patients into pre-defined categories can cause them to omit or distort information that doesn't fit
+- Many conditions, especially underdocumented, understudied, or rare conditions, have symptom presentations that standard inventories weren't designed to capture
+
+**Best practice resolves this tension sequentially:** elicit freely first, then map to structured dimensions. This is the approach the skill uses, and it is empirically supported.
+
+---
+
+## Key principles with methodological grounding
+
+### 1. Open-ended elicitation before structured dimensions
+
+**Why:** Cognitive interviewing research shows that presenting response categories before asking for open description anchors respondents to those categories — they describe their experience in terms of the options they've been shown rather than their actual experience. This is a well-documented source of measurement error in survey design.
+
+**In practice:** "What symptoms are you experiencing?" (free description first) before "On a scale of 0-10, how severe is the pain?" This is the correct sequence. Do not invert it.
+
+**Source:** 
+
+Willis, G. B. (2004). Cognitive interviewing: A tool for improving questionnaire design. sage publications.
+
+---
+
+### 2. Functional anchors are more reliable than abstract numeric scales
+
+**Why:** The 0-10 numerical rating scale (NRS) for pain is widely used but has documented reliability problems: patients interpret the same number differently, and the same patient uses numbers differently across contexts. Functional anchors ("0 = no pain at all, 10 = worst pain imaginable, like breaking a bone") improve inter-rater and test-retest reliability.
+
+The more clinically useful question is often not "rate your pain 0-10" but "what can't you do because of this?" This is a functional impact question. This is also what clinicians weight heavily in time-limited appointments, because it converts subjective experience into an observable, actionable problem.
+
+**In practice:** Use numeric scales as a rough orientation, but always pair them with a functional anchor. The skill's required "one concrete functional impact statement" is grounded in this evidence.
+
+**Source:** 
+
+Farrar, J. T., Young Jr, J. P., LaMoreaux, L., Werth, J. L., & Poole, R. M. (2001). Clinical importance of changes in chronic pain intensity measured on an 11-point numerical pain rating scale. Pain, 94(2), 149-158. PMID: 11690728. This landmark paper established the concept of the Minimum Clinically Important Difference (MCID) for the NRS and demonstrated the limits of treating numeric pain ratings as continuous, interval-level data.
+
+---
+
+### 3. Content validity: does your inventory capture what matters to this patient?
+
+**Why:** An inventory has *content validity* if it covers the domains that are actually relevant to the patient's experience. Standard instruments frequently fail content validity for understudied conditions, for conditions with heterogeneous presentations, and for patients whose demographics differ from the instrument's development population. The FDA has made content validity a regulatory requirement for patient-reported outcome instruments used in drug development — meaning this is not a theoretical concern.
+
+**In practice:** After collecting structured dimensions, ask: "Is there anything about how this affects you that we haven't captured?" This is not a throwaway question — it is a content validity check. For conditions with unusual presentations or limited research, this question is especially important because standard categories may miss the most diagnostically significant aspects of the patient's experience.
+
+**Source:** Patrick DL, Burke LB, Gwaltney CJ, et al. "Content validity—establishing and reporting the evidence in newly developed patient-reported outcomes (PRO) instruments for medical product evaluation." *Value in Health.* 2011;14(8):977-988. PMID: 21995957. 
+
+---
+
+### 4. Patient-generated measures capture things standardized instruments miss
+
+**Why:** Patients often have symptom concerns or functional impacts that fall outside the domains any standard instrument assesses. The MYMOP (Measure Yourself Medical Outcome Profile) was developed specifically to address this: rather than asking patients to rate pre-defined domains, it asks patients to name the two symptoms or problems that matter most to them and rate those. Studies consistently show that patient-nominated items capture different, and often more important, concerns than clinician-generated items. In general, Patient-Centered Outcomes Measures (PCOMs) have the potential to systematically incorporate patient perspectives to measure those outcomes that matter most to patients.
+
+**In practice:** This principle supports the skill's "co-occurrence" branching question. Patients often mentally file related symptoms as separate, unrelated problems. Asking "is there anything else going on, even things that seem unrelated?" is not optional. This provides a mechanism by which patient-generated symptom data surfaces alongside clinician-generated categories.
+
+**Sources:** 
+
+Paterson C. "Measuring outcomes in primary care: a patient generated measure, MYMOP, compared with the SF-36 health survey." *BMJ.* 1996;312(7037):1016-1020. PMID: 8616351. Paterson's development and validation of MYMOP is a foundational work on patient-generated outcome measures and demonstrates empirically that what patients most want to track is systematically different from what standard instruments measure.
+
+Morel, T., & Cano, S. J. (2017). Measuring what matters to rare disease patients–reflections on the work by the IRDiRC taskforce on patient-centered outcome measures. Orphanet journal of rare diseases, 12(1), 171. Argues for argue for greater multi-stakeholder collaboration to develop PCOMs, with rare disease patients and families at the center, and proposes propose mixed methods psychometric research as the best route to deliver fit-for-purpose PCOMs in rare diseases, as this methodology brings together qualitative and quantitative research methods in tandem with the explicit aim to efficiently utilise data from small samples.
+
+Garratt, A., Schmidt, L., Mackintosh, A., & Fitzpatrick, R. (2002). Quality of life measurement: bibliographic study of patient assessed health outcome measures. Bmj, 324(7351), 1417.  PMID: 12065262. PMC: PMC115850.
+Key finding: Of 3,921 reports on PRO instruments, only 1% covered individualized measures. Directly states individualized measures "have measurement properties that are not captured by generic and specific measures based on summed rating scales."
+
+Wiering, B., de Boer, D., & Delnoij, D. (2017). Asking what matters: the relevance and use of patient‐reported outcome measures that were developed without patient involvement. Health Expectations, 20(6), 1330-1341. What patients rate as highly important can be underweighted in standardized outcome measures that are developed without patient involvement.
+
+---
+
+### 5. The PROMIS framework: what validated patient-reported outcomes look like
+
+The Patient-Reported Outcomes Measurement Information System (PROMIS) is a rigorously developed and validated bank of PRO instruments. Developed with NIH funding over 15+ years, PROMIS item banks cover physical function, pain interference, fatigue, sleep disturbance, anxiety, depression, and other domains, all developed with extensive patient input, cognitive interviewing, and large-scale psychometric validation across diverse populations.
+
+PROMIS is relevant to this skill not as an instrument to administer directly, but as a benchmark for what *good* symptom measurement looks like:
+- Items were developed with patient input (content validity)
+- Items were cognitively tested before finalization
+- Items use functional language, not just abstract ratings
+- The same constructs are measured consistently across conditions
+- Normative data allows comparison to general population
+
+**Why this matters for elicitation:** When Claude helps a patient describe symptoms, the PROMIS domain framework is a useful reference for what dimensions matter. For example, pain *intensity* and pain *interference* (how much pain affects daily activities) are separate constructs. Both matter, and conflating them is a common error.
+
+**Source:** Cella D, Riley W, Stone A, et al. "The Patient-Reported Outcomes Measurement Information System (PROMIS) developed and tested its first wave of adult self-reported health outcome item banks: 2005–2008." *Journal of Clinical Epidemiology.* 2010;63(11):1179-1194. PMID: 20685078. This is the primary development paper for PROMIS. Instruments are freely available at healthmeasures.net.
+
+---
+
+### 6. Symptom elicitation and the explanatory model
+
+Patients come to medical encounters with their own theory of what is happening and why. Eliciting this model strengthens understanding and exchange, but it is not just about building rapport. Elicitation of patients' own mental models and theories about their health can directly change what information the patient volunteers and what they withhold. Patients who believe their symptom is caused by stress may minimize physical details they consider "irrelevant." Patients anchored on a specific diagnosis may omit symptoms that don't fit that diagnosis.
+
+Arthur Kleinman's explanatory model framework — developed in medical anthropology but now widely used in clinical communication research — provides a theoretical grounding for why patient-centered elicitation matters. The key questions from Kleinman's model: What do you think is causing this? Why did it start when it did? What does it do to you? What do you fear most about it?
+
+These are not questions the skill asks directly, but they represent the underlying information structure that free elicitation surfaces. Claude's instruction to ask "what prompted you to look into this now?" is a partial application of this principle. 
+
+**Source:** Kleinman A, Eisenberg L, Good B. "Culture, illness, and care: clinical lessons from anthropologic and cross-cultural research." *Annals of Internal Medicine.* 1978;88(2):251-258. PMID: 626456. This is one of the most cited papers in clinical communication research and the foundational text for explanatory model elicitation in medicine.
+
+---
+
+## What this means for how Claude conducts Phase 1
+
+**Do:**
+- Start with free description before introducing any structured dimensions
+- Use functional language: "what can't you do" before "rate your pain 0-10"
+- Always close with an open check: "Is there anything about how this affects you that we haven't captured yet?"
+- Preserve the patient's exact words in the symptom inventory where they're diagnostically or contextually significant — don't always translate into clinical language
+- Treat the co-occurrence question as a patient-generated measure check, not an afterthought
+
+**Don't:**
+- Present structured dimensions (severity scale, frequency categories) before the patient has described freely
+- Treat a 0-10 rating as the primary severity data — always pair it with a functional anchor
+- Assume standard inventory dimensions cover everything — especially for understudied, rare, or complex conditions
+- Rephrase the patient's symptom language into clinical terminology without noting the original description
+
+**The content validity check (required):**
+After collecting structured dimensions, always ask: "Is there anything about how this affects you that we haven't captured?" This is a mechanism by which important symptom information that falls outside standard categories can get surfaced. For conditions with heterogeneous presentations or limited research, this question frequently returns the most diagnostically significant data in the entire interview.


### PR DESCRIPTION
Adds `informed-patient`, restructured for progressive disclosure.

Upstream is [DrCatHicks/informed-patient](https://github.com/DrCatHicks/informed-patient) (Cat Hicks, CC BY 4.0, 145 stars). It walks a user through a symptom interview, a structured literature search with quality-tagged sources, and an evidence-evaluation pass. The output is a markdown file the user brings to an appointment.

## The split

Upstream ships one 34.6KB SKILL.md plus five reference files. That SKILL.md is larger than anything in this repo (`declauding` is the previous ceiling at 23.9KB) and roughly 80% of it is phase-specific procedure that only matters once you are in that phase.

Split into an 8.1KB resident core and three new phase references:

| file | bytes | when it loads |
|---|---|---|
| `SKILL.md` | 8092 | on trigger |
| `references/phase-1-interview.md` | 6441 | before the first interview question |
| `references/phase-2-search.md` | 11952 | before the first search query |
| `references/phase-3-evaluation.md` | 6400 | before drafting hypotheses |

Procedure text in the three phase references is upstream's, verbatim.

The five upstream references carry over with one edit each: intra-directory links lost their `references/` prefix (`references/red-flags.md` → `red-flags.md`), since the files that link to them now sit in the same directory. Six such links across three files; nothing else in those five changed.

## Contents of the resident core

Upstream's `EVALUATION.md` is a 30-test suite, and its section 3 tests process adherence — that branching questions are asked, that a functional-impact statement is required, that red flags fire after the search rather than at the end. A split that pushed those behind a lazy load would let a reference that never loads take a guardrail with it.

So the core keeps: scope boundaries, the no-diagnose / no-treatment-recommendation / no-therapy rules, citation integrity, "absence of evidence is a finding", the phase sequence with per-phase entry conditions, the ten red-flag names, and the artifact-is-a-file requirement. Explanation and verbatim template text went to references. When a reference fails to load, the cost is now quality rather than sequence or safety.

The trigger stays narrow, as upstream wrote it: explicit request by name, no firing on health questions or symptom mentions alone.

## Attribution

CC BY 4.0 requires attribution, a link to the licence, and an indication of changes. All three are in the SKILL.md `## Attribution` section. `LICENSE.txt` carries the full text, included because this repo is MIT at the root and this subtree is not.

## Verification

`muninn_utils.skill_lint.validate_skill_file(..., require_version=True)` passes. `declaude_lint.py --skip-quoted` on the authored core reports 8 candidates, all format artifacts (the numbered flag list reading as fragment cadence, upstream's ⚠️ convention, a definition-list dash).

The behavioral tests in upstream's `EVALUATION.md` are not automated and I have not run them against this build. That is the check worth running before trusting the split.

`scripts/validate_skills.py informed-patient` passes on this branch.

## Not done

`.claude-plugin/marketplace.json` bundles skills into category plugins and its version string is a datestamp, so something regenerates it. I did not add an entry — no existing category (`ai-and-reasoning`, `code-intelligence`, `web-and-retrieval`, …) is an obvious home for a health skill, and the taxonomy is yours. Merging this without the entry gets the skill into the sideload path; the marketplace bundle can follow.
