### PR TITLE
dunking-anonymously: anonymised dunk-quote renderer

### DIFF
--- a/dunking-anonymously/SKILL.md
+++ b/dunking-anonymously/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: dunking-anonymously
+description: Renders a Bluesky post as an anonymised screenshot so its words can be criticised without a link back to whoever wrote them. Blacks out avatar, display name, handle and any at-mentions in declassified-document styling, then emits a PNG and its alt text. Use for anonymous dunk-quoting, "dunk on this without linking it", "screenshot this post with the author hidden", "quote this without naming them", "redact this before I share it", or when a bad take from a small account deserves an answer and its author does not deserve your followers.
+metadata:
+  version: 0.1.0
+---
+
+# Dunking anonymously
+
+A quote-post delivers your whole audience to the original author. For an account
+with forty followers that is a pile-on whatever your caption said. This renders
+the post as an image instead, so the words can be quoted without the handle.
+
+Idea from Luis Villa, who built the same feature for himself
+(https://bsky.app/profile/lu.is/post/3mv6ynbcjr62b). His render greys the
+identity out; this one blacks it out.
+
+## Procedure
+
+```bash
+python3 scripts/dunk.py https://bsky.app/profile/someone.bsky.social/post/3mv6...
+```
+
+Takes a bsky.app URL, an `at://` URI, or `handle/rkey`. Writes `<rkey>.png` to
+the working directory, prints the alt text to stdout, and writes `<rkey>.json`
+holding the source URI for your own records. The source URI stays out of both
+the image and the alt text.
+
+| flag | effect |
+|---|---|
+| `--redact "phrase"` | blacks out a literal phrase, repeatable |
+| `--stamp` | adds the rotated REDACTED stamp |
+| `--show-date` | prints the post date in the footer |
+| `--out PATH` | output path |
+| `--width N` | image width, default 1200 |
+
+Then read the rendered PNG, actually open it, and re-run with `--redact` for
+anything in the body that identifies the author. This is the step
+that gets skipped.
+
+Deps are PIL and the standard library. DejaVu Mono ships with the container. The
+API call is unauthenticated, so it needs no token and leaves no trace in anyone's
+notifications.
+
+## Redactions applied
+
+Avatar, display name and handle become black bars. Every at-mention facet in the
+body is blacked out, since a mention is a second person's handle and a strong
+search key for finding the original. Embedded images, video, link cards and quoted
+posts render as `[image not shown]` and friends rather than being fetched, since
+an embedded image can carry a face, a location or a watermark.
+
+Engagement counts are dropped. The date is dropped unless `--show-date`, because
+a date plus one distinctive sentence narrows a search to a single post.
+
+The script cannot strip identity from the post's own words. Bluesky indexes full
+post text, so a post naming its author's employer, town or cat stays traceable by
+anyone who pastes a sentence into search. `--redact` is the only defence and it
+is manual.
+
+## When NOT to use this skill
+
+| situation | what owns it |
+|---|---|
+| reading, searching or sampling Bluesky content | `browsing-bluesky` |
+| sorting an account list by topic | `categorizing-bsky-accounts` |
+| posting a link with a card preview | `muninn_utils.bsky_card` |
+| bulk-classifying the repliers under a post | `muninn_utils.bsky_moderation` |
+
+Quote-post public figures and large accounts normally. Anonymising a senator is
+not protection. It removes the reader's ability to check the source while
+protecting nobody. The skill is for accounts small enough that attention itself
+is the harm.
+
+**Earned exceptions.** Anonymising a large account is earned when the post is
+being shown as a specimen of a pattern rather than as one person's position, and
+the handle would pull the thread toward the individual. It is not earned when the
+reader would reasonably want to verify who said it.
+
+**Abandon mid-run** when the post cannot be anonymised, meaning the author's
+identity is the claim, the text names them, or the render still reads as them
+after `--redact` has eaten half the body. At that point either quote-post it with the
+link or drop it. A half-redacted post that everyone recognises is worse than
+both, because it performs restraint while doing the pile-on.
+
+Do not use it to launder something you would not say with the link attached. If
+the criticism only works because nobody can read the original in context, fix
+the criticism.
+
+## Common failure modes
+
+**Black bars in the header, author named in the body.** The render looks
+correctly anonymised and one sentence still says "when I worked at Foo". Signal:
+you did not read the PNG, you read the terminal. Open the image every time and
+pass `--redact` per identifying phrase.
+
+**Two bars where one phrase should be.** A multi-word `--redact` phrase renders
+as separate bars with visible gaps, and word lengths leak. Signal: gaps inside
+what should be one black run. Adjacent redacted tokens are meant to merge across the
+spaces between them. If they do not, the merge logic in `render()` broke.
+
+**Mentions survive the redaction.** Signal: an `@handle` renders as readable
+text. The script reads mention *facets*, not the `@` character, so a post whose
+facets were stripped by the client that wrote it has no mention to find. Catch
+it by reading the PNG and use `--redact "@handle"` as the fallback.
+
+**`no post at at://...`.** The post is deleted, the author blocks the public
+AppView, or the rkey is wrong. Not a transport failure — refetching will not fix
+it.
+
+## Verification
+
+```bash
+python3 scripts/dunk.py <url> --stamp
+```
+
+Then open the PNG. Three checks: no handle or display name anywhere in the image,
+no at-mention rendered as text, and the alt text opening with "Screenshot of a
+Bluesky post, author hidden:".
+
+A bad success here is a clean-looking render that still identifies its author —
+every bar in place, and the body naming a workplace or a town. It passes every
+automated check the script can make, which is why the read-through is part of the
+procedure rather than a nicety.
+
+## Posting it
+
+Attach the PNG in whatever client you post from and paste the printed alt text.
+It opens with "Screenshot of a Bluesky post, author hidden:" so screen-reader
+users get the framing that sighted readers get from the black bars.

--- a/dunking-anonymously/scripts/dunk.py
+++ b/dunking-anonymously/scripts/dunk.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Render a Bluesky post as an anonymised screenshot — declassified-document styling.
+
+Fetches via the public (unauthenticated) AppView API, strips every identifier of
+the author, and writes a PNG plus alt text you can attach to a post of your own.
+
+    python3 dunk.py https://bsky.app/profile/lu.is/post/3mv6ynbcjr62b
+    python3 dunk.py at://did:plc:xxxx/app.bsky.feed.post/3mv6... --stamp
+    python3 dunk.py <url> --redact "my town" --redact "the conference" --show-date
+
+Outputs <rkey>.png, prints the alt text to stdout, and writes <rkey>.json with
+the source URI for your own records. The source URI never appears in the image
+or the alt text.
+"""
+
+import argparse
+import json
+import os
+import random
+import re
+import urllib.parse
+import urllib.request
+
+API = "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread"
+UA = "muninn-raven"
+
+FONT_DIR = "/usr/share/fonts/truetype/dejavu"
+MONO = os.path.join(FONT_DIR, "DejaVuSansMono.ttf")
+MONO_BOLD = os.path.join(FONT_DIR, "DejaVuSansMono-Bold.ttf")
+
+PAPER = (242, 239, 231)
+INK = (26, 24, 20)
+FADE = (120, 114, 102)
+BAR = (12, 12, 12)
+STAMP = (168, 38, 38)
+
+
+# ---------------------------------------------------------------- fetching
+
+
+def post_uri(ref: str) -> str:
+    """Accept a bsky.app URL, an at:// URI, or handle/rkey. Return an at:// URI."""
+    ref = ref.strip()
+    if ref.startswith("at://"):
+        return ref
+    m = re.search(r"/profile/([^/]+)/post/([A-Za-z0-9]+)", ref)
+    if m:
+        return f"at://{m.group(1)}/app.bsky.feed.post/{m.group(2)}"
+    m = re.fullmatch(r"([^/\s]+)/([A-Za-z0-9]+)", ref)
+    if m:
+        return f"at://{m.group(1)}/app.bsky.feed.post/{m.group(2)}"
+    raise SystemExit(f"cannot parse post reference: {ref!r}")
+
+
+def fetch(uri: str) -> dict:
+    url = f"{API}?{urllib.parse.urlencode({'uri': uri, 'depth': 0})}"
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        data = json.load(r)
+    post = data.get("thread", {}).get("post")
+    if not post:
+        raise SystemExit(f"no post at {uri} (deleted, blocked, or wrong rkey)")
+    return post
+
+
+# ---------------------------------------------------------------- redaction
+
+EMBED_NOTE = {
+    "app.bsky.embed.images": "[image not shown]",
+    "app.bsky.embed.external": "[link preview not shown]",
+    "app.bsky.embed.video": "[video not shown]",
+    "app.bsky.embed.record": "[quoted post not shown]",
+    "app.bsky.embed.recordWithMedia": "[quoted post and media not shown]",
+}
+
+
+def spans(post: dict, extra: list) -> list:
+    """Return [(text, redacted)] segments. Mentions always go; extra is literal."""
+    record = post["record"]
+    raw = record.get("text", "").encode("utf-8")
+    cuts = []
+    for facet in record.get("facets", []):
+        kinds = {f.get("$type", "") for f in facet.get("features", [])}
+        if any("mention" in k for k in kinds):
+            idx = facet["index"]
+            cuts.append((idx["byteStart"], idx["byteEnd"]))
+    out, pos = [], 0
+    for start, end in sorted(cuts):
+        if start < pos:
+            continue
+        out.append((raw[pos:start].decode("utf-8", "replace"), False))
+        out.append((raw[start:end].decode("utf-8", "replace"), True))
+        pos = end
+    out.append((raw[pos:].decode("utf-8", "replace"), False))
+
+    for phrase in extra:
+        if not phrase:
+            continue
+        split = []
+        for text, red in out:
+            if red or phrase.lower() not in text.lower():
+                split.append((text, red))
+                continue
+            i = 0
+            low = text.lower()
+            needle = phrase.lower()
+            while True:
+                j = low.find(needle, i)
+                if j < 0:
+                    split.append((text[i:], False))
+                    break
+                split.append((text[i:j], False))
+                split.append((text[j : j + len(phrase)], True))
+                i = j + len(phrase)
+        out = [s for s in split if s[0]]
+    return [s for s in out if s[0]]
+
+
+def alt_text(segments: list, note: str) -> str:
+    body = "".join("[redacted]" if red else t for t, red in segments)
+    if note:
+        body = f"{body}\n\n{note}"
+    alt = f"Screenshot of a Bluesky post, author hidden: {body}"
+    return alt[:1997] + "..." if len(alt) > 2000 else alt
+
+
+# ---------------------------------------------------------------- rendering
+
+
+def wrap(draw, segments, font, max_w):
+    """Word-wrap [(text, redacted)] into lines of [(word, redacted, width)]."""
+    lines, line, width = [], [], 0
+    space = draw.textlength(" ", font=font)
+    paras, gaps = split_paragraphs(segments)
+    for para_i, para in enumerate(paras):
+        for text, red in para:
+            for word in re.split(r"(\s+)", text):
+                if not word:
+                    continue
+                if word.isspace():
+                    if line:
+                        line.append((" ", False, space))
+                        width += space
+                    continue
+                w = draw.textlength(word, font=font)
+                if line and width + w > max_w:
+                    while line and line[-1][0] == " ":
+                        line.pop()
+                    lines.append(line)
+                    line, width = [], 0
+                line.append((word, red, w))
+                width += w
+        while line and line[-1][0] == " ":
+            line.pop()
+        lines.append(line)
+        line, width = [], 0
+        if gaps[para_i]:
+            lines.append([])  # blank line between paragraphs
+    while lines and not lines[-1]:
+        lines.pop()
+    return lines
+
+
+def split_paragraphs(segments):
+    """Split on newlines. Returns (paragraphs, gap_after) — gap only for blank lines."""
+    paras, gaps, cur = [], [], []
+    for text, red in segments:
+        if red:
+            cur.append((text, red))
+            continue
+        parts = text.split("\n")
+        for i, part in enumerate(parts):
+            if i:
+                if cur:
+                    paras.append(cur)
+                    gaps.append(False)
+                    cur = []
+                elif paras:
+                    gaps[-1] = True  # this newline followed an empty line
+            if part:
+                cur.append((part, False))
+    if cur:
+        paras.append(cur)
+        gaps.append(False)
+    return (paras or [[]]), (gaps or [False])
+
+
+def render(segments, note, date, width, use_stamp, out_path):
+    from PIL import Image, ImageDraw, ImageFont
+
+    pad = 56
+    body_font = ImageFont.truetype(MONO, 27)
+    small = ImageFont.truetype(MONO, 17)
+    label = ImageFont.truetype(MONO_BOLD, 15)
+    max_w = width - 2 * pad
+
+    probe = Image.new("RGB", (10, 10))
+    d = ImageDraw.Draw(probe)
+    lines = wrap(d, segments, body_font, max_w)
+
+    line_h = 40
+    head_h = 118
+    note_h = 44 if note else 0
+    foot_h = 56
+    stamp_h = 120 if use_stamp else 0
+    height = pad + head_h + len(lines) * line_h + note_h + foot_h + stamp_h + pad
+
+    img = Image.new("RGB", (width, height), PAPER)
+    d = ImageDraw.Draw(img)
+
+    # photocopy grain
+    rng = random.Random(1312)
+    px = img.load()
+    for _ in range((width * height) // 220):
+        x, y = rng.randrange(width), rng.randrange(height)
+        v = rng.randint(-14, 6)
+        r, g, b = px[x, y]
+        px[x, y] = (max(0, r + v), max(0, g + v), max(0, b + v))
+
+    d.rectangle([pad - 22, pad - 22, width - pad + 22, height - pad + 22],
+                outline=(178, 170, 156), width=2)
+
+    # header: avatar block + two name bars, all struck out
+    y = pad
+    d.rectangle([pad, y, pad + 86, y + 86], fill=BAR)
+
+    bar_x = pad + 110
+    d.rectangle([bar_x, y + 8, bar_x + 330, y + 42], fill=BAR)
+    d.text((bar_x + 14, y + 25), "REDACTED", font=label, fill=PAPER, anchor="lm")
+    d.rectangle([bar_x, y + 52, bar_x + 232, y + 80], fill=BAR)
+    d.text((bar_x + 14, y + 66), "REDACTED", font=label, fill=PAPER, anchor="lm")
+
+    # body
+    y = pad + head_h
+    for line in lines:
+        x = pad
+        run_start = None
+        for i, (word, red, w) in enumerate(line):
+            joins = red or (
+                run_start is not None
+                and word == " "
+                and i + 1 < len(line)
+                and line[i + 1][1]
+            )
+            if joins:
+                if run_start is None:
+                    run_start = x
+            else:
+                if run_start is not None:
+                    d.rectangle([run_start, y + 4, x, y + 32], fill=BAR)
+                    run_start = None
+                d.text((x, y), word, font=body_font, fill=INK)
+            x += w
+        if run_start is not None:
+            d.rectangle([run_start, y + 4, x, y + 32], fill=BAR)
+        y += line_h
+
+    if note:
+        d.text((pad, y + 6), note, font=small, fill=FADE)
+        y += note_h
+
+    y += stamp_h
+    foot = "SOURCE WITHHELD — ANONYMOUS QUOTE"
+    if date:
+        foot += f"   ·   {date}"
+    d.line([pad, height - pad - 34, width - pad, height - pad - 34], fill=(196, 188, 172), width=1)
+    d.text((pad, height - pad - 22), foot, font=small, fill=FADE)
+
+    if use_stamp:
+        stamp = Image.new("RGBA", (392, 112), (0, 0, 0, 0))
+        sd = ImageDraw.Draw(stamp)
+        sf = ImageFont.truetype(MONO_BOLD, 46)
+        sd.rectangle([5, 5, 387, 107], outline=STAMP + (165,), width=6)
+        sd.text((196, 57), "REDACTED", font=sf, fill=STAMP + (165,), anchor="mm")
+        stamp = stamp.rotate(9, expand=True, resample=Image.BICUBIC)
+        img.paste(stamp, (width - stamp.width - pad,
+                          height - pad - 46 - stamp.height), stamp)
+
+    img.save(out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------- cli
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("post", help="bsky.app URL, at:// URI, or handle/rkey")
+    ap.add_argument("--out", help="output PNG path (default ./<rkey>.png)")
+    ap.add_argument("--redact", action="append", default=[],
+                    help="literal phrase to black out; repeatable")
+    ap.add_argument("--show-date", action="store_true",
+                    help="print the post date in the footer (default off — dates narrow the field)")
+    ap.add_argument("--stamp", action="store_true", help="add the rotated REDACTED stamp")
+    ap.add_argument("--width", type=int, default=1200)
+    args = ap.parse_args()
+
+    uri = post_uri(args.post)
+    post = fetch(uri)
+    record = post["record"]
+
+    segments = spans(post, args.redact)
+    etype = (record.get("embed") or {}).get("$type", "")
+    note = EMBED_NOTE.get(etype.split("#")[0], "")
+    date = record.get("createdAt", "")[:10] if args.show_date else ""
+
+    rkey = uri.rsplit("/", 1)[-1]
+    out = args.out or f"{rkey}.png"
+    render(segments, note, date, args.width, args.stamp, out)
+
+    alt = alt_text(segments, note)
+    with open(os.path.splitext(out)[0] + ".json", "w") as f:
+        json.dump({"source_uri": uri, "alt": alt, "image": out}, f, indent=1)
+
+    print(out)
+    print("--- alt text ---")
+    print(alt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New skill: `dunking-anonymously` v0.1.0. Renders a Bluesky post as an anonymised
screenshot so its words can be criticised without a quote-post delivering your
followers to a small account.

Idea from Luis Villa, who built the same feature for himself
(https://bsky.app/profile/lu.is/post/3mv6ynbcjr62b). His render greys the
identity out; this one blacks it out in declassified-document styling, with a
paper ground, monospace, photocopy grain and an optional rotated REDACTED stamp.

`scripts/dunk.py` fetches through `public.api.bsky.app` unauthenticated, blacks
out avatar, display name, handle and every at-mention facet in the body, renders
embeds as `[image not shown]` rather than fetching them, and writes a PNG, its
alt text, and a sidecar JSON holding the source URI. The source URI stays out of
the image and the alt text. Dates are off by default, since a date plus one
distinctive sentence narrows a search to a single post.

`--redact "phrase"` blacks out arbitrary literal text. The script cannot strip
identity from the post's own words, and Bluesky indexes full post text, so a
post naming its author's town stays search-traceable. The SKILL.md treats
reading the rendered PNG as part of the procedure rather than a nicety, and
names the bad success: every bar in place, body still identifying.

Supersedes #793, which shipped the same two files under the non-gerund name
`bsky-dunking` and without the applicability boundary, failure-mode and
verification sections.

## Verification

- Rendered the source post end to end, with and without `--stamp`, `--redact`,
  `--show-date`.
- Unit-tested `spans()` against a synthetic record with two mention facets at
  real UTF-8 byte offsets plus a `--redact` phrase. Checked contiguous bar
  merging, where a two-word phrase must produce one bar rather than two, and
  single-newline versus blank-line paragraph handling.
- `quick_validate.py` passes.
- `skill_confusability.py` over the 99-skill pool with a 5-query positive set,
  two sibling sets and two `__none__` negatives: top-1 5/5 at rank 1. One steal
  at 0.403, below the 0.43 hit floor, on a `browsing-bluesky` query that
  `browsing-bluesky` scores 0.241 on itself. Nearest negative, "redact the names
  in this PDF", lands at 0.424, just under the floor.
- `uvx ruff@0.16.0 check scripts/dunk.py` passes.
- `declaude_lint.py SKILL.md --skip-quoted` clears everything but two known
  false positives.

Pure PIL and stdlib. DejaVu Mono is already in the container.
